### PR TITLE
Small Changes  in histogram dialog

### DIFF
--- a/instat/dlgHistogram.designer.vb
+++ b/instat/dlgHistogram.designer.vb
@@ -51,6 +51,10 @@ Partial Class dlgHistogram
         Me.toolStripMenuItemDensityOptions = New System.Windows.Forms.ToolStripMenuItem()
         Me.toolStripMenuItemDensityRidgesOptions = New System.Windows.Forms.ToolStripMenuItem()
         Me.toolStripMenuItemFrequencyPolygonOptions = New System.Windows.Forms.ToolStripMenuItem()
+        Me.lblReorder = New System.Windows.Forms.Label()
+        Me.ucrNudBinwidth = New instat.ucrNud()
+        Me.ucrChkBinWidth = New instat.ucrCheck()
+        Me.ucrInputAddReorder = New instat.ucrInputComboBox()
         Me.cmdOptions = New instat.ucrSplitButton()
         Me.ucrChkDisplayAsDotPlot = New instat.ucrCheck()
         Me.ucrChkRidges = New instat.ucrCheck()
@@ -62,8 +66,6 @@ Partial Class dlgHistogram
         Me.ucrHistogramSelector = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrPnlOptions = New instat.UcrPanel()
-        Me.lblReorder = New System.Windows.Forms.Label()
-        Me.ucrInputAddReorder = New instat.ucrInputComboBox()
         Me.contextMenuStripOptions.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -178,6 +180,49 @@ Partial Class dlgHistogram
         Me.toolStripMenuItemFrequencyPolygonOptions.Name = "toolStripMenuItemFrequencyPolygonOptions"
         Me.toolStripMenuItemFrequencyPolygonOptions.Size = New System.Drawing.Size(221, 22)
         Me.toolStripMenuItemFrequencyPolygonOptions.Text = "Frequency Polygon Options"
+        '
+        'lblReorder
+        '
+        Me.lblReorder.AutoSize = True
+        Me.lblReorder.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblReorder.Location = New System.Drawing.Point(286, 298)
+        Me.lblReorder.Name = "lblReorder"
+        Me.lblReorder.Size = New System.Drawing.Size(48, 13)
+        Me.lblReorder.TabIndex = 38
+        Me.lblReorder.Text = "Reorder:"
+        '
+        'ucrNudBinwidth
+        '
+        Me.ucrNudBinwidth.AutoSize = True
+        Me.ucrNudBinwidth.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudBinwidth.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        Me.ucrNudBinwidth.Location = New System.Drawing.Point(100, 287)
+        Me.ucrNudBinwidth.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudBinwidth.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudBinwidth.Name = "ucrNudBinwidth"
+        Me.ucrNudBinwidth.Size = New System.Drawing.Size(50, 20)
+        Me.ucrNudBinwidth.TabIndex = 41
+        Me.ucrNudBinwidth.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        '
+        'ucrChkBinWidth
+        '
+        Me.ucrChkBinWidth.AutoSize = True
+        Me.ucrChkBinWidth.Checked = False
+        Me.ucrChkBinWidth.Location = New System.Drawing.Point(10, 285)
+        Me.ucrChkBinWidth.Name = "ucrChkBinWidth"
+        Me.ucrChkBinWidth.Size = New System.Drawing.Size(153, 23)
+        Me.ucrChkBinWidth.TabIndex = 40
+        '
+        'ucrInputAddReorder
+        '
+        Me.ucrInputAddReorder.AddQuotesIfUnrecognised = True
+        Me.ucrInputAddReorder.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputAddReorder.GetSetSelectedIndex = -1
+        Me.ucrInputAddReorder.IsReadOnly = False
+        Me.ucrInputAddReorder.Location = New System.Drawing.Point(287, 314)
+        Me.ucrInputAddReorder.Name = "ucrInputAddReorder"
+        Me.ucrInputAddReorder.Size = New System.Drawing.Size(120, 21)
+        Me.ucrInputAddReorder.TabIndex = 39
         '
         'cmdOptions
         '
@@ -300,33 +345,14 @@ Partial Class dlgHistogram
         Me.ucrPnlOptions.Size = New System.Drawing.Size(433, 30)
         Me.ucrPnlOptions.TabIndex = 0
         '
