### PR TITLE
Ensured that Enter dialog assignments are correctly deleted

### DIFF
--- a/instat/clsRSyntax.vb
+++ b/instat/clsRSyntax.vb
@@ -94,8 +94,6 @@ Public Class RSyntax
     ''' <summary>   The R command in the form of a string. </summary>
     Public strCommandString As String = ""
 
-    ''' <summary>   The script associated with the base R code. </summary>
-    Public strScript As String
 
     ''' <summary>   The R functions/operators/commands that should be run before the base R code. </summary>
     Private lstBeforeCodes As New List(Of RCodeStructure)
@@ -231,6 +229,8 @@ Public Class RSyntax
             clsBaseFunction.GetAllAssignTo(lstCodes, lstValues)
         ElseIf bUseBaseOperator Then
             clsBaseOperator.GetAllAssignTo(lstCodes, lstValues)
+        ElseIf bUseCommandString Then
+            clsBaseCommandString.GetAllAssignTo(lstCodes, lstValues)
         End If
         lstBeforeCodes.Sort(AddressOf CompareCodePositions)
         For Each clsTempCode As RCodeStructure In lstBeforeCodes
@@ -295,6 +295,7 @@ Public Class RSyntax
     '''--------------------------------------------------------------------------------------------
     Public Function GetScript() As String
         Dim strTemp As String = ""
+        Dim strScript As String = ""
 
         If bUseBaseFunction Then
             strTemp = clsBaseFunction.ToScript(strScript)
@@ -431,6 +432,7 @@ Public Class RSyntax
         clsBaseFunction = clsFunction
         bUseBaseFunction = True
         bUseBaseOperator = False
+        bUseCommandString = False
     End Sub
 
     '''--------------------------------------------------------------------------------------------
@@ -442,6 +444,7 @@ Public Class RSyntax
         clsBaseOperator = clsOperator
         bUseBaseFunction = False
         bUseBaseOperator = True
+        bUseCommandString = False
     End Sub
 
     '''--------------------------------------------------------------------------------------------

--- a/instat/ucrButtons.vb
+++ b/instat/ucrButtons.vb
@@ -173,10 +173,6 @@ Public Class ucrButtons
             frmMain.AddToScriptWindow(clsRsyntax.GetScript(), bMakeVisible:=bMakeVisibleScriptWindow, bAppendAtCurrentCursorPosition:=bAppendScriptsAtCurrentScriptWindowCursorPosition)
         End If
 
-        'This clears the script after it has been run, but leave the function and parameters in the base function
-        'so that it can be run exactly the same when reopened.
-        clsRsyntax.strScript = ""
-
         'Run additional after codes
         lstAfterCodes = clsRsyntax.GetAfterCodes()
         lstAfterScripts = clsRsyntax.GetScriptsFromCodeList(lstAfterCodes)


### PR DESCRIPTION
I found another regression in PR #8881:
The last line of the script generated by the `Enter` dialog should be `rm(list=c("enter", "survey"))
`. However it was only `rm(list=c("survey"))`.
I fixed this in this PR.
I also reversed an unnecessary (but harmless) change I made in PR #8913 (making `strScript` public).

@rdstern Please could you check that the Enter and Calculator dialogs still work as expected?

Thank you