### PR TITLE
Improving column Right click to Numeric

### DIFF
--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -661,20 +661,24 @@ Public Class ucrDataView
                 GetCurrentDataFrameFocus().clsPrepareFunctions.ConvertToNumeric(strColumn, True)
             Else
                 Dim bCheckLabels As Boolean = GetCurrentDataFrameFocus().clsPrepareFunctions.CheckHasLabels(strColumn)
-                frmConvertToNumeric.SetDataFrameName(GetCurrentDataFrameFocus().strName)
-                frmConvertToNumeric.SetColumnName(strColumn)
-                frmConvertToNumeric.CheckLabels(bCheckLabels)
-                frmConvertToNumeric.SetNonNumeric(iNonNumericValues)
-                frmConvertToNumeric.ShowDialog()
-                ' Yes for "normal" convert and No for "ordinal" convert
-                Select Case frmConvertToNumeric.DialogResult
-                    Case DialogResult.Yes
-                        GetCurrentDataFrameFocus().clsPrepareFunctions.ConvertToNumeric(strColumn, True)
-                    Case DialogResult.No
-                        GetCurrentDataFrameFocus().clsPrepareFunctions.ConvertToNumeric(strColumn, False)
-                    Case DialogResult.Cancel
-                        Continue For
-                End Select
+                If bCheckLabels = False Then
+                    frmConvertToNumeric.SetDataFrameName(GetCurrentDataFrameFocus().strName)
+                    frmConvertToNumeric.SetColumnName(strColumn)
+                    frmConvertToNumeric.CheckLabels(bCheckLabels)
+                    frmConvertToNumeric.SetNonNumeric(iNonNumericValues)
+                    frmConvertToNumeric.ShowDialog()
+                    ' Yes for "normal" convert and No for "ordinal" convert
+                    Select Case frmConvertToNumeric.DialogResult
+                        Case DialogResult.Yes
+                            GetCurrentDataFrameFocus().clsPrepareFunctions.ConvertToNumeric(strColumn, True)
+                        Case DialogResult.No
+                            GetCurrentDataFrameFocus().clsPrepareFunctions.ConvertToNumeric(strColumn, False)
+                        Case DialogResult.Cancel
+                            Continue For
+                    End Select
+                ElseIf bCheckLabels = True Then
+                    GetCurrentDataFrameFocus().clsPrepareFunctions.ConvertToNumeric(strColumn, True)
+                End If
                 frmConvertToNumeric.Close()
             End If
         Next


### PR DESCRIPTION
Fixes #8920
for this PR we set up some conditions for the convert to numeric
1. if the column has a `non-numeric value` within, it should immediately show the `frmConvertToNumeric` dialog so that the user can use either `normal convert` or `ordinal convert`. This prevents the regression found in #9020 
2. check to see if the column factor being converted to numeric contains label/levels (so even if you convert a logical to factor, you should ensure that it has labels else the `frmConvertToNumeric` will pop-up )

@rdstern , @N-thony 
this is ready for review
Thanks