### PR TITLE
Correcting the browsing in the Export Dataset Dialogue

### DIFF
--- a/instat/ucrReceiverMultiple.vb
+++ b/instat/ucrReceiverMultiple.vb
@@ -322,7 +322,7 @@ Public Class ucrReceiverMultiple
     End Function
 
     Public Overrides Function GetVariableNamesList(Optional bWithQuotes As Boolean = True, Optional strQuotes As String = Chr(34)) As String()
-        Dim arrItems(lstSelectedVariables.Items.Count) As String
+        Dim arrItems(lstSelectedVariables.Items.Count - 1) As String
         Dim strQuoteHolder As String = If(bWithQuotes, strQuotes, "")
         For i = 0 To lstSelectedVariables.Items.Count - 1
             arrItems(i) = strQuoteHolder & lstSelectedVariables.Items(i).Text & strQuoteHolder


### PR DESCRIPTION
Fixes #8866
@rdstern I have used this as a good example to show the team in our today meeting on how to debug the code and fix when there is an issue. The problem was more general and coming from `GetVariableNamesList` function from `ucrReceiverMultiple` control. Have a look.