-        'lblReorder
-        '
-        Me.lblReorder.AutoSize = True
-        Me.lblReorder.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblReorder.Location = New System.Drawing.Point(286, 298)
-        Me.lblReorder.Name = "lblReorder"
-        Me.lblReorder.Size = New System.Drawing.Size(48, 13)
-        Me.lblReorder.TabIndex = 38
-        Me.lblReorder.Text = "Reorder:"
-        '
-        'ucrInputAddReorder
-        '
-        Me.ucrInputAddReorder.AddQuotesIfUnrecognised = True
-        Me.ucrInputAddReorder.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrInputAddReorder.GetSetSelectedIndex = -1
-        Me.ucrInputAddReorder.IsReadOnly = False
-        Me.ucrInputAddReorder.Location = New System.Drawing.Point(287, 314)
-        Me.ucrInputAddReorder.Name = "ucrInputAddReorder"
-        Me.ucrInputAddReorder.Size = New System.Drawing.Size(120, 21)
-        Me.ucrInputAddReorder.TabIndex = 39
-        '
         'dlgHistogram
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(448, 422)
+        Me.Controls.Add(Me.ucrNudBinwidth)
+        Me.Controls.Add(Me.ucrChkBinWidth)
         Me.Controls.Add(Me.lblReorder)
         Me.Controls.Add(Me.ucrInputAddReorder)
         Me.Controls.Add(Me.cmdOptions)
@@ -382,4 +408,6 @@ Partial Class dlgHistogram
     Friend WithEvents toolStripMenuItemDotOptions As ToolStripMenuItem
     Friend WithEvents lblReorder As Label
     Friend WithEvents ucrInputAddReorder As ucrInputComboBox
+    Friend WithEvents ucrChkBinWidth As ucrCheck
+    Friend WithEvents ucrNudBinwidth As ucrNud
 End Class

--- a/instat/dlgHistogram.designer.vb
+++ b/instat/dlgHistogram.designer.vb
@@ -66,6 +66,7 @@ Partial Class dlgHistogram
         Me.ucrHistogramSelector = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrPnlOptions = New instat.UcrPanel()
+        Me.ucrChkOmitYAxis = New instat.ucrCheck()
         Me.contextMenuStripOptions.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -345,12 +346,22 @@ Partial Class dlgHistogram
         Me.ucrPnlOptions.Size = New System.Drawing.Size(433, 30)
         Me.ucrPnlOptions.TabIndex = 0
         '
+        'ucrChkOmitYAxis
+        '
+        Me.ucrChkOmitYAxis.AutoSize = True
+        Me.ucrChkOmitYAxis.Checked = False
+        Me.ucrChkOmitYAxis.Location = New System.Drawing.Point(8, 262)
+        Me.ucrChkOmitYAxis.Name = "ucrChkOmitYAxis"
+        Me.ucrChkOmitYAxis.Size = New System.Drawing.Size(153, 23)
+        Me.ucrChkOmitYAxis.TabIndex = 42
+        '
         'dlgHistogram
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(448, 422)
+        Me.Controls.Add(Me.ucrChkOmitYAxis)
         Me.Controls.Add(Me.ucrNudBinwidth)
         Me.Controls.Add(Me.ucrChkBinWidth)
         Me.Controls.Add(Me.lblReorder)
@@ -410,4 +421,5 @@ Partial Class dlgHistogram
     Friend WithEvents ucrInputAddReorder As ucrInputComboBox
     Friend WithEvents ucrChkBinWidth As ucrCheck
     Friend WithEvents ucrNudBinwidth As ucrNud
+    Friend WithEvents ucrChkOmitYAxis As ucrCheck
 End Class

--- a/instat/dlgHistogram.designer.vb
+++ b/instat/dlgHistogram.designer.vb
@@ -67,6 +67,8 @@ Partial Class dlgHistogram
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrPnlOptions = New instat.UcrPanel()
         Me.ucrChkOmitYAxis = New instat.ucrCheck()
+        Me.ucrNudMinHeight = New instat.ucrNud()
+        Me.ucrChkMinHeight = New instat.ucrCheck()
         Me.contextMenuStripOptions.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -350,10 +352,32 @@ Partial Class dlgHistogram
         '
         Me.ucrChkOmitYAxis.AutoSize = True
         Me.ucrChkOmitYAxis.Checked = False
-        Me.ucrChkOmitYAxis.Location = New System.Drawing.Point(8, 262)
+        Me.ucrChkOmitYAxis.Location = New System.Drawing.Point(10, 262)
         Me.ucrChkOmitYAxis.Name = "ucrChkOmitYAxis"
         Me.ucrChkOmitYAxis.Size = New System.Drawing.Size(153, 23)
         Me.ucrChkOmitYAxis.TabIndex = 42
