### PR TITLE
Adding Help context number to the Help > Packages Documentation dialog

### DIFF
--- a/instat/dlgHelpVignettes.vb
+++ b/instat/dlgHelpVignettes.vb
@@ -40,6 +40,7 @@ Public Class dlgHelpVignettes
         Dim expPackageNames As SymbolicExpression
         Dim chrPackageNames As CharacterVector
 
+        ucrBase.iHelpTopicID = 695
         ucrPnlHelpVignettes.AddRadioButton(rdoHelp)
         ucrPnlHelpVignettes.AddRadioButton(rdoVignettes)
 


### PR DESCRIPTION
Fixes issue #8990 
@rdstern I have tested this with a different context that is valid in the current help file and it is working well, hence, this will work once the file is updated 