### PR TITLE
Defining the Timeseries Data 

### DIFF
--- a/instat/Model/DataFrame/clsDataFramePage.vb
+++ b/instat/Model/DataFrame/clsDataFramePage.vb
@@ -294,6 +294,8 @@ Public Class clsDataFramePage
             columnHeader.strTypeShortCode = "(CX)"
         ElseIf strHeaderType.Contains("sfc_MULTIPOLYGON") OrElse strHeaderType.Contains("sfc") Then
             columnHeader.strTypeShortCode = "(G)"
+        ElseIf strHeaderType.Contains("Timeseries") OrElse strHeaderType.Contains("ts") Then
+            columnHeader.strTypeShortCode = "(TS)"
             ' Types of data for specific Application areas e.g. survival are coded with "(A)"
             ' No examples implemented yet.
             'ElseIf strType.Contains() Then

--- a/instat/dlgDuplicateColumns.Designer.vb
+++ b/instat/dlgDuplicateColumns.Designer.vb
@@ -61,6 +61,7 @@ Partial Class dlgDuplicateColumns
         Me.ucrSelectorForDuplicateColumn = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrSaveColumn = New instat.ucrSave()
+        Me.ucrChkIgnoreLabels = New instat.ucrCheck()
         Me.grpConvertTo.SuspendLayout()
         Me.grpFactorToNumericOptions.SuspendLayout()
         Me.SuspendLayout()
@@ -328,12 +329,23 @@ Partial Class dlgDuplicateColumns
         Me.ucrSaveColumn.Size = New System.Drawing.Size(327, 22)
         Me.ucrSaveColumn.TabIndex = 30
         '
+        'ucrChkIgnoreLabels
+        '
+        Me.ucrChkIgnoreLabels.AutoSize = True
+        Me.ucrChkIgnoreLabels.Checked = False
+        Me.ucrChkIgnoreLabels.Location = New System.Drawing.Point(371, 340)
+        Me.ucrChkIgnoreLabels.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrChkIgnoreLabels.Name = "ucrChkIgnoreLabels"
+        Me.ucrChkIgnoreLabels.Size = New System.Drawing.Size(100, 23)
+        Me.ucrChkIgnoreLabels.TabIndex = 31
+        '
         'dlgDuplicateColumns
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(486, 432)
+        Me.Controls.Add(Me.ucrChkIgnoreLabels)
         Me.Controls.Add(Me.ucrSaveColumn)
         Me.Controls.Add(Me.ucrChkChangeType)
         Me.Controls.Add(Me.ucrChkConvertCreateLabels)
@@ -385,4 +397,5 @@ Partial Class dlgDuplicateColumns
     Friend WithEvents ucrChkConvertKeepAttributes As ucrCheck
     Friend WithEvents ucrChkChangeType As ucrCheck
     Friend WithEvents ucrSaveColumn As ucrSave
+    Friend WithEvents ucrChkIgnoreLabels As ucrCheck
 End Class

--- a/instat/dlgDuplicateColumns.vb
+++ b/instat/dlgDuplicateColumns.vb
@@ -108,6 +108,12 @@ Public Class dlgDuplicateColumns
         ucrChkConvertKeepAttributes.SetText("Keep Attributes")
         ucrChkConvertKeepAttributes.SetRDefault("TRUE")
 
+        ucrPnlConvertTo.AddToLinkedControls(ucrChkIgnoreLabels, {rdoConvertToNumeric}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrChkIgnoreLabels.SetParameter(New RParameter("ignore_labels", 7))
+        ucrChkIgnoreLabels.SetValuesCheckedAndUnchecked("TRUE", "FALSE")
+        ucrChkIgnoreLabels.SetRDefault("FALSE")
+        ucrChkIgnoreLabels.SetText("Ignore Labels")
+
         ucrPnlConvertTo.AddToLinkedControls(ucrChkConvertCreateLabels, {rdoConvertToNumeric}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrChkConvertCreateLabels.SetParameter(New RParameter("keep.labels", 7))
         ucrChkConvertCreateLabels.SetText("Create Labels")
@@ -217,5 +223,13 @@ Public Class dlgDuplicateColumns
 
     Private Sub CoreControls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverDuplicateColumns.ControlContentsChanged, ucrPnlConvertTo.ControlContentsChanged, ucrNudConvertDisplayDecimals.ControlContentsChanged, ucrChkConvertSpecifyDecimalsToDisplay.ControlContentsChanged, ucrChkChangeType.ControlContentsChanged
         TestOKEnabled()
+    End Sub
+
+    Private Sub ucrChkIgnoreLabels_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkIgnoreLabels.ControlValueChanged
+        If ucrChkIgnoreLabels.Checked Then
+            clsConvertFunction.AddParameter("ignore_labels", "TRUE")
+        Else
+            clsConvertFunction.RemoveParameterByName("ignore_labels")
+        End If
     End Sub
 End Class


### PR DESCRIPTION
fixing partly #9004 
This Fixes part a) and the second part of part b)
for the part b 
I took a look at the function in the `Right-click > Convert to Numeric` and realised it had ignore labels as part of the convert to function.
this option is already available in the `Prepare > Data Frame > Convert Column` but under a different name (simple convert) but not available in the duplicate dialog so i added it there.

@rdstern , @N-thony this PR is ready for review
Thanks