+        '
+        'ucrNudMinHeight
+        '
+        Me.ucrNudMinHeight.AutoSize = True
+        Me.ucrNudMinHeight.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudMinHeight.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        Me.ucrNudMinHeight.Location = New System.Drawing.Point(100, 313)
+        Me.ucrNudMinHeight.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudMinHeight.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudMinHeight.Name = "ucrNudMinHeight"
+        Me.ucrNudMinHeight.Size = New System.Drawing.Size(50, 20)
+        Me.ucrNudMinHeight.TabIndex = 44
+        Me.ucrNudMinHeight.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        '
+        'ucrChkMinHeight
+        '
+        Me.ucrChkMinHeight.AutoSize = True
+        Me.ucrChkMinHeight.Checked = False
+        Me.ucrChkMinHeight.Location = New System.Drawing.Point(10, 311)
+        Me.ucrChkMinHeight.Name = "ucrChkMinHeight"
+        Me.ucrChkMinHeight.Size = New System.Drawing.Size(153, 23)
+        Me.ucrChkMinHeight.TabIndex = 43
         '
         'dlgHistogram
         '
@@ -361,6 +385,8 @@ Partial Class dlgHistogram
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(448, 422)
+        Me.Controls.Add(Me.ucrNudMinHeight)
+        Me.Controls.Add(Me.ucrChkMinHeight)
         Me.Controls.Add(Me.ucrChkOmitYAxis)
         Me.Controls.Add(Me.ucrNudBinwidth)
         Me.Controls.Add(Me.ucrChkBinWidth)
@@ -422,4 +448,6 @@ Partial Class dlgHistogram
     Friend WithEvents ucrChkBinWidth As ucrCheck
     Friend WithEvents ucrNudBinwidth As ucrNud
     Friend WithEvents ucrChkOmitYAxis As ucrCheck
+    Friend WithEvents ucrNudMinHeight As ucrNud
+    Friend WithEvents ucrChkMinHeight As ucrCheck
 End Class

--- a/instat/dlgHistogram.vb
+++ b/instat/dlgHistogram.vb
@@ -235,13 +235,13 @@ Public Class dlgHistogram
         ucrPnlOptions.SetRCode(clsRgeomPlotFunction, bReset)
         ucrChkPercentages.SetRCode(clsYScalecontinuousFunction, bReset)
         ucrChkDisplayAsDotPlot.SetRCode(clsRgeomPlotFunction, bReset)
-        ucrChkBinWidth.SetRCode(clsRgeomPlotFunction, bReset)
         ucrNudBinwidth.SetRCode(clsRgeomPlotFunction, bReset)
         ucrChkRidges.SetRCode(clsRgeomPlotFunction, bReset)
         ucrVariablesAsFactorforHist.SetRCode(clsRaesFunction, bReset)
         If bReset Then
             ucrInputStats.SetRCode(clsHistAesFunction, bReset)
             ucrFactorReceiver.SetRCode(clsRaesFunction, bReset)
+            ucrChkBinWidth.SetRCode(clsRgeomPlotFunction, bReset)
         End If
     End Sub
 

--- a/instat/dlgHistogram.vb
+++ b/instat/dlgHistogram.vb
@@ -20,6 +20,9 @@ Public Class dlgHistogram
     Private bFirstLoad As Boolean = True
     Private bReset As Boolean = True
     Private clsBaseOperator As New ROperator
+    Private clsBaseOperator2 As New ROperator
+    Private clsYlabScalesFunction As New RFunction
+    Private clsBreaksFunction As New RFunction
     Private clsRggplotFunction As New RFunction
     Private clsRgeomPlotFunction As New RFunction
     Private clsRaesFunction As New RFunction
@@ -114,6 +117,8 @@ Public Class dlgHistogram
         ucrChkDisplayAsDotPlot.SetText("Display as Dotplot")
         ucrChkDisplayAsDotPlot.AddFunctionNamesCondition(True, "geom_dotplot")
         ucrChkDisplayAsDotPlot.AddFunctionNamesCondition(False, "geom_dotplot", False)
+        ucrChkDisplayAsDotPlot.AddToLinkedControls({ucrChkOmitYAxis}, {True}, bNewLinkedHideIfParameterMissing:=True)
+        ucrChkOmitYAxis.SetText("Omit Y Axis")
 
         ucrChkBinWidth.SetText("Binwidth")
         'ucrChkBinWidth.SetParameter(New RParameter("binwidth", 3))
