### PR TITLE
Update to crops definition function to allow for "both"

### DIFF
--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -2046,6 +2046,7 @@ DataBook$set("public","get_variable_sets", function(data_name, set_names, force_
 }
 )
 
+
 DataBook$set("public", "crops_definitions", function(data_name, year, station, rain, day, rain_totals, plant_days, plant_lengths, start_check = TRUE, season_data_name, start_day, end_day, definition_props = TRUE, print_table = TRUE) {
   plant_day_name <- "plant_day"
   plant_length_name <- "plant_length"
@@ -2054,8 +2055,8 @@ DataBook$set("public", "crops_definitions", function(data_name, year, station, r
   is_station <- !missing(station)
   
   if(missing(year)) stop("Year column must be specified.")
-  if(!is_station) by <- year
-  else by <- c(year, station)
+  by <- if(!is_station) year else c(year, station)
+
   if(missing(season_data_name)) season_data_name <- data_name
   if(season_data_name != data_name) {
     season_by <- self$get_equivalent_columns(from_data_name = data_name, columns = by, to_data_name = season_data_name)
@@ -2064,20 +2065,8 @@ DataBook$set("public", "crops_definitions", function(data_name, year, station, r
   year_col <- self$get_columns_from_data(data_name, year)
   unique_year <- na.omit(unique(year_col))
   
-  expand_list <- list()
-  names_list <- c()
-  
-  expand_list[[length(expand_list) + 1]] <- rain_totals
-  names_list[length(names_list) + 1] <- rain_total_name
-  
-  expand_list[[length(expand_list) + 1]] <- plant_lengths
-  names_list[length(names_list) + 1] <- plant_length_name
-  
-  expand_list[[length(expand_list) + 1]] <- plant_days
-  names_list[length(names_list) + 1] <- plant_day_name
-  
-  expand_list[[length(expand_list) + 1]] <- unique_year
-  names_list[length(names_list) + 1] <- year
+  expand_list <- list(rain_totals, plant_lengths, plant_days, unique_year)
+  names_list <- c(rain_total_name, plant_length_name, plant_day_name, year)
   
   if(is_station) {
     station_col <- self$get_columns_from_data(data_name, station)
@@ -2085,8 +2074,10 @@ DataBook$set("public", "crops_definitions", function(data_name, year, station, r
     expand_list[[length(expand_list) + 1]] <- unique_station
     names_list[length(names_list) + 1] <- station
   }
+
   df <- setNames(expand.grid(expand_list), names_list)
   daily_data <- self$get_data_frame(data_name)
+  
   if(season_data_name != data_name) {
     join_by <- by
     names(join_by) <- season_by
@@ -2106,7 +2097,7 @@ DataBook$set("public", "crops_definitions", function(data_name, year, station, r
   }
   
   # Plant day condition
-  if(start_check) {
+  if(start_check %in% c("yes", "both")) {
     df$plant_day_cond <- (df[[start_day]] <= df[[plant_day_name]])
   }
   
@@ -2114,34 +2105,57 @@ DataBook$set("public", "crops_definitions", function(data_name, year, station, r
   df$length_cond <- (df[[plant_day_name]] + df[[plant_length_name]] <= df[[end_day]])
   
   # Rain total condition
-  df[["rain_total_actual"]] <- sapply(1:nrow(df), 
-                                      function(x) {
-                                        ind <- daily_data[[year]] == df[[year]][x] & daily_data[[day]] >= df[[plant_day_name]][x] & 
-                                          daily_data[[day]] < (df[[plant_day_name]][x] + df[[plant_length_name]][x])
-                                        if(is_station) ind <- ind & (daily_data[[station]] == df[[station]][x])
-                                        rain_values <- daily_data[[rain]][ind]
-                                        sum_rain <- sum(rain_values, na.rm = TRUE)
-                                        # TODO + 1 is needed because of non leap years
-                                        # if period include 29 Feb then period is 1 less than required length
-                                        if(length(rain_values) + 1 < df[[plant_length_name]][x] || (anyNA(rain_values) && sum_rain < df[[rain_total_name]][x])) sum_rain <- NA
-                                        sum_rain
-                                      }
-  )
+# Create a column for the rain total actuals initialised with NA
+df[["rain_total_actual"]] <- NA
+
+# Vectorise the conditions for each 
+for (i in 1:nrow(df)) {
+  # Create a condition to filter the daily data based on the year, day, and plant day/length
+  ind <- daily_data[[year]] == df[[year]][i] &
+         daily_data[[day]] >= df[[plant_day_name]][i] &
+         daily_data[[day]] < (df[[plant_day_name]][i] + df[[plant_length_name]][i])
+  
+  if (is_station) {
+    ind <- ind & (daily_data[[station]] == df[[station]][i])
+  }
+
+  # Filter the daily data based on the condition
+  rain_values <- daily_data[[rain]][ind]
+
+  # Calculate the sum of rain values and check conditions
+  sum_rain <- sum(rain_values, na.rm = TRUE)
+  
+  if (length(rain_values) + 1 < df[[plant_length_name]][i] || (anyNA(rain_values) && sum_rain < df[[rain_total_name]][i])) {
+    sum_rain <- NA
+  }
+
+  # Assign the calculated sum to the respective row in the result dataframe
+  df[["rain_total_actual"]][i] <- sum_rain
+}
   df$rain_cond <- df[[rain_total_name]] <= df[["rain_total_actual"]]
   
   # All three conditions met
-  df$overall_cond <- ((if(start_check) df$plant_day_cond else TRUE) & df$length_cond & df$rain_cond)
+  if (start_check == "yes"){
+    df$overall_cond <- df$plant_day_cond & df$length_cond & df$rain_cond
+  } else if (start_check == "no"){
+    df$overall_cond <- TRUE & df$length_cond & df$rain_cond
+  } else {
+    df$overall_cond_with_start <- df$plant_day_cond & df$length_cond & df$rain_cond
+    df$overall_cond_no_start <- TRUE & df$length_cond & df$rain_cond
+  }
   
   crops_name <- "crop_def"
   crops_name <- next_default_item(prefix = crops_name, existing_names = self$get_data_names(), include_index = FALSE)
   data_tables <- list(df)
   names(data_tables) <- crops_name
   self$import_data(data_tables = data_tables)
+
   if(season_data_name != data_name) {
     crops_by <- season_by
     names(crops_by) <- by
     self$add_link(crops_name, season_data_name, crops_by, keyed_link_label)
   }
+
   if(definition_props) {
     calc_from <- list()
     if(!missing(station)) calc_from[[length(calc_from) + 1]] <- station
@@ -2150,24 +2164,61 @@ DataBook$set("public", "crops_definitions", function(data_name, year, station, r
     calc_from[[length(calc_from) + 1]] <- rain_total_name
     names(calc_from) <- rep(crops_name, length(calc_from))
     grouping <- instat_calculation$new(type = "by", calculated_from = calc_from)
-    prop_calc_from <- list("overall_cond")
-    names(prop_calc_from) <- crops_name
-    propor_table <- instat_calculation$new(function_exp="sum(overall_cond, na.rm = TRUE)/length(na.omit(overall_cond))",
-                                           save = 2, calculated_from = prop_calc_from,
-                                           manipulations = list(grouping),
-                                           type="summary", result_name = "prop_success", result_data_frame = "crop_prop")
-    prop_data_frame <- self$run_instat_calculation(propor_table, display = TRUE)
-    if(print_table) {
-      prop_data_frame$prop_success <- round(prop_data_frame$prop_success, 2)
-      prop_table_unstacked <- reshape2::dcast(formula = as.formula(paste(if(!missing(station)) paste(station, "+"), plant_length_name, "+", rain_total_name, "~", plant_day_name)), data = prop_data_frame, value.var = "prop_success")
-      if(!missing(station)) f <- interaction(prop_table_unstacked[[station]], prop_table_unstacked[[plant_length_name]], lex.order = TRUE)
-      else f <- prop_table_unstacked[[plant_length_name]]
-      prop_table_split <- split(prop_table_unstacked, f)
-      return(prop_table_split)
-    }
-  }
-}
-)
+    
+    if (start_check %in% c("yes", "no")){
+      prop_calc_from <- list("overall_cond")
+      names(prop_calc_from) <- crops_name
+      propor_table <- instat_calculation$new(function_exp="sum(overall_cond, na.rm = TRUE)/length(na.omit(overall_cond))",
+                                             save = 2, calculated_from = prop_calc_from,
+                                             manipulations = list(grouping),
+                                             type="summary", result_name = "prop_success", result_data_frame = "crop_prop")
+      prop_data_frame <- self$run_instat_calculation(propor_table, display = TRUE)
+      if(print_table) {
+        prop_data_frame$prop_success <- round(prop_data_frame$prop_success, 2)
+        prop_table_unstacked <- reshape2::dcast(formula = as.formula(paste(if(!missing(station)) paste(station, "+"), plant_length_name, "+", rain_total_name, "~", plant_day_name)), data = prop_data_frame, value.var = "prop_success")
+        if(!missing(station)) f <- interaction(prop_table_unstacked[[station]], prop_table_unstacked[[plant_length_name]], lex.order = TRUE)
+        else f <- prop_table_unstacked[[plant_length_name]]
+        prop_table_split <- split(prop_table_unstacked, f)
+        return(prop_table_split)
+      }
+    } else {
+      prop_calc_from_with_start <- list("overall_cond_with_start")
+      names(prop_calc_from_with_start) <- crops_name
+      propor_table_with_start <- instat_calculation$new(function_exp="sum(overall_cond_with_start, na.rm = TRUE)/length(na.omit(overall_cond_with_start))",
+                                             save = 2, calculated_from = prop_calc_from_with_start,
+                                             manipulations = list(grouping),
+                                             type="summary", result_name = "prop_success", result_data_frame = "crop_prop_with_start")
+      prop_data_frame_with_start <- self$run_instat_calculation(propor_table_with_start, display = TRUE)
+      
+      prop_calc_from_no_start <- list("overall_cond_no_start")
+      names(prop_calc_from_no_start) <- crops_name
+      propor_table_no_start <- instat_calculation$new(function_exp="sum(overall_cond_no_start, na.rm = TRUE)/length(na.omit(overall_cond_no_start))",
+                                                        save = 2, calculated_from = prop_calc_from_no_start,
+                                                        manipulations = list(grouping),
+                                                        type="summary", result_name = "prop_success", result_data_frame = "crop_prop_no_start")
+      prop_data_frame_no_start <- self$run_instat_calculation(propor_table_no_start, display = TRUE)
+      
+      if(print_table) {
+        prop_data_frame_with_start$prop_success <- round(prop_data_frame_with_start$prop_success, 2)
+        prop_table_unstacked_with_start <- reshape2::dcast(formula = as.formula(paste(if(!missing(station)) paste(station, "+"), plant_length_name, "+", rain_total_name, "~", plant_day_name)), data = prop_data_frame_with_start, value.var = "prop_success")
+        if(!missing(station)) f <- interaction(prop_table_unstacked_with_start[[station]], prop_table_unstacked_with_start[[plant_length_name]], lex.order = TRUE)
+        else f <- prop_table_unstacked_with_start[[plant_length_name]]
+        prop_table_split_with_start <- split(prop_table_unstacked_with_start, f)
+        
+        prop_data_frame_no_start$prop_success <- round(prop_data_frame_no_start$prop_success, 2)
+        prop_table_unstacked_no_start <- reshape2::dcast(formula = as.formula(paste(if(!missing(station)) paste(station, "+"), plant_length_name, "+", rain_total_name, "~", plant_day_name)), data = prop_data_frame_no_start, value.var = "prop_success")
+        if(!missing(station)) f <- interaction(prop_table_unstacked_no_start[[station]], prop_table_unstacked_no_start[[plant_length_name]], lex.order = TRUE)
+        else f <- prop_table_unstacked_no_start[[plant_length_name]]
+        prop_table_split_no_start <- split(prop_table_unstacked_no_start, f)
+
+        # Create an empty list to store the merged data
+        merged_list <- list()
+       
+        # Vectorize the addition of source indicators and merging of data frames
+        prop_table_split_with_start <- lapply(prop_table_split_with_start, function(df) {
+            df$source <- 'with start'
+  return(df)
+})
 
 #' Converting grid (wide) format daily climatic data into tidy (long format) data
 #' @param x Input data frame

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -2054,8 +2054,8 @@ DataBook$set("public", "crops_definitions", function(data_name, year, station, r
   is_station <- !missing(station)
   
   if(missing(year)) stop("Year column must be specified.")
-  by <- ifelse(!is_station, year, c(year, station))
-  
+  if(!is_station) by <- year
+  else by <- c(year, station)
   if(missing(season_data_name)) season_data_name <- data_name
   if(season_data_name != data_name) {
     season_by <- self$get_equivalent_columns(from_data_name = data_name, columns = by, to_data_name = season_data_name)

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -2055,7 +2055,7 @@ DataBook$set("public", "crops_definitions", function(data_name, year, station, r
   is_station <- !missing(station)
   
   if(missing(year)) stop("Year column must be specified.")
-  by <- if(!is_station) year else c(year, station)
+  by <- ifelse(!is_station, year, c(year, station))
 
   if(missing(season_data_name)) season_data_name <- data_name
   if(season_data_name != data_name) {


### PR DESCRIPTION
We want to have the option to see the results with "Start Check" both TRUE and FALSE in the same table (as two columns)

This PR does this, so now `start_check` takes `"yes"`, `"no"`, and `"both"` as arguments.

`start_check == "yes"` works how `start_check == TRUE` used to work
`start_check == "no"` works how `start_check == FALSE` used to work
`start_check == "both"` gives results for `start_check == TRUE` and `start_check == FALSE`. This therefore gives **two** columns - instead of `overall_cond`, which is given for the above two options, this gives `overall_cond_with_start` and `overall_cond_no_start`.

This is for use in EPICSA where we want to have stored a whole set of summaries to be calculable from a saved file (i.e., the resulting "crops_def" file here)

This is linked to issue #9052. I suggest that whoever implements #9052 reads in these changes (this should **not** be merged without amendments made to the dialog because of the changes in `start_check`)