### PR TITLE
Made the Context Menu Control in the Split Button Scrollable

### DIFF
--- a/instat/ucrSplitButton.vb
+++ b/instat/ucrSplitButton.vb
@@ -585,9 +585,60 @@ Public Class ucrSplitButton
 
         State = PushButtonState.Pressed
 
-        If _contextSplitMenuStrip IsNot Nothing Then
-            _contextSplitMenuStrip.Show(Me, New Point(0, Height), ToolStripDropDownDirection.BelowRight)
+        Dim tmpForm As New Form With {
+            .AutoScaleMode = AutoScaleMode.None,
+            .FormBorderStyle = FormBorderStyle.None,
+            .StartPosition = FormStartPosition.Manual,
+            .ShowInTaskbar = False
+        }
+
+        '' Event handler for item click
+        'Dim itemClickHandler As EventHandler = Sub(sender As Object, e As ToolStripItemClickedEventArgs)
+        '                                           ' Handle the item click here
+        '                                           ' You can perform actions based on the selected item
+        '                                           ' ...
+
+        '                                           ' Detach the event handler
+        '                                           RemoveHandler _contextSplitMenuStrip.ItemClicked, itemClickHandler
+
+        '                                           ' Close the form
+        '                                           tmpForm.Close()
+        '                                       End Sub
+
+        '' Attach the event handler
+        'AddHandler _contextSplitMenuStrip.ItemClicked, itemClickHandler
+
+        Dim panel As New Panel With {
+            .Dock = DockStyle.Fill,
+            .AutoScroll = True
+        }
+
+        _contextSplitMenuStrip.TopLevel = False
+        _contextSplitMenuStrip.Dock = DockStyle.Top
+        panel.Controls.Add(_contextSplitMenuStrip)
+
+        ' Set the panel size based on the preferred size of the context menu
+        panel.Size = _contextSplitMenuStrip.PreferredSize
+
+        ' Set a maximum height for the form
+        Dim maxHeight As Integer = 100
+        If panel.Height > maxHeight Then
+            panel.Height = maxHeight
         End If
+
+        tmpForm.Size = New Size(panel.Width, panel.Height)
+        tmpForm.Location = PointToScreen(New Point(0, Height))
+
+        tmpForm.Controls.Add(panel)
+        tmpForm.Show()
+        _contextSplitMenuStrip.Show(panel, New Point(0, 0))
+
+        ' Set the initial vertical scroll position to show the last items in the menu
+        panel.VerticalScroll.Value = panel.VerticalScroll.Maximum
+
+        'If _contextSplitMenuStrip IsNot Nothing Then
+        '    _contextSplitMenuStrip.Show(Me, New Point(0, Height), ToolStripDropDownDirection.BelowRight)
+        'End If
     End Sub
 
     Private Sub SplitMenuStrip_Opening(sender As Object, e As CancelEventArgs)

--- a/instat/ucrSplitButton.vb
+++ b/instat/ucrSplitButton.vb
@@ -232,13 +232,18 @@ Public Class ucrSplitButton
         If mevent.Button = MouseButtons.Right AndAlso ClientRectangle.Contains(mevent.Location) AndAlso Not _bSplitMenuVisible Then
             ShowContextMenuStrip()
         ElseIf _contextSplitMenuStrip Is Nothing OrElse Not _bSplitMenuVisible Then
-            SetButtonDrawState()
-
             If ClientRectangle.Contains(mevent.Location) AndAlso Not _dropDownRectangle.Contains(mevent.Location) Then
-                OnClick(New EventArgs())
+                ' Trigger the Click event
+                OnClick(EventArgs.Empty)
             End If
         End If
+
+        ' Set the button state to Normal regardless of other conditions
+        State = PushButtonState.Normal
+
+        MyBase.OnMouseUp(mevent)
     End Sub
+
 
     Protected Overrides Sub OnPaint(pevent As PaintEventArgs)
         MyBase.OnPaint(pevent)
@@ -593,15 +598,13 @@ Public Class ucrSplitButton
         }
         Dim panel As New Panel With {
             .Dock = DockStyle.Fill,
-            .AutoScroll = True
+            .AutoScroll = True,
+            .Size = _contextSplitMenuStrip.PreferredSize,
+            .BorderStyle = BorderStyle.FixedSingle
         }
         _contextSplitMenuStrip.TopLevel = False
         _contextSplitMenuStrip.Dock = DockStyle.Top
 
-        ' Set the panel size based on the preferred size of the context menu
-        panel.Size = _contextSplitMenuStrip.PreferredSize
-
-        ' Event handler for item click
         AddHandler _contextSplitMenuStrip.ItemClicked, Sub(sender As Object, e As ToolStripItemClickedEventArgs)
                                                            tmpForm.Close()
                                                        End Sub
@@ -612,6 +615,10 @@ Public Class ucrSplitButton
                                            End If
                                        End Sub
 
