### PR TITLE
Added the reformat option into the script window via right click

### DIFF
--- a/instat/ucrScript.Designer.vb
+++ b/instat/ucrScript.Designer.vb
@@ -53,6 +53,7 @@ Partial Class ucrScript
         Me.mnuRunAllText = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator3 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuOpenScriptasFile = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuInsertScript = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuLoadScriptFromFile = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuSaveScript = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator4 = New System.Windows.Forms.ToolStripSeparator()
@@ -60,6 +61,7 @@ Partial Class ucrScript
         Me.lblHeaderScript = New System.Windows.Forms.Label()
         Me.tlpTableContainer = New System.Windows.Forms.TableLayoutPanel()
         Me.Panel = New System.Windows.Forms.Panel()
+        Me.cmdInsertScript = New System.Windows.Forms.Button()
         Me.cmdSave = New System.Windows.Forms.Button()
         Me.cmdLoadScript = New System.Windows.Forms.Button()
         Me.cmdRemoveTab = New System.Windows.Forms.Button()
@@ -70,8 +72,7 @@ Partial Class ucrScript
         Me.cmdRunStatementSelection = New System.Windows.Forms.Button()
         Me.TabControl = New System.Windows.Forms.TabControl()
         Me.toolTipScriptWindow = New System.Windows.Forms.ToolTip(Me.components)
-        Me.cmdInsertScript = New System.Windows.Forms.Button()
-        Me.mnuInsertScript = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuReformat = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuContextScript.SuspendLayout()
         Me.tlpTableContainer.SuspendLayout()
         Me.Panel.SuspendLayout()
@@ -80,73 +81,73 @@ Partial Class ucrScript
         'mnuContextScript
         '
         Me.mnuContextScript.ImageScalingSize = New System.Drawing.Size(24, 24)
-        Me.mnuContextScript.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuUndo, Me.mnuRedo, Me.ToolStripSeparator1, Me.mnuCut, Me.mnuCopy, Me.mnuPaste, Me.mnuSelectAll, Me.mnuClear, Me.ToolStripSeparator2, Me.mnuRunCurrentStatementSelection, Me.mnuRunAllText, Me.ToolStripSeparator3, Me.mnuOpenScriptasFile, Me.mnuInsertScript, Me.mnuLoadScriptFromFile, Me.mnuSaveScript, Me.ToolStripSeparator4, Me.mnuHelp})
+        Me.mnuContextScript.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuUndo, Me.mnuRedo, Me.ToolStripSeparator1, Me.mnuCut, Me.mnuCopy, Me.mnuPaste, Me.mnuSelectAll, Me.mnuClear, Me.ToolStripSeparator2, Me.mnuRunCurrentStatementSelection, Me.mnuRunAllText, Me.ToolStripSeparator3, Me.mnuOpenScriptasFile, Me.mnuInsertScript, Me.mnuLoadScriptFromFile, Me.mnuSaveScript, Me.ToolStripSeparator4, Me.mnuHelp, Me.mnuReformat})
         Me.mnuContextScript.Name = "mnuContextLogFile"
-        Me.mnuContextScript.Size = New System.Drawing.Size(426, 509)
+        Me.mnuContextScript.Size = New System.Drawing.Size(306, 380)
         '
         'mnuUndo
         '
         Me.mnuUndo.Name = "mnuUndo"
         Me.mnuUndo.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.Z), System.Windows.Forms.Keys)
-        Me.mnuUndo.Size = New System.Drawing.Size(425, 32)
+        Me.mnuUndo.Size = New System.Drawing.Size(305, 22)
         Me.mnuUndo.Text = "Undo"
         '
         'mnuRedo
         '
         Me.mnuRedo.Name = "mnuRedo"
         Me.mnuRedo.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.Y), System.Windows.Forms.Keys)
