### PR TITLE
Unticked the NTotal checkbox when opening the column summaries subdialog

### DIFF
--- a/instat/dlgColumnStats.vb
+++ b/instat/dlgColumnStats.vb
@@ -112,7 +112,6 @@ Public Class dlgColumnStats
 
         clsSummariesList.SetRCommand("c")
         clsSummariesList.AddParameter("summary_count_non_missing", Chr(34) & "summary_count_non_missing" & Chr(34), bIncludeArgumentName:=False, iPosition:=1)
-        clsSummariesList.AddParameter("summary_count", Chr(34) & "summary_count" & Chr(34), bIncludeArgumentName:=False, iPosition:=3)
         clsSummariesList.AddParameter("summary_sum", Chr(34) & "summary_sum" & Chr(34), bIncludeArgumentName:=False, iPosition:=11)
 
         clsDefaultFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$calculate_summary")


### PR DESCRIPTION
Fixes partly #9123 
This PR fixes part (a) of the issue. which is to untick the N total checkbox in the column summaries sub dialog when it open.
currently working on the part b
@N-thony can you have a look and review
thanks 