### PR TITLE
Bug fixes when a select is operational the Delete Empty Variables does much more

### DIFF
--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
@@ -100,7 +100,7 @@ Public Class ucrDataViewReoGrid
             dlgDeleteRowsOrColums.rdoEmpty.Enabled = False
         Else
             dlgDeleteRowsOrColums.rdoEmpty.Enabled = True
-            'this fixes issue #8535, where the select deletes the hidden columns when bcolumnselectionapplied is used.
+            'this fixes issue #8535, where the dlgDeleteRowsorColumns deletes the hidden columns when bcolumnselectionapplied is used.
         End If
 
         'todo. As of 30/05/2022, the reogrid control version used did not have this setting option

--- a/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrDataViewReoGrid.vb
@@ -96,6 +96,13 @@ Public Class ucrDataViewReoGrid
             grdData.CurrentWorksheet.ScrollToCell("A1") ' will always set the scrollbar at the top.
         End If
 
+        If dataFrame.clsFilterOrColumnSelection.bColumnSelectionApplied Then
+            dlgDeleteRowsOrColums.rdoEmpty.Enabled = False
+        Else
+            dlgDeleteRowsOrColums.rdoEmpty.Enabled = True
+            'this fixes issue #8535, where the select deletes the hidden columns when bcolumnselectionapplied is used.
+        End If
+
         'todo. As of 30/05/2022, the reogrid control version used did not have this setting option
         'see issue #7221 for more information.
         'get pixel size equivalent of the longest row header text


### PR DESCRIPTION
fixes #8535 
I made the Empty option to be only available when there isn't a selection in place, since the first option was difficult to do.
@rdstern , @N-thony this is ready for review.
Thanks