### PR TITLE
Correctly Assigned RHelp to the HeatMap Dialog

### DIFF
--- a/instat/dlgHeatMapPlot.vb
+++ b/instat/dlgHeatMapPlot.vb
@@ -81,7 +81,7 @@ Public Class dlgHeatMapPlot
         Dim dctLegendPosition As New Dictionary(Of String, String)
         Dim dctPalette As New Dictionary(Of String, String)
 
-        ucrBase.iHelpTopicID = 476
+        ucrBase.iHelpTopicID = 437
         ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
         ucrBase.clsRsyntax.iCallType = 3
 


### PR DESCRIPTION
Fixes #9220 
I have correctly assigned the Rhelp for the Heatmap dialog it now shows the Heatmap Help when you click on the help button. 
@rachelkg , @rdstern can you have a look 
Thanks 