### PR TITLE
Minor Change to Factor level for One Variable Summarise

### DIFF
--- a/instat/dlgOneVariableSummarise.Designer.vb
+++ b/instat/dlgOneVariableSummarise.Designer.vb
@@ -245,11 +245,11 @@ Partial Class dlgOneVariableSummarise
         Me.ucrNudMaxSum.AutoSize = True
         Me.ucrNudMaxSum.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudMaxSum.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudMaxSum.Location = New System.Drawing.Point(246, 249)
+        Me.ucrNudMaxSum.Location = New System.Drawing.Point(224, 249)
         Me.ucrNudMaxSum.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
         Me.ucrNudMaxSum.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudMaxSum.Name = "ucrNudMaxSum"
-        Me.ucrNudMaxSum.Size = New System.Drawing.Size(50, 20)
+        Me.ucrNudMaxSum.Size = New System.Drawing.Size(72, 20)
         Me.ucrNudMaxSum.TabIndex = 8
         Me.ucrNudMaxSum.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '

--- a/instat/dlgOneVariableSummarise.vb
+++ b/instat/dlgOneVariableSummarise.vb
@@ -75,7 +75,7 @@ Public Class dlgOneVariableSummarise
         ucrReceiverOneVarSummarise.SetMeAsReceiver()
 
         ucrNudMaxSum.SetParameter(New RParameter("maxsum", 2))
-        ucrNudMaxSum.SetMinMax(1, 12)
+        ucrNudMaxSum.SetMinMax(1, Integer.MaxValue)
         ucrNudMaxSum.SetLinkedDisplayControl(lblMaxSum)
 
         ucrPnlSummaries.AddRadioButton(rdoDefault)


### PR DESCRIPTION
Fixes #9114 
i have changed the `masum` maximum limit from 12 to the `integer.maxvalue` which is 2147483647
when you open the dialog it will display 12 as the initially but it can be increased now
@jkmusyoka can you review this
Thanks