-        Me.mnuRedo.Size = New System.Drawing.Size(425, 32)
+        Me.mnuRedo.Size = New System.Drawing.Size(305, 22)
         Me.mnuRedo.Text = "Redo"
         '
         'ToolStripSeparator1
         '
         Me.ToolStripSeparator1.Name = "ToolStripSeparator1"
-        Me.ToolStripSeparator1.Size = New System.Drawing.Size(422, 6)
+        Me.ToolStripSeparator1.Size = New System.Drawing.Size(302, 6)
         '
         'mnuCut
         '
         Me.mnuCut.Name = "mnuCut"
         Me.mnuCut.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.X), System.Windows.Forms.Keys)
-        Me.mnuCut.Size = New System.Drawing.Size(425, 32)
+        Me.mnuCut.Size = New System.Drawing.Size(305, 22)
         Me.mnuCut.Text = "Cut"
         '
         'mnuCopy
         '
         Me.mnuCopy.Name = "mnuCopy"
         Me.mnuCopy.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.C), System.Windows.Forms.Keys)
-        Me.mnuCopy.Size = New System.Drawing.Size(425, 32)
+        Me.mnuCopy.Size = New System.Drawing.Size(305, 22)
         Me.mnuCopy.Text = "Copy"
         '
         'mnuPaste
         '
         Me.mnuPaste.Name = "mnuPaste"
         Me.mnuPaste.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.V), System.Windows.Forms.Keys)
-        Me.mnuPaste.Size = New System.Drawing.Size(425, 32)
+        Me.mnuPaste.Size = New System.Drawing.Size(305, 22)
         Me.mnuPaste.Text = "Paste"
         '
         'mnuSelectAll
         '
         Me.mnuSelectAll.Name = "mnuSelectAll"
         Me.mnuSelectAll.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.A), System.Windows.Forms.Keys)
-        Me.mnuSelectAll.Size = New System.Drawing.Size(425, 32)
+        Me.mnuSelectAll.Size = New System.Drawing.Size(305, 22)
         Me.mnuSelectAll.Text = "Select All"
         '
         'mnuClear
         '
         Me.mnuClear.Name = "mnuClear"
         Me.mnuClear.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.L), System.Windows.Forms.Keys)
-        Me.mnuClear.Size = New System.Drawing.Size(425, 32)
+        Me.mnuClear.Size = New System.Drawing.Size(305, 22)
         Me.mnuClear.Text = "Clear All"
         '
         'ToolStripSeparator2
         '
         Me.ToolStripSeparator2.Name = "ToolStripSeparator2"
-        Me.ToolStripSeparator2.Size = New System.Drawing.Size(422, 6)
+        Me.ToolStripSeparator2.Size = New System.Drawing.Size(302, 6)
         '
         'mnuRunCurrentStatementSelection
         '
         Me.mnuRunCurrentStatementSelection.Name = "mnuRunCurrentStatementSelection"
-        Me.mnuRunCurrentStatementSelection.Size = New System.Drawing.Size(425, 32)
+        Me.mnuRunCurrentStatementSelection.Size = New System.Drawing.Size(305, 22)
         Me.mnuRunCurrentStatementSelection.Text = "Run Current Statement/Selection Ctrl+Enter"
         '
         'mnuRunAllText
@@ -154,41 +155,47 @@ Partial Class ucrScript
         Me.mnuRunAllText.Name = "mnuRunAllText"
         Me.mnuRunAllText.ShortcutKeys = CType(((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.Alt) _
             Or System.Windows.Forms.Keys.R), System.Windows.Forms.Keys)
-        Me.mnuRunAllText.Size = New System.Drawing.Size(425, 32)
+        Me.mnuRunAllText.Size = New System.Drawing.Size(305, 22)
         Me.mnuRunAllText.Text = "Run All Text"
         '
         'ToolStripSeparator3
         '
         Me.ToolStripSeparator3.Name = "ToolStripSeparator3"
