### PR TITLE
Fixed the issue of roman numbers not displaying in the grid

### DIFF
--- a/instat/ucrCalculator.vb
+++ b/instat/ucrCalculator.vb
@@ -4691,9 +4691,9 @@ Public Class ucrCalculator
 
     Private Sub cmdRoman_Click(sender As Object, e As EventArgs) Handles cmdRoman.Click
         If chkShowParameters.Checked Then
-            ucrReceiverForCalculation.AddToReceiverAtCursorPosition("utils::as.roman(x= )", 2)
+            ucrReceiverForCalculation.AddToReceiverAtCursorPosition("as.character(utils::as.roman(x= ))", 3)
         Else
-            ucrReceiverForCalculation.AddToReceiverAtCursorPosition("utils::as.roman( )", 2)
+            ucrReceiverForCalculation.AddToReceiverAtCursorPosition("as.character(utils::as.roman( ))", 3)
         End If
     End Sub
 


### PR DESCRIPTION
Fixes issue #9005 
@rdstern not very long ago, I realised that the issue we are experiencing likely arises from the fact that the as.roman() function in R converts numbers to Roman numerals as a character vector. When you add this character vector back to your data frame using data_book$add_columns_to_data(), the column might be interpreted as numeric rather than character, resulting in "normal" numbers instead of Roman numerals.
Problem:
Character Conversion: as.roman(x3a) returns Roman numerals as characters.
Data Frame Column Type: When you add the Roman numeral characters to your data frame, they might be converted to numeric types if the data frame expects numeric values, leading to the display of normal numbers.

So, I went ahead and made the changes in the calculator so that instead of *utils::as.roman()), we have *as.character(utils::as.roman())*
Well, this is working well now for both the reogrid and the output window, have a look!