+        AddHandler tmpForm.LostFocus, Sub(sender As Object, e As EventArgs)
+                                          _bSplitMenuVisible = False
+                                          tmpForm.Close()
+                                      End Sub
 
         panel.Controls.Add(_contextSplitMenuStrip)
         ' Set a maximum height for the form

--- a/instat/ucrSplitButton.vb
+++ b/instat/ucrSplitButton.vb
@@ -591,45 +591,43 @@ Public Class ucrSplitButton
             .StartPosition = FormStartPosition.Manual,
             .ShowInTaskbar = False
         }
-
-        ' Event handler for item click
-        AddHandler _contextSplitMenuStrip.ItemClicked, Sub(sender As Object, e As ToolStripItemClickedEventArgs)
-                                                           RemoveHandler _contextSplitMenuStrip.ItemClicked
-                                                           ' Close the form
-                                                           tmpForm.Close()
-                                                       End Sub
-
         Dim panel As New Panel With {
             .Dock = DockStyle.Fill,
             .AutoScroll = True
         }
-
         _contextSplitMenuStrip.TopLevel = False
         _contextSplitMenuStrip.Dock = DockStyle.Top
-        panel.Controls.Add(_contextSplitMenuStrip)
 
         ' Set the panel size based on the preferred size of the context menu
         panel.Size = _contextSplitMenuStrip.PreferredSize
 
+        ' Event handler for item click
+        AddHandler _contextSplitMenuStrip.ItemClicked, Sub(sender As Object, e As ToolStripItemClickedEventArgs)
+                                                           tmpForm.Close()
+                                                       End Sub
+
+        AddHandler tmpForm.FormClosed, Sub(sender As Object, e As FormClosedEventArgs)
+                                           If panel.Controls.Contains(_contextSplitMenuStrip) Then
+                                               panel.Controls.Remove(_contextSplitMenuStrip)
+                                           End If
+                                       End Sub
+
+
+        panel.Controls.Add(_contextSplitMenuStrip)
         ' Set a maximum height for the form
         Dim maxHeight As Integer = 100
         If panel.Height > maxHeight Then
             panel.Height = maxHeight
         End If
 
+        If _contextSplitMenuStrip IsNot Nothing Then
+            _contextSplitMenuStrip.Show()
+        End If
+
         tmpForm.Size = New Size(panel.Width, panel.Height)
         tmpForm.Location = PointToScreen(New Point(0, Height))
-
         tmpForm.Controls.Add(panel)
         tmpForm.Show()
-        _contextSplitMenuStrip.Show(panel, New Point(0, 0))
-
-        ' Set the initial vertical scroll position to show the last items in the menu
-        panel.VerticalScroll.Value = panel.VerticalScroll.Maximum
-
-        'If _contextSplitMenuStrip IsNot Nothing Then
-        '    _contextSplitMenuStrip.Show(Me, New Point(0, Height), ToolStripDropDownDirection.BelowRight)
-        'End If
     End Sub
 
     Private Sub SplitMenuStrip_Opening(sender As Object, e As CancelEventArgs)

--- a/instat/ucrSplitButton.vb
+++ b/instat/ucrSplitButton.vb
@@ -598,8 +598,7 @@ Public Class ucrSplitButton
         }
         Dim panel As New Panel With {
             .Dock = DockStyle.Fill,
-            .BorderStyle = BorderStyle.None,
-            .Size = _contextSplitMenuStrip.PreferredSize
+            .BorderStyle = BorderStyle.None
         }
         _contextSplitMenuStrip.TopLevel = False
         _contextSplitMenuStrip.Dock = DockStyle.Top
@@ -623,9 +622,14 @@ Public Class ucrSplitButton
         panel.Controls.Add(_contextSplitMenuStrip)
         ' Set a maximum height for the form
         Dim maxHeight As Integer = 250
-        If panel.Height > maxHeight Then
-            panel.Height = maxHeight
+
+        ' Ensure that the panel fits the preferred size of the context menu without extra space
+        Dim preferredSize As Size = _contextSplitMenuStrip.PreferredSize
+        If preferredSize.Height > maxHeight Then
             panel.AutoScroll = True
+            preferredSize.Height = maxHeight
+        Else
+            panel.AutoScroll = False
         End If
 
         If _contextSplitMenuStrip IsNot Nothing Then
@@ -634,14 +638,16 @@ Public Class ucrSplitButton
 
         ' Calculate whether to show the form above or below
         Dim screenRect As Rectangle = Screen.FromControl(Me).WorkingArea
-        Dim bShowUp As Boolean = PointToScreen(New Point(0, Height + panel.Height)).Y > screenRect.Bottom
+        Dim showUp As Boolean = PointToScreen(New Point(0, Height + PreferredSize.Height)).Y > screenRect.Bottom
 
-        If bShowUp Then
+        ' Set the form size and location accordingly
+        tmpForm.Size = New Size(PreferredSize.Width, PreferredSize.Height)
+        If showUp Then
             tmpForm.Location = PointToScreen(New Point(0, Height - tmpForm.Height))
         Else
             tmpForm.Location = PointToScreen(New Point(0, Height))
         End If