@@ -158,11 +163,14 @@ Public Class dlgHistogram
 
     Private Sub SetDefaults()
         clsBaseOperator = New ROperator
+        clsBaseOperator2 = New ROperator
         clsRggplotFunction = New RFunction
         clsRgeomPlotFunction = New RFunction
         clsRaesFunction = New RFunction
         clsHistAesFunction = New RFunction
         clsPercentage = New RFunction
+        clsYlabScalesFunction = New RFunction
+        clsBreaksFunction = New RFunction
         clsForecatsReverse = New RFunction
         clsForecatsInfreqValue = New RFunction
         clsForecatsReverseValue = New RFunction
@@ -175,6 +183,7 @@ Public Class dlgHistogram
 
         ucrInputAddReorder.SetText(strNone)
         ucrInputAddReorder.bUpdateRCodeFromControl = True
+
 
         clsBaseOperator.SetOperation("+")
         clsBaseOperator.AddParameter("ggplot", clsRFunctionParameter:=clsRggplotFunction, iPosition:=0)
@@ -206,6 +215,13 @@ Public Class dlgHistogram
 
         clsForecatsInfreqValue.SetPackageName("forcats")
         clsForecatsInfreqValue.SetRCommand("fct_infreq")
+
+        'clsBaseOperator2.SetOperation("+")
+        'clsBaseOperator2.AddParameter("ggplot", clsRFunctionParameter:=clsYlabScalesFunction, iPosition:=0)
+
+        clsYlabScalesFunction.SetRCommand("scale_y_continuous")
+        clsYlabScalesFunction.AddParameter("NULL", "NULL", bIncludeArgumentName:=False, iPosition:=0)
+        clsYlabScalesFunction.AddParameter("breaks", "NULL", iPosition:=1)
 
         clsBaseOperator.AddParameter(GgplotDefaults.clsDefaultThemeParameter.Clone())
         clsXlabsFunction = GgplotDefaults.clsXlabTitleFunction.Clone()
@@ -244,6 +260,7 @@ Public Class dlgHistogram
             ucrFactorReceiver.SetRCode(clsRaesFunction, bReset)
             ucrChkBinWidth.SetRCode(clsRgeomPlotFunction, bReset)
             ucrNudBinwidth.SetRCode(clsRgeomPlotFunction, bReset)
+            ucrChkOmitYAxis.SetRCode(clsYlabScalesFunction, bReset)
         End If
     End Sub
 
@@ -269,12 +286,6 @@ Public Class dlgHistogram
         clsRgeomPlotFunction.SetPackageName("ggplot2")
         ucrInputAddReorder.Visible = Not ucrFactorReceiver.IsEmpty()
 
-        If Not ucrNudBinwidth.IsEmpty Then
-            clsRgeomPlotFunction.AddParameter("binwidth", 1.5, iPosition:=1)
-        Else
-            clsRgeomPlotFunction.RemoveParameterByName("binwidth")
-        End If
-
         If rdoHistogram.Checked Then
             If ucrChkDisplayAsDotPlot.Checked Then
                 clsRgeomPlotFunction.SetRCommand("geom_dotplot")
@@ -294,11 +305,7 @@ Public Class dlgHistogram
                     clsRgeomPlotFunction.RemoveParameterByName("stackgroups")
                 End If
             End If
-            If Not ucrNudBinwidth.IsEmpty Then
-                clsRgeomPlotFunction.AddParameter("binwidth", 1.5, iPosition:=1)
-            Else
-                clsRgeomPlotFunction.RemoveParameterByName("binwidth")
-            End If
+
             ucrFactorReceiver.ChangeParameterName("fill")
             If Not ucrSaveHist.bUserTyped Then ucrSaveHist.SetPrefix("histogram")
         End If
@@ -331,6 +338,7 @@ Public Class dlgHistogram
         End If
         autoTranslate(Me)
         UpdateParameter()
+
     End Sub
 
     Private Sub UpdateParameter()
@@ -387,7 +395,7 @@ Public Class dlgHistogram
         End If
     End Sub
 
