### PR TITLE
Fixes bug where the script tab does not come with a name

### DIFF
--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -26,7 +26,7 @@ Public Class ucrScript
     Private iMaxLineNumberCharLength As Integer = 0
     Private Const iTabIndexLog As Integer = 0
     Private strRInstatLogFilesFolderPath As String = Path.Combine(Path.GetFullPath(FileIO.SpecialDirectories.MyDocuments), "R-Instat_Log_files")
-
+    Private strCurrentScriptFileName As String = "" 'holds the saved script file name to help remember the current selected folder path
     Friend WithEvents clsScriptActive As Scintilla
     Friend WithEvents clsScriptLog As Scintilla
 
@@ -214,7 +214,12 @@ Public Class ucrScript
         Using dlgSave As New SaveFileDialog
             dlgSave.Title = "Save " & If(bIsLog, "Log", "Script") & " To File"
             dlgSave.Filter = "R Script File (*.R)|*.R|Text File (*.txt)|*.txt"
-
+            If Not String.IsNullOrEmpty(strCurrentScriptFileName) Then
+                dlgSave.FileName = Path.GetFileName(strCurrentScriptFileName)
+                dlgSave.InitialDirectory = Path.GetDirectoryName(strCurrentScriptFileName)
+            Else
+                dlgSave.InitialDirectory = frmMain.clsInstatOptions.strWorkingDirectory
+            End If
             'Ensure that dialog opens in correct folder.
             'In theory, we should be able to use `dlgLoad.RestoreDirectory = True` but this does
             'not work (I think a bug in WinForms).So we need to use static variables instead.
@@ -225,6 +230,7 @@ Public Class ucrScript
             If dlgSave.ShowDialog() = DialogResult.OK Then
                 Try
                     File.WriteAllText(dlgSave.FileName, If(bIsLog, clsScriptLog.Text, clsScriptActive.Text))
+                    strCurrentScriptFileName = dlgSave.FileName
                     bIsTextChanged = False
                     TabControl.SelectedTab.Text = System.IO.Path.GetFileNameWithoutExtension(dlgSave.FileName)
                     frmMain.clsRecentItems.addToMenu(Replace(Path.Combine(Path.GetFullPath(FileIO.SpecialDirectories.MyDocuments), System.IO.Path.GetFileName(dlgSave.FileName)), "\", "/"))


### PR DESCRIPTION
Fixes #8722

This fixes the problem of when the script tab does not prompt the user with the name. 

@rdstern , @N-thony this PR is ready for review. 

Thanks