### PR TITLE
Fix Error in Climatic > Prepare > Transform > Moving sum 

### DIFF
--- a/instat/dlgTransformClimatic.vb
+++ b/instat/dlgTransformClimatic.vb
@@ -1236,6 +1236,7 @@ Public Class dlgTransformClimatic
         RainDays()
         ReduceWaterBalance()
         RainfallChange()
+        AddCalculate()
     End Sub
 
     Private Sub ucrReceiverStation_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverStation.ControlValueChanged


### PR DESCRIPTION
Fixes #9158 
@jkmusyoka @rdstern , I think the error occurred because the  `calculated_from` argument was not getting the variable in `Element Receiver`. Please check