-        Me.ToolStripSeparator3.Size = New System.Drawing.Size(422, 6)
+        Me.ToolStripSeparator3.Size = New System.Drawing.Size(302, 6)
         '
         'mnuOpenScriptasFile
         '
         Me.mnuOpenScriptasFile.Name = "mnuOpenScriptasFile"
-        Me.mnuOpenScriptasFile.Size = New System.Drawing.Size(425, 32)
+        Me.mnuOpenScriptasFile.Size = New System.Drawing.Size(305, 22)
         Me.mnuOpenScriptasFile.Text = "Open Script as File"
+        '
+        'mnuInsertScript
+        '
+        Me.mnuInsertScript.Name = "mnuInsertScript"
+        Me.mnuInsertScript.Size = New System.Drawing.Size(305, 22)
+        Me.mnuInsertScript.Text = "Insert Script"
         '
         'mnuLoadScriptFromFile
         '
         Me.mnuLoadScriptFromFile.Name = "mnuLoadScriptFromFile"
-        Me.mnuLoadScriptFromFile.Size = New System.Drawing.Size(425, 32)
+        Me.mnuLoadScriptFromFile.Size = New System.Drawing.Size(305, 22)
         Me.mnuLoadScriptFromFile.Text = "Load Script from File..."
         '
         'mnuSaveScript
         '
         Me.mnuSaveScript.Name = "mnuSaveScript"
-        Me.mnuSaveScript.Size = New System.Drawing.Size(425, 32)
+        Me.mnuSaveScript.Size = New System.Drawing.Size(305, 22)
         Me.mnuSaveScript.Text = "Save Script..."
         '
         'ToolStripSeparator4
         '
         Me.ToolStripSeparator4.Name = "ToolStripSeparator4"
-        Me.ToolStripSeparator4.Size = New System.Drawing.Size(422, 6)
+        Me.ToolStripSeparator4.Size = New System.Drawing.Size(302, 6)
         '
         'mnuHelp
         '
         Me.mnuHelp.Name = "mnuHelp"
-        Me.mnuHelp.Size = New System.Drawing.Size(425, 32)
+        Me.mnuHelp.Size = New System.Drawing.Size(305, 22)
         Me.mnuHelp.Text = "Help"
         '
         'lblHeaderScript
@@ -197,10 +204,9 @@ Partial Class ucrScript
         Me.lblHeaderScript.Dock = System.Windows.Forms.DockStyle.Fill
         Me.lblHeaderScript.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!)
         Me.lblHeaderScript.ForeColor = System.Drawing.SystemColors.Control
-        Me.lblHeaderScript.Location = New System.Drawing.Point(4, 0)
-        Me.lblHeaderScript.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblHeaderScript.Location = New System.Drawing.Point(3, 0)
         Me.lblHeaderScript.Name = "lblHeaderScript"
-        Me.lblHeaderScript.Size = New System.Drawing.Size(997, 30)
+        Me.lblHeaderScript.Size = New System.Drawing.Size(664, 20)
         Me.lblHeaderScript.TabIndex = 0
         Me.lblHeaderScript.Text = "Script Window"
         Me.lblHeaderScript.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
@@ -214,16 +220,15 @@ Partial Class ucrScript
         Me.tlpTableContainer.Controls.Add(Me.TabControl, 0, 2)
         Me.tlpTableContainer.Dock = System.Windows.Forms.DockStyle.Fill
         Me.tlpTableContainer.Location = New System.Drawing.Point(0, 0)
-        Me.tlpTableContainer.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.tlpTableContainer.Name = "tlpTableContainer"
         Me.tlpTableContainer.RowCount = 3
-        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
-        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 50.0!))
+        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20.0!))
+        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 33.0!))
         Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 80.0!))
-        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 338.0!))
+        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 225.0!))
         Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20.0!))
-        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
-        Me.tlpTableContainer.Size = New System.Drawing.Size(1005, 750)
+        Me.tlpTableContainer.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20.0!))
+        Me.tlpTableContainer.Size = New System.Drawing.Size(670, 500)
         Me.tlpTableContainer.TabIndex = 9
         '
         'Panel
