### PR TITLE
Added the Rename Tab to Column Summaries Sub-Dialog

### DIFF
--- a/instat/sdgSummaries.Designer.vb
+++ b/instat/sdgSummaries.Designer.vb
@@ -175,6 +175,10 @@ Partial Class sdgSummaries
         Me.ucrChkSum = New instat.ucrCheck()
         Me.ucrChkMean = New instat.ucrCheck()
         Me.tbSummaries = New System.Windows.Forms.TabControl()
+        Me.tbRename = New System.Windows.Forms.TabPage()
+        Me.ucrChkIncludeVariable = New instat.ucrCheck()
+        Me.grdRenameColumns = New unvell.ReoGrid.ReoGridControl()
+        Me.ucrSelectVariables = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ttVerificationSummaries = New System.Windows.Forms.ToolTip(Me.components)
         Me.ucrButtonsSummaries = New instat.ucrButtonsSubdialogue()
         Me.tbCircular.SuspendLayout()
@@ -201,6 +205,7 @@ Partial Class sdgSummaries
         Me.grpNotOrderedFactor.SuspendLayout()
         Me.grpNumeric.SuspendLayout()
         Me.tbSummaries.SuspendLayout()
+        Me.tbRename.SuspendLayout()
         Me.SuspendLayout()
         '
         'tbCircular
@@ -1725,11 +1730,64 @@ Partial Class sdgSummaries
         Me.tbSummaries.Controls.Add(Me.tbPosition)
         Me.tbSummaries.Controls.Add(Me.tbModel)
         Me.tbSummaries.Controls.Add(Me.tbCircular)
+        Me.tbSummaries.Controls.Add(Me.tbRename)
         Me.tbSummaries.Location = New System.Drawing.Point(6, 7)
         Me.tbSummaries.Name = "tbSummaries"
         Me.tbSummaries.SelectedIndex = 0
         Me.tbSummaries.Size = New System.Drawing.Size(417, 423)
         Me.tbSummaries.TabIndex = 0
+        '
+        'tbRename
+        '
+        Me.tbRename.Controls.Add(Me.ucrChkIncludeVariable)
+        Me.tbRename.Controls.Add(Me.grdRenameColumns)
+        Me.tbRename.Controls.Add(Me.ucrSelectVariables)
+        Me.tbRename.Location = New System.Drawing.Point(4, 22)
+        Me.tbRename.Name = "tbRename"
+        Me.tbRename.Padding = New System.Windows.Forms.Padding(3)
+        Me.tbRename.Size = New System.Drawing.Size(409, 397)
+        Me.tbRename.TabIndex = 9
+        Me.tbRename.Text = "Rename"
+        Me.tbRename.UseVisualStyleBackColor = True
+        '
+        'ucrChkIncludeVariable
+        '
+        Me.ucrChkIncludeVariable.AutoSize = True
+        Me.ucrChkIncludeVariable.Checked = False
+        Me.ucrChkIncludeVariable.Location = New System.Drawing.Point(92, 22)
+        Me.ucrChkIncludeVariable.Name = "ucrChkIncludeVariable"
+        Me.ucrChkIncludeVariable.Size = New System.Drawing.Size(225, 23)
+        Me.ucrChkIncludeVariable.TabIndex = 21
+        '
+        'grdRenameColumns
+        '
+        Me.grdRenameColumns.BackColor = System.Drawing.Color.White
+        Me.grdRenameColumns.ColumnHeaderContextMenuStrip = Nothing
+        Me.grdRenameColumns.LeadHeaderContextMenuStrip = Nothing
+        Me.grdRenameColumns.Location = New System.Drawing.Point(12, 94)
+        Me.grdRenameColumns.Name = "grdRenameColumns"
+        Me.grdRenameColumns.RowHeaderContextMenuStrip = Nothing
+        Me.grdRenameColumns.Script = Nothing
+        Me.grdRenameColumns.SheetTabContextMenuStrip = Nothing
+        Me.grdRenameColumns.SheetTabNewButtonVisible = True
+        Me.grdRenameColumns.SheetTabVisible = True
+        Me.grdRenameColumns.SheetTabWidth = 154
+        Me.grdRenameColumns.ShowScrollEndSpacing = True
+        Me.grdRenameColumns.Size = New System.Drawing.Size(378, 256)
+        Me.grdRenameColumns.TabIndex = 19
+        Me.grdRenameColumns.Text = "Variables"
+        '
+        'ucrSelectVariables
+        '
+        Me.ucrSelectVariables.AutoSize = True
+        Me.ucrSelectVariables.bDropUnusedFilterLevels = False
+        Me.ucrSelectVariables.bShowHiddenColumns = False
+        Me.ucrSelectVariables.bUseCurrentFilter = True
+        Me.ucrSelectVariables.Location = New System.Drawing.Point(12, 48)
+        Me.ucrSelectVariables.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrSelectVariables.Name = "ucrSelectVariables"
+        Me.ucrSelectVariables.Size = New System.Drawing.Size(213, 183)
+        Me.ucrSelectVariables.TabIndex = 20
         '
         'ucrButtonsSummaries
         '
