### PR TITLE
Ensured that R script only analysed if it has changed since the last analysis

### DIFF
--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -25,6 +25,7 @@ Public Class ucrScript
     Private bIsTextChanged = False
     Private iMaxLineNumberCharLength As Integer = 0
     Private Const iTabIndexLog As Integer = 0
+    Private clsRScript As RScript = Nothing
     Private strRInstatLogFilesFolderPath As String = Path.Combine(Path.GetFullPath(FileIO.SpecialDirectories.MyDocuments), "R-Instat_Log_files")
 
     Friend WithEvents clsScriptActive As Scintilla
@@ -298,6 +299,7 @@ Public Class ucrScript
 
         TabControl.SelectedTab = tabPageAdded
         bIsTextChanged = False
+        clsRScript = Nothing
         EnableDisableButtons()
     End Sub
 
@@ -544,6 +546,7 @@ Public Class ucrScript
                 TabControl.SelectedTab.Text = System.IO.Path.GetFileNameWithoutExtension(dlgLoad.FileName)
                 strInitialDirectory = Path.GetDirectoryName(dlgLoad.FileName)
                 bIsTextChanged = False
+                clsRScript = Nothing
                 frmMain.clsRecentItems.addToMenu(Replace(Path.Combine(Path.GetFullPath(FileIO.SpecialDirectories.MyDocuments), System.IO.Path.GetFileName(dlgLoad.FileName)), "\", "/"))
                 frmMain.bDataSaved = True
             Catch
@@ -643,7 +646,10 @@ Public Class ucrScript
         Try
             Dim dctRStatements As OrderedDictionary
             Try
-                dctRStatements = New RScript(clsScriptActive.Text).statements
+                If clsRScript Is Nothing Then
+                    clsRScript = New RScript(clsScriptActive.Text)
+                End If
+                dctRStatements = clsRScript.statements
             Catch ex As Exception
                 MsgBox("R script parsing failed with message:" & Environment.NewLine _
                    & Environment.NewLine & ex.Message & Environment.NewLine & Environment.NewLine _
@@ -763,6 +769,7 @@ Public Class ucrScript
 
     Private Sub clsScriptActive_TextChanged(sender As Object, e As EventArgs) Handles clsScriptActive.TextChanged
         bIsTextChanged = True
+        clsRScript = Nothing
         EnableDisableButtons()
         SetLineNumberMarginWidth(clsScriptActive.Lines.Count.ToString().Length)
     End Sub
@@ -980,7 +987,7 @@ Public Class ucrScript
                 'This is just to be on the safe side. It is not worth the extra complexity of
                 'checking if the script is the same as the associated file name
                 bIsTextChanged = clsScriptActive.TextLength > 0
-
+                clsRScript = Nothing
                 EnableDisableButtons()
                 Exit Sub
             End If


### PR DESCRIPTION
Fixes #8852 

@rdstern 
This PR should not change the script window functionality. It just makes the statement-by-statement execution faster by storing the R code analysis and only reanalysing if/when the script changes. The analysis is anyway very fast (the time taken to execute the statement is mainly in the R environment) so you will not notice any difference in statement-by-statement execution speed for short scripts. But on an older laptop with very long scripts this PR should make execution faster.

'Run All' and 'Run Selected' functionality is not affected (it's not worth optimizing this because these options create a temporary script with a comment at the top).

Please could you test?
Thanks