@@ -238,88 +243,88 @@ Partial Class ucrScript
         Me.Panel.Controls.Add(Me.cmdRunAll)
         Me.Panel.Controls.Add(Me.cmdRunStatementSelection)
         Me.Panel.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.Panel.Location = New System.Drawing.Point(4, 34)
-        Me.Panel.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.Panel.Location = New System.Drawing.Point(3, 23)
         Me.Panel.Name = "Panel"
-        Me.Panel.Size = New System.Drawing.Size(997, 42)
+        Me.Panel.Size = New System.Drawing.Size(664, 27)
         Me.Panel.TabIndex = 10
+        '
+        'cmdInsertScript
+        '
+        Me.cmdInsertScript.Location = New System.Drawing.Point(335, 1)
+        Me.cmdInsertScript.Name = "cmdInsertScript"
+        Me.cmdInsertScript.Size = New System.Drawing.Size(75, 23)
+        Me.cmdInsertScript.TabIndex = 8
+        Me.cmdInsertScript.Text = "Insert"
+        Me.cmdInsertScript.UseVisualStyleBackColor = True
         '
         'cmdSave
         '
-        Me.cmdSave.Location = New System.Drawing.Point(279, 2)
-        Me.cmdSave.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdSave.Location = New System.Drawing.Point(186, 1)
         Me.cmdSave.Name = "cmdSave"
-        Me.cmdSave.Size = New System.Drawing.Size(82, 34)
+        Me.cmdSave.Size = New System.Drawing.Size(55, 23)
         Me.cmdSave.TabIndex = 3
         Me.cmdSave.Text = "Save"
         Me.cmdSave.UseVisualStyleBackColor = True
         '
         'cmdLoadScript
         '
-        Me.cmdLoadScript.Location = New System.Drawing.Point(194, 2)
-        Me.cmdLoadScript.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdLoadScript.Location = New System.Drawing.Point(129, 1)
         Me.cmdLoadScript.Name = "cmdLoadScript"
-        Me.cmdLoadScript.Size = New System.Drawing.Size(82, 34)
+        Me.cmdLoadScript.Size = New System.Drawing.Size(55, 23)
         Me.cmdLoadScript.TabIndex = 2
         Me.cmdLoadScript.Text = "Load"
         Me.cmdLoadScript.UseVisualStyleBackColor = True
         '
         'cmdRemoveTab
         '
-        Me.cmdRemoveTab.Location = New System.Drawing.Point(620, 2)
-        Me.cmdRemoveTab.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdRemoveTab.Location = New System.Drawing.Point(413, 1)
         Me.cmdRemoveTab.Name = "cmdRemoveTab"
-        Me.cmdRemoveTab.Size = New System.Drawing.Size(112, 34)
+        Me.cmdRemoveTab.Size = New System.Drawing.Size(75, 23)
         Me.cmdRemoveTab.TabIndex = 5
         Me.cmdRemoveTab.Text = "Remove"
         Me.cmdRemoveTab.UseVisualStyleBackColor = True
         '
         'cmdAddTab
         '
-        Me.cmdAddTab.Location = New System.Drawing.Point(386, 2)
-        Me.cmdAddTab.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdAddTab.Location = New System.Drawing.Point(257, 1)
         Me.cmdAddTab.Name = "cmdAddTab"
-        Me.cmdAddTab.Size = New System.Drawing.Size(112, 34)
+        Me.cmdAddTab.Size = New System.Drawing.Size(75, 23)
         Me.cmdAddTab.TabIndex = 4
         Me.cmdAddTab.Text = "New"
         Me.cmdAddTab.UseVisualStyleBackColor = True
         '
         'cmdHelp
         '
-        Me.cmdHelp.Location = New System.Drawing.Point(872, 2)
-        Me.cmdHelp.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdHelp.Location = New System.Drawing.Point(581, 1)
         Me.cmdHelp.Name = "cmdHelp"