-    Private Sub ucrPnlOptions_Control() Handles ucrPnlOptions.ControlValueChanged, ucrChkDisplayAsDotPlot.ControlValueChanged, ucrChkRidges.ControlValueChanged, ucrFactorReceiver.ControlValueChanged, ucrVariablesAsFactorforHist.ControlValueChanged, ucrInputAddReorder.ControlValueChanged
+    Private Sub ucrPnlOptions_Control() Handles ucrPnlOptions.ControlValueChanged, ucrChkDisplayAsDotPlot.ControlValueChanged, ucrChkRidges.ControlValueChanged, ucrFactorReceiver.ControlValueChanged, ucrVariablesAsFactorforHist.ControlValueChanged, ucrInputAddReorder.ControlValueChanged, ucrChkOmitYAxis.ControlValueChanged
         toolStripMenuItemHistogramOptions.Enabled = rdoHistogram.Checked AndAlso Not ucrChkDisplayAsDotPlot.Checked
         toolStripMenuItemDotOptions.Enabled = rdoHistogram.Checked AndAlso ucrChkDisplayAsDotPlot.Checked
         toolStripMenuItemDensityOptions.Enabled = rdoDensity_ridges.Checked AndAlso Not ucrChkRidges.Checked
@@ -518,5 +526,13 @@ Public Class dlgHistogram
     Private Sub ucrPnlOptions_Control(ucrChangedControl As ucrCore) Handles ucrVariablesAsFactorforHist.ControlValueChanged, ucrPnlOptions.ControlValueChanged, ucrInputAddReorder.ControlValueChanged, ucrFactorReceiver.ControlValueChanged, ucrChkRidges.ControlValueChanged, ucrChkDisplayAsDotPlot.ControlValueChanged
 
     End Sub
-
+    Private Sub ucrChkOmitYAxis_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkOmitYAxis.ControlValueChanged, ucrChkDisplayAsDotPlot.ControlValueChanged
+        If ucrChkDisplayAsDotPlot.Checked Then
+            If ucrChkOmitYAxis.Checked Then
+                clsBaseOperator.AddParameter("scale", clsRFunctionParameter:=clsYlabScalesFunction, iPosition:=4, bIncludeArgumentName:=False)
+            Else
+                clsBaseOperator.RemoveParameterByName("scale")
+            End If
+        End If
+    End Sub
 End Class

--- a/instat/dlgHistogram.vb
+++ b/instat/dlgHistogram.vb
@@ -115,6 +115,16 @@ Public Class dlgHistogram
         ucrChkDisplayAsDotPlot.AddFunctionNamesCondition(True, "geom_dotplot")
         ucrChkDisplayAsDotPlot.AddFunctionNamesCondition(False, "geom_dotplot", False)
 
+        ucrChkBinWidth.SetText("Binwidth")
+        'ucrChkBinWidth.SetParameter(New RParameter("binwidth", 3))
+        ucrChkBinWidth.AddToLinkedControls({ucrNudBinwidth}, {True}, bNewLinkedHideIfParameterMissing:=True)
+
+        ucrNudBinwidth.SetParameter(New RParameter("binwidth", 3))
+        ucrNudBinwidth.SetMinMax(0.00, 10.0)
+        ucrNudBinwidth.DecimalPlaces = 2
+        ucrNudBinwidth.Increment = 0.01
+        ucrNudBinwidth.SetRDefault(1.5)
+
         ucrChkRidges.SetText("Density Ridges")
         ucrChkRidges.AddFunctionNamesCondition(True, "geom_density_ridges")
         ucrChkRidges.AddFunctionNamesCondition(False, "geom_density_ridges", False)