-        tmpForm.Size = New Size(panel.Width, panel.Height)
+
         tmpForm.Controls.Add(panel)
         tmpForm.Show()
     End Sub

--- a/instat/ucrSplitButton.vb
+++ b/instat/ucrSplitButton.vb
@@ -598,13 +598,11 @@ Public Class ucrSplitButton
         }
         Dim panel As New Panel With {
             .Dock = DockStyle.Fill,
-            .Size = _contextSplitMenuStrip.PreferredSize,
-            .AutoScroll = True,
-            .BorderStyle = BorderStyle.FixedSingle
+            .BorderStyle = BorderStyle.None,
+            .Size = _contextSplitMenuStrip.PreferredSize
         }
         _contextSplitMenuStrip.TopLevel = False
         _contextSplitMenuStrip.Dock = DockStyle.Top
-        _contextSplitMenuStrip.Padding = New Padding(0, -2, 0, -2)
         _contextSplitMenuStrip.ShowImageMargin = False
 
         AddHandler _contextSplitMenuStrip.ItemClicked, Sub(sender As Object, e As ToolStripItemClickedEventArgs)
@@ -627,14 +625,23 @@ Public Class ucrSplitButton
         Dim maxHeight As Integer = 250
         If panel.Height > maxHeight Then
             panel.Height = maxHeight
+            panel.AutoScroll = True
         End If
 
         If _contextSplitMenuStrip IsNot Nothing Then
             _contextSplitMenuStrip.Show()
         End If
 
+        ' Calculate whether to show the form above or below
+        Dim screenRect As Rectangle = Screen.FromControl(Me).WorkingArea
+        Dim bShowUp As Boolean = PointToScreen(New Point(0, Height + panel.Height)).Y > screenRect.Bottom
+
+        If bShowUp Then
+            tmpForm.Location = PointToScreen(New Point(0, Height - tmpForm.Height))
+        Else
+            tmpForm.Location = PointToScreen(New Point(0, Height))
+        End If
         tmpForm.Size = New Size(panel.Width, panel.Height)
-        tmpForm.Location = PointToScreen(New Point(0, Height))
         tmpForm.Controls.Add(panel)
         tmpForm.Show()
     End Sub

--- a/instat/ucrSplitButton.vb
+++ b/instat/ucrSplitButton.vb
@@ -598,12 +598,14 @@ Public Class ucrSplitButton
         }
         Dim panel As New Panel With {
             .Dock = DockStyle.Fill,
-            .AutoScroll = True,
             .Size = _contextSplitMenuStrip.PreferredSize,
+            .AutoScroll = True,
             .BorderStyle = BorderStyle.FixedSingle
         }
         _contextSplitMenuStrip.TopLevel = False
         _contextSplitMenuStrip.Dock = DockStyle.Top
+        _contextSplitMenuStrip.Padding = New Padding(0, -2, 0, -2)
+        _contextSplitMenuStrip.ShowImageMargin = False
 
         AddHandler _contextSplitMenuStrip.ItemClicked, Sub(sender As Object, e As ToolStripItemClickedEventArgs)
                                                            tmpForm.Close()
@@ -622,7 +624,7 @@ Public Class ucrSplitButton
 
         panel.Controls.Add(_contextSplitMenuStrip)
         ' Set a maximum height for the form
-        Dim maxHeight As Integer = 100
+        Dim maxHeight As Integer = 250
         If panel.Height > maxHeight Then
             panel.Height = maxHeight
         End If

--- a/instat/ucrSplitButton.vb
+++ b/instat/ucrSplitButton.vb
@@ -592,21 +592,12 @@ Public Class ucrSplitButton
             .ShowInTaskbar = False
         }
 
-        '' Event handler for item click
-        'Dim itemClickHandler As EventHandler = Sub(sender As Object, e As ToolStripItemClickedEventArgs)
-        '                                           ' Handle the item click here
-        '                                           ' You can perform actions based on the selected item
-        '                                           ' ...
-
-        '                                           ' Detach the event handler
-        '                                           RemoveHandler _contextSplitMenuStrip.ItemClicked, itemClickHandler
-
-        '                                           ' Close the form
-        '                                           tmpForm.Close()
-        '                                       End Sub
-
-        '' Attach the event handler
-        'AddHandler _contextSplitMenuStrip.ItemClicked, itemClickHandler
+        ' Event handler for item click
+        AddHandler _contextSplitMenuStrip.ItemClicked, Sub(sender As Object, e As ToolStripItemClickedEventArgs)
+                                                           RemoveHandler _contextSplitMenuStrip.ItemClicked
+                                                           ' Close the form
+                                                           tmpForm.Close()
+                                                       End Sub
 
         Dim panel As New Panel With {
             .Dock = DockStyle.Fill,


### PR DESCRIPTION
@rdstern this replaces PR #8673 in case we decide to use the same control i.e `contexmenustrip` in the split button. I made it scrollable, have a look.