-        Me.cmdHelp.Size = New System.Drawing.Size(82, 34)
+        Me.cmdHelp.Size = New System.Drawing.Size(55, 23)
         Me.cmdHelp.TabIndex = 7
         Me.cmdHelp.Text = "Help"
         Me.cmdHelp.UseVisualStyleBackColor = True
         '
         'cmdClear
         '
-        Me.cmdClear.Location = New System.Drawing.Point(735, 2)
-        Me.cmdClear.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdClear.Location = New System.Drawing.Point(490, 1)
         Me.cmdClear.Name = "cmdClear"
-        Me.cmdClear.Size = New System.Drawing.Size(120, 34)
+        Me.cmdClear.Size = New System.Drawing.Size(80, 23)
         Me.cmdClear.TabIndex = 6
         Me.cmdClear.Text = "Clear"
         Me.cmdClear.UseVisualStyleBackColor = True
         '
         'cmdRunAll
         '
-        Me.cmdRunAll.Location = New System.Drawing.Point(87, 2)
-        Me.cmdRunAll.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdRunAll.Location = New System.Drawing.Point(58, 1)
         Me.cmdRunAll.Name = "cmdRunAll"
-        Me.cmdRunAll.Size = New System.Drawing.Size(82, 34)
+        Me.cmdRunAll.Size = New System.Drawing.Size(55, 23)
         Me.cmdRunAll.TabIndex = 1
         Me.cmdRunAll.Text = "Run All"
         Me.cmdRunAll.UseVisualStyleBackColor = True
         '
         'cmdRunStatementSelection
         '
-        Me.cmdRunStatementSelection.Location = New System.Drawing.Point(3, 2)
-        Me.cmdRunStatementSelection.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdRunStatementSelection.Location = New System.Drawing.Point(2, 1)
         Me.cmdRunStatementSelection.Name = "cmdRunStatementSelection"
-        Me.cmdRunStatementSelection.Size = New System.Drawing.Size(82, 34)
+        Me.cmdRunStatementSelection.Size = New System.Drawing.Size(55, 23)
         Me.cmdRunStatementSelection.TabIndex = 0
         Me.cmdRunStatementSelection.Text = "Run"
         Me.cmdRunStatementSelection.UseVisualStyleBackColor = True
@@ -327,38 +332,26 @@ Partial Class ucrScript
         'TabControl
         '
         Me.TabControl.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.TabControl.Location = New System.Drawing.Point(4, 84)
-        Me.TabControl.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.TabControl.Location = New System.Drawing.Point(3, 56)
         Me.TabControl.Name = "TabControl"
         Me.TabControl.SelectedIndex = 0
-        Me.TabControl.Size = New System.Drawing.Size(997, 662)
+        Me.TabControl.Size = New System.Drawing.Size(664, 441)
         Me.TabControl.TabIndex = 1
         '
-        'cmdInsertScript
+        'mnuReformat
         '
-        Me.cmdInsertScript.Location = New System.Drawing.Point(503, 2)
-        Me.cmdInsertScript.Margin = New System.Windows.Forms.Padding(4)
-        Me.cmdInsertScript.Name = "cmdInsertScript"
-        Me.cmdInsertScript.Size = New System.Drawing.Size(112, 34)
-        Me.cmdInsertScript.TabIndex = 8
-        Me.cmdInsertScript.Text = "Insert"
-        Me.cmdInsertScript.UseVisualStyleBackColor = True
-        '
-        'mnuInsertScript
-        '
-        Me.mnuInsertScript.Name = "mnuInsertScript"
-        Me.mnuInsertScript.Size = New System.Drawing.Size(425, 32)
-        Me.mnuInsertScript.Text = "Insert Script"
+        Me.mnuReformat.Name = "mnuReformat"
+        Me.mnuReformat.Size = New System.Drawing.Size(305, 22)
+        Me.mnuReformat.Text = "Reformat"
         '
         'ucrScript
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.Controls.Add(Me.tlpTableContainer)
-        Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.Name = "ucrScript"
-        Me.Size = New System.Drawing.Size(1005, 750)
+        Me.Size = New System.Drawing.Size(670, 500)
         Me.Tag = "Script_Window"
         Me.mnuContextScript.ResumeLayout(False)
         Me.tlpTableContainer.ResumeLayout(False)
