### PR TITLE
Fixes Bug with the facets in the Mosiac dialog

### DIFF
--- a/instat/dlgMosaicPlot.vb
+++ b/instat/dlgMosaicPlot.vb
@@ -390,6 +390,8 @@ Public Class dlgMosaicPlot
 
         If bWrap OrElse bRow OrElse bCol Then
             clsBaseOperator.AddParameter("facets", clsRFunctionParameter:=clsFacetFunction)
+        Else
+            clsBaseOperator.RemoveParameterByName("facets")
         End If
         If bWrap Then
             clsFacetFunction.SetRCommand("facet_wrap")


### PR DESCRIPTION
Fixes #9198 
I have fixed the problem with the facet in the mosaic plot dialogue, which gives an error when you remove the facet value in the dialogue. 

@rachelkg , @N-thony can you have a look
Thanks 