@@ -132,6 +142,7 @@ Public Class dlgHistogram
         ucrInputAddReorder.SetLinkedDisplayControl(lblReorder)
 
         ucrPnlOptions.AddToLinkedControls({ucrChkDisplayAsDotPlot}, {rdoHistogram}, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlOptions.AddToLinkedControls({ucrChkBinWidth}, {rdoHistogram, rdoFrequencyPolygon}, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlOptions.AddToLinkedControls({ucrChkRidges}, {rdoDensity_ridges}, bNewLinkedHideIfParameterMissing:=True)
         ucrChkRidges.AddToLinkedControls(ucrInputStats, {"FALSE"}, bNewLinkedHideIfParameterMissing:=True)
 
@@ -224,6 +235,8 @@ Public Class dlgHistogram
         ucrPnlOptions.SetRCode(clsRgeomPlotFunction, bReset)
         ucrChkPercentages.SetRCode(clsYScalecontinuousFunction, bReset)
         ucrChkDisplayAsDotPlot.SetRCode(clsRgeomPlotFunction, bReset)
+        ucrChkBinWidth.SetRCode(clsRgeomPlotFunction, bReset)
+        ucrNudBinwidth.SetRCode(clsRgeomPlotFunction, bReset)
         ucrChkRidges.SetRCode(clsRgeomPlotFunction, bReset)
         ucrVariablesAsFactorforHist.SetRCode(clsRaesFunction, bReset)
         If bReset Then
@@ -272,6 +285,11 @@ Public Class dlgHistogram
                     clsRgeomPlotFunction.RemoveParameterByName("binpositions")
                     clsRgeomPlotFunction.RemoveParameterByName("stackgroups")
                 End If
+            End If
+            If Not ucrNudBinwidth.IsEmpty Then
+                clsRgeomPlotFunction.AddParameter("binwidth", 1.5, iPosition:=1)
+            Else
+                clsRgeomPlotFunction.RemoveParameterByName("binwidth")
             End If
             ucrFactorReceiver.ChangeParameterName("fill")
             If Not ucrSaveHist.bUserTyped Then ucrSaveHist.SetPrefix("histogram")
@@ -485,7 +503,12 @@ Public Class dlgHistogram
         End If
     End Sub
 
-    Private Sub CoreControls_ControlContentsChanged() Handles ucrVariablesAsFactorforHist.ControlContentsChanged, ucrSaveHist.ControlContentsChanged, ucrFactorReceiver.ControlContentsChanged, ucrChkRidges.ControlContentsChanged, ucrInputAddReorder.ControlContentsChanged
+    Private Sub CoreControls_ControlContentsChanged() Handles ucrVariablesAsFactorforHist.ControlContentsChanged, ucrSaveHist.ControlContentsChanged, ucrFactorReceiver.ControlContentsChanged, ucrChkRidges.ControlContentsChanged, ucrInputAddReorder.ControlContentsChanged, ucrChkBinWidth.ControlContentsChanged, ucrNudBinwidth.ControlContentsChanged
         TestOkEnabled()
     End Sub
+
+    Private Sub ucrPnlOptions_Control(ucrChangedControl As ucrCore) Handles ucrVariablesAsFactorforHist.ControlValueChanged, ucrPnlOptions.ControlValueChanged, ucrInputAddReorder.ControlValueChanged, ucrFactorReceiver.ControlValueChanged, ucrChkRidges.ControlValueChanged, ucrChkDisplayAsDotPlot.ControlValueChanged
+
+    End Sub
+
 End Class

--- a/instat/dlgHistogram.vb
+++ b/instat/dlgHistogram.vb
@@ -119,7 +119,6 @@ Public Class dlgHistogram
         ucrChkOmitYAxis.SetText("Omit Y Axis")
 
         ucrChkBinWidth.SetText("Binwidth")
-        'ucrChkBinWidth.SetParameter(New RParameter("binwidth", 3))
         ucrChkBinWidth.AddToLinkedControls({ucrNudBinwidth}, {True}, bNewLinkedHideIfParameterMissing:=True)
 
         ucrNudBinwidth.SetParameter(New RParameter("binwidth", 3))
@@ -132,6 +131,16 @@ Public Class dlgHistogram
         ucrChkRidges.SetText("Density Ridges")
         ucrChkRidges.AddFunctionNamesCondition(True, "geom_density_ridges")
         ucrChkRidges.AddFunctionNamesCondition(False, "geom_density_ridges", False)
+        ucrChkRidges.AddToLinkedControls({ucrChkMinHeight}, {True}, bNewLinkedHideIfParameterMissing:=True)
+
+        ucrChkMinHeight.SetText("Min Height")
+        ucrChkMinHeight.AddToLinkedControls({ucrNudMinHeight}, {True}, bNewLinkedHideIfParameterMissing:=True)
+
+        ucrNudMinHeight.SetParameter(New RParameter("rel_min_height", 4))
+        ucrNudMinHeight.SetMinMax(0.00, 10.0)
+        ucrNudMinHeight.DecimalPlaces = 3
+        ucrNudMinHeight.Increment = 0.01
+        ucrNudMinHeight.SetRDefault(0.01)
 
         ucrVariablesAsFactorforHist.SetParameter(New RParameter("x", 0))
         ucrVariablesAsFactorforHist.SetFactorReceiver(ucrFactorReceiver)
@@ -252,7 +261,9 @@ Public Class dlgHistogram
             ucrInputStats.SetRCode(clsHistAesFunction, bReset)
             ucrFactorReceiver.SetRCode(clsRaesFunction, bReset)
             ucrChkBinWidth.SetRCode(clsRgeomPlotFunction, bReset)
+            ucrChkMinHeight.SetRCode(clsRgeomPlotFunction, bReset)
             ucrNudBinwidth.SetRCode(clsRgeomPlotFunction, bReset)
+            ucrNudMinHeight.SetRCode(clsRgeomPlotFunction, bReset)
             ucrChkOmitYAxis.SetRCode(clsYlabScalesFunction, bReset)
         End If
     End Sub
@@ -388,7 +399,7 @@ Public Class dlgHistogram
         End If
     End Sub
 
-    Private Sub ucrPnlOptions_Control() Handles ucrPnlOptions.ControlValueChanged, ucrChkDisplayAsDotPlot.ControlValueChanged, ucrChkRidges.ControlValueChanged, ucrFactorReceiver.ControlValueChanged, ucrVariablesAsFactorforHist.ControlValueChanged, ucrInputAddReorder.ControlValueChanged, ucrChkOmitYAxis.ControlValueChanged
+    Private Sub ucrPnlOptions_Control() Handles ucrPnlOptions.ControlValueChanged, ucrChkDisplayAsDotPlot.ControlValueChanged, ucrChkRidges.ControlValueChanged, ucrFactorReceiver.ControlValueChanged, ucrVariablesAsFactorforHist.ControlValueChanged, ucrInputAddReorder.ControlValueChanged, ucrChkOmitYAxis.ControlValueChanged, ucrNudBinwidth.ControlValueChanged
         toolStripMenuItemHistogramOptions.Enabled = rdoHistogram.Checked AndAlso Not ucrChkDisplayAsDotPlot.Checked
         toolStripMenuItemDotOptions.Enabled = rdoHistogram.Checked AndAlso ucrChkDisplayAsDotPlot.Checked
         toolStripMenuItemDensityOptions.Enabled = rdoDensity_ridges.Checked AndAlso Not ucrChkRidges.Checked
@@ -512,13 +523,10 @@ Public Class dlgHistogram
         End If
     End Sub
 
-    Private Sub CoreControls_ControlContentsChanged() Handles ucrVariablesAsFactorforHist.ControlContentsChanged, ucrSaveHist.ControlContentsChanged, ucrFactorReceiver.ControlContentsChanged, ucrChkRidges.ControlContentsChanged, ucrInputAddReorder.ControlContentsChanged, ucrChkBinWidth.ControlContentsChanged, ucrNudBinwidth.ControlContentsChanged
+    Private Sub CoreControls_ControlContentsChanged() Handles ucrVariablesAsFactorforHist.ControlContentsChanged, ucrSaveHist.ControlContentsChanged, ucrFactorReceiver.ControlContentsChanged, ucrChkRidges.ControlContentsChanged, ucrInputAddReorder.ControlContentsChanged, ucrChkBinWidth.ControlContentsChanged, ucrNudBinwidth.ControlContentsChanged, ucrNudMinHeight.ControlContentsChanged
         TestOkEnabled()
     End Sub
 
-    Private Sub ucrPnlOptions_Control(ucrChangedControl As ucrCore) Handles ucrVariablesAsFactorforHist.ControlValueChanged, ucrPnlOptions.ControlValueChanged, ucrInputAddReorder.ControlValueChanged, ucrFactorReceiver.ControlValueChanged, ucrChkRidges.ControlValueChanged, ucrChkDisplayAsDotPlot.ControlValueChanged
-
-    End Sub
     Private Sub ucrChkOmitYAxis_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkOmitYAxis.ControlValueChanged, ucrChkDisplayAsDotPlot.ControlValueChanged
         If ucrChkDisplayAsDotPlot.Checked Then
             If ucrChkOmitYAxis.Checked Then
@@ -528,4 +536,5 @@ Public Class dlgHistogram
             End If
         End If
     End Sub
+
 End Class

--- a/instat/dlgHistogram.vb
+++ b/instat/dlgHistogram.vb
@@ -125,6 +125,7 @@ Public Class dlgHistogram
         ucrNudBinwidth.Increment = 0.01
         ucrNudBinwidth.SetRDefault(1.5)
 
+
         ucrChkRidges.SetText("Density Ridges")
         ucrChkRidges.AddFunctionNamesCondition(True, "geom_density_ridges")
         ucrChkRidges.AddFunctionNamesCondition(False, "geom_density_ridges", False)
@@ -237,6 +238,7 @@ Public Class dlgHistogram
         ucrChkDisplayAsDotPlot.SetRCode(clsRgeomPlotFunction, bReset)
         ucrChkRidges.SetRCode(clsRgeomPlotFunction, bReset)
         ucrVariablesAsFactorforHist.SetRCode(clsRaesFunction, bReset)
+
         If bReset Then
             ucrInputStats.SetRCode(clsHistAesFunction, bReset)
             ucrFactorReceiver.SetRCode(clsRaesFunction, bReset)
@@ -266,8 +268,6 @@ Public Class dlgHistogram
         clsHistAesFunction.AddParameter("y", "stat(count)", iPosition:=0)
         clsRgeomPlotFunction.SetPackageName("ggplot2")
         ucrInputAddReorder.Visible = Not ucrFactorReceiver.IsEmpty()
-
-
 
         If Not ucrNudBinwidth.IsEmpty Then
             clsRgeomPlotFunction.AddParameter("binwidth", 1.5, iPosition:=1)

--- a/instat/dlgHistogram.vb
+++ b/instat/dlgHistogram.vb
@@ -20,9 +20,7 @@ Public Class dlgHistogram
     Private bFirstLoad As Boolean = True
     Private bReset As Boolean = True
     Private clsBaseOperator As New ROperator
-    Private clsBaseOperator2 As New ROperator
     Private clsYlabScalesFunction As New RFunction
-    Private clsBreaksFunction As New RFunction
     Private clsRggplotFunction As New RFunction
     Private clsRgeomPlotFunction As New RFunction
     Private clsRaesFunction As New RFunction
@@ -163,14 +161,12 @@ Public Class dlgHistogram
 
     Private Sub SetDefaults()
         clsBaseOperator = New ROperator
-        clsBaseOperator2 = New ROperator
         clsRggplotFunction = New RFunction
         clsRgeomPlotFunction = New RFunction
         clsRaesFunction = New RFunction
         clsHistAesFunction = New RFunction
         clsPercentage = New RFunction
         clsYlabScalesFunction = New RFunction
-        clsBreaksFunction = New RFunction
         clsForecatsReverse = New RFunction
         clsForecatsInfreqValue = New RFunction
         clsForecatsReverseValue = New RFunction
@@ -215,9 +211,6 @@ Public Class dlgHistogram
 
         clsForecatsInfreqValue.SetPackageName("forcats")
         clsForecatsInfreqValue.SetRCommand("fct_infreq")
-
-        'clsBaseOperator2.SetOperation("+")
-        'clsBaseOperator2.AddParameter("ggplot", clsRFunctionParameter:=clsYlabScalesFunction, iPosition:=0)
 
         clsYlabScalesFunction.SetRCommand("scale_y_continuous")
         clsYlabScalesFunction.AddParameter("NULL", "NULL", bIncludeArgumentName:=False, iPosition:=0)

--- a/instat/dlgHistogram.vb
+++ b/instat/dlgHistogram.vb
@@ -235,13 +235,13 @@ Public Class dlgHistogram
         ucrPnlOptions.SetRCode(clsRgeomPlotFunction, bReset)
         ucrChkPercentages.SetRCode(clsYScalecontinuousFunction, bReset)
         ucrChkDisplayAsDotPlot.SetRCode(clsRgeomPlotFunction, bReset)
-        ucrNudBinwidth.SetRCode(clsRgeomPlotFunction, bReset)
         ucrChkRidges.SetRCode(clsRgeomPlotFunction, bReset)
         ucrVariablesAsFactorforHist.SetRCode(clsRaesFunction, bReset)
         If bReset Then
             ucrInputStats.SetRCode(clsHistAesFunction, bReset)
             ucrFactorReceiver.SetRCode(clsRaesFunction, bReset)
             ucrChkBinWidth.SetRCode(clsRgeomPlotFunction, bReset)
+            ucrNudBinwidth.SetRCode(clsRgeomPlotFunction, bReset)
         End If
     End Sub
 
@@ -266,6 +266,14 @@ Public Class dlgHistogram
         clsHistAesFunction.AddParameter("y", "stat(count)", iPosition:=0)
         clsRgeomPlotFunction.SetPackageName("ggplot2")
         ucrInputAddReorder.Visible = Not ucrFactorReceiver.IsEmpty()
+
+
+
+        If Not ucrNudBinwidth.IsEmpty Then
+            clsRgeomPlotFunction.AddParameter("binwidth", 1.5, iPosition:=1)
+        Else
+            clsRgeomPlotFunction.RemoveParameterByName("binwidth")
+        End If
 
         If rdoHistogram.Checked Then
             If ucrChkDisplayAsDotPlot.Checked Then


### PR DESCRIPTION
Fixes #8789

this Fixes parts c, d and f

This is not ready for review.

There seem to be a problem with the check boxes for binwidth and min.height, unless you change the values in the up and down button, the checkboxes do not tick in the sub-dialog.
I am still working to find a solution