@@ -399,4 +392,5 @@ Partial Class ucrScript
     Friend WithEvents cmdLoadScript As Button
     Friend WithEvents cmdInsertScript As Button
     Friend WithEvents mnuInsertScript As ToolStripMenuItem
+    Friend WithEvents mnuReformat As ToolStripMenuItem
 End Class

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -237,8 +237,6 @@ Public Class ucrScript
         FormatCode = Join(formattedLines, vbCrLf)
     End Function
 
-
-
     Private Function GetTextBefore(ByVal text As String, ByVal position As Long) As String
         ' Returns the text before the specified position
         If position > 0 Then

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -182,23 +182,16 @@ Public Class ucrScript
         Dim inAssignment As Boolean
         Dim assignmentPos As Long
 
-        ' Split the code into lines
         lines = Split(code, vbCrLf)
         ReDim formattedLines(0 To UBound(lines))
-
-        ' Initialize the indentation level
         indentLevel = 0
         inAssignment = False
 
-        ' Loop through each line and apply formatting rules
         For i = LBound(lines) To UBound(lines)
-            ' Trim whitespace from the line
             formattedLine = Trim(lines(i))
-
-            ' Check for assignment lines
             assignmentPos = InStr(formattedLine, "<-")
             If assignmentPos > 0 Then
-                ' For R-style assignments
+                ' R-style assignments
                 formattedLine = Trim(Mid(formattedLine, 1, assignmentPos - 1)) & " <- " & Trim(Mid(formattedLine, assignmentPos + 2))
                 formattedLines(i) = Space(indentLevel * 4) & formattedLine
                 inAssignment = True
@@ -225,11 +218,12 @@ Public Class ucrScript
                 formattedLine = Replace(formattedLine, ",", " , ")
                 formattedLines(i) = Space(indentLevel * 4) & formattedLine
             End If
-
-            ' Align the assignment operators for nested function calls
-            If InStr(formattedLine, "data.frame") > 0 Then
-                formattedLines(i) = Space(indentLevel * 4) & formattedLine
+            If InStr(formattedLine, "(") > 0 Then
                 indentLevel = indentLevel + 1
+            End If
+            If InStr(formattedLine, ")") > 0 Then
+                indentLevel = indentLevel - 1
+                If indentLevel < 0 Then indentLevel = 0 ' Prevent negative indentation
             End If
         Next i
 

--- a/instat/ucrScript.vb
+++ b/instat/ucrScript.vb
@@ -164,10 +164,6 @@ Public Class ucrScript
 
             ' Replace the selected text with the formatted text
             clsScriptActive.Text = GetTextBefore(fullText, startPos) & formattedText & GetTextAfter(fullText, endPos)
-
-            ' Optionally, you can call the Copy function if needed
-            clsScriptActive.Copy()
-
             EnableDisableButtons()
         End If
     End Sub


### PR DESCRIPTION
fixes partly #8847
To fully implement the Reformat code in the Edit menu, i need to test how well it work on the script window itself so i implemented
a right click reformat option and this is the result
 I think i was able to do the white spaces and indents (the screen recording did not show me right clicking and selecting the reformat option so i used a screenshot to show)

https://github.com/user-attachments/assets/903db2d0-4923-4531-8d4c-db0ba4ac106a

![image](https://github.com/user-attachments/assets/00effa86-514a-4a48-bb0a-fa81ba073ca4)

@lloyddewit or @N-thony can this be reviewed to show whether that is what you guys wanted the reformat to work like