@@ -1799,6 +1857,8 @@ Partial Class sdgSummaries
         Me.grpNumeric.ResumeLayout(False)
         Me.grpNumeric.PerformLayout()
         Me.tbSummaries.ResumeLayout(False)
+        Me.tbRename.ResumeLayout(False)
+        Me.tbRename.PerformLayout()
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -1942,4 +2002,8 @@ Partial Class sdgSummaries
     Friend WithEvents ucrPnlPosition As UcrPanel
     Friend WithEvents ucrChkWhereMax As ucrCheck
     Friend WithEvents ucrChkWhereMin As ucrCheck
+    Friend WithEvents tbRename As TabPage
+    Friend WithEvents grdRenameColumns As unvell.ReoGrid.ReoGridControl
+    Friend WithEvents ucrSelectVariables As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrChkIncludeVariable As ucrCheck
 End Class

--- a/instat/sdgSummaries.vb
+++ b/instat/sdgSummaries.vb
@@ -65,6 +65,9 @@ Public Class sdgSummaries
         ucrChkIncludeVariable.AddParameterValuesCondition(True, "check", "True")
         ucrChkIncludeVariable.AddParameterValuesCondition(False, "check", "False")
 
+        ucrSelectVariables.SetParameter(New RParameter("data_name", 0))
+        ucrSelectVariables.SetParameterIsString()
+
         ucrChkNonMissing.SetParameter(New RParameter("summary_count_non_missing", 1), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "summary_count_non_missing" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
         ucrChkNonMissing.SetText("N Non Missing")
 
@@ -423,10 +426,8 @@ Public Class sdgSummaries
 
         clsNewLabelDataframeFunction.SetRCommand("data.frame")
         clsDefaultRFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$rename_column_in_data")
-        clsDefaultRFunction.AddParameter("type", Chr(34) & "single" & Chr(34), iPosition:=4)
-        clsDefaultRFunction.AddParameter(".fn", "janitor::make_clean_names", iPosition:=5)
-        clsDefaultRFunction.AddParameter("case", Chr(34) & "snake" & Chr(34), iPosition:=7)
-        clsDefaultRFunction.AddParameter("minlength", "8", iPosition:=10)
+
+        clsDefaultRFunction.AddParameter("type", Chr(34) & "multiple" & Chr(34), iPosition:=2)
 
         'updating labels of weighted summaries
         ucrChkSum.SetText("Sum" & strWeightLabel)
@@ -611,6 +612,9 @@ Public Class sdgSummaries
             bOkEnabled = False
         Else
             bOkEnabled = True
+        End If
+        If clsDefaultRFunction.clsParameters.Count > 0 Then
+            frmMain.clsRLink.RunInternalScript(strScript:=clsDefaultRFunction.ToScript, bSilent:=False)
         End If
     End Sub
 
@@ -1014,5 +1018,9 @@ Public Class sdgSummaries
 
     Private Sub ucrChkIncludeVariable_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkIncludeVariable.ControlValueChanged
         MakeLabelColumnVisible()
+    End Sub
+
+    Private Sub ucrSelectVariables_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectVariables.ControlValueChanged
+        clsDefaultRFunction.AddParameter("data_name", Chr(34) & ucrSelectVariables.strCurrentDataFrame & Chr(34), iPosition:=1)
     End Sub
 End Class


### PR DESCRIPTION
Fixes #9123 
This Implements the part B of the issue
@N-thony Please this PR has the rename tab and is able to populate the column grid but renaming the column is the issue now