### PR TITLE
Fixes issue with Random Split having overlapping groups

### DIFF
--- a/instat/dlgRandomSplit.vb
+++ b/instat/dlgRandomSplit.vb
@@ -132,8 +132,7 @@ Public Class dlgRandomSplit
         clsTesting.SetPackageName("rsample")
         clsTesting.SetRCommand("testing")
         ucrBase.clsRsyntax.SetBaseRFunction(clsInitialSplit)
-        ucrBase.clsRsyntax.AddToAfterCodes(clsTesting, 0)
-        ucrBase.clsRsyntax.AddToAfterCodes(clsTraining, 1)
+
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
@@ -153,7 +152,7 @@ Public Class dlgRandomSplit
         ucrChkStratifyingFactor.SetRCode(clsInitialSplit, bReset)
 
         If bReset Then
-            ucrChkTest.SetRCode(clsInitialSplit, bReset)
+            ucrChkTest.SetRCode(clsTesting, bReset)
         End If
     End Sub
 
@@ -190,24 +189,35 @@ Public Class dlgRandomSplit
     Private Sub SetBaseFunction()
         ucrBase.clsRsyntax.ClearCodes()
         If rdoSample.Checked Then
-            If ucrSaveTestingData.IsComplete Then
-                clsTesting.AddParameter("x", clsRFunctionParameter:=clsInitialSplit)
+            If ucrChkTest.Checked AndAlso ucrSaveTestingData.IsComplete Then
+                clsTesting.AddParameter("x", "rsample")
+                ucrBase.clsRsyntax.AddToAfterCodes(clsTesting, 0)
+            Else
+                ucrBase.clsRsyntax.RemoveFromAfterCodes(clsTesting)
             End If
             If ucrSaveTrainingData.IsComplete Then
-                clsTraining.AddParameter("x", clsRFunctionParameter:=clsInitialSplit)
+                clsTraining.AddParameter("x", "rsample")
+                ucrBase.clsRsyntax.AddToAfterCodes(clsTraining, 1)
+            Else
+                ucrBase.clsRsyntax.RemoveFromAfterCodes(clsTraining)
             End If
             ucrBase.clsRsyntax.SetBaseRFunction(clsInitialSplit)
         Else
-            If ucrSaveTestingData.IsComplete Then
-                clsTesting.AddParameter("x", clsRFunctionParameter:=clsInitialTimeSplit)
+            If ucrChkTest.Checked AndAlso ucrSaveTestingData.IsComplete Then
+                clsTesting.AddParameter("x", "rsample")
+                ucrBase.clsRsyntax.AddToAfterCodes(clsTesting, 0)
+            Else
+                ucrBase.clsRsyntax.RemoveFromAfterCodes(clsTesting)
             End If
             If ucrSaveTrainingData.IsComplete Then
-                clsTraining.AddParameter("x", clsRFunctionParameter:=clsInitialTimeSplit)
+                clsTraining.AddParameter("x", "rsample")
+                ucrBase.clsRsyntax.AddToAfterCodes(clsTraining, 1)
+            Else
+                ucrBase.clsRsyntax.RemoveFromAfterCodes(clsTraining)
             End If
             ucrBase.clsRsyntax.SetBaseRFunction(clsInitialTimeSplit)
         End If
-        ucrBase.clsRsyntax.AddToAfterCodes(clsTesting, 0)
-        ucrBase.clsRsyntax.AddToAfterCodes(clsTraining, 1)
+
     End Sub
 
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
@@ -233,4 +243,7 @@ Public Class dlgRandomSplit
         SetBaseFunction()
     End Sub
 
+    Private Sub ucrChkTest_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkTest.ControlValueChanged
+        SetBaseFunction()
+    End Sub
 End Class


### PR DESCRIPTION
fixes #8957
@lilyclements I have fixed the issue of the Random split having overlapping groups by letting the
`rsample <- rsample::initial_split(data=survey, prop=0.75)`
can you review this
Thanks