### PR TITLE
Load the data in the grid directly after double-clicking .RDS file

### DIFF
--- a/instat/ApplicationEvents.vb
+++ b/instat/ApplicationEvents.vb
@@ -9,7 +9,8 @@
     Partial Friend Class MyApplication
         ''' <summary>   Handles the event raised when launching a single-instance application. 
         '''             If the event was triggered by double-clicking on a data file, then the sub 
-        '''             opens R-Instat (if not already running), and load the data in the Grid.</summary>
+        '''             opens R-Instat (if not already running), and load the data in the Grid
+        '''             with the double-clicked file's path.</summary>
         '''
         ''' <param name="sender">   Source of the event. </param>
         ''' <param name="e">        Startup next instance event information. </param>

--- a/instat/ApplicationEvents.vb
+++ b/instat/ApplicationEvents.vb
@@ -9,27 +9,19 @@
     Partial Friend Class MyApplication
         ''' <summary>   Handles the event raised when launching a single-instance application. 
         '''             If the event was triggered by double-clicking on a data file, then the sub 
-        '''             opens R-Instat (if not already running), displays the import dataset dialog 
-        '''             and populates the dialog with the double-clicked file's path.</summary>
+        '''             opens R-Instat (if not already running), and load the data in the Grid.</summary>
         '''
         ''' <param name="sender">   Source of the event. </param>
         ''' <param name="e">        Startup next instance event information. </param>
         '''----------------------------------------------------------------------------------------
         Private Sub MyApplication_StartupNextInstance(ByVal sender As Object, ByVal e As Microsoft.VisualBasic.ApplicationServices.StartupNextInstanceEventArgs) Handles Me.StartupNextInstance
-            frmMain.TopMost = True 'Needed to force the window above the other windows
-            frmMain.TopMost = False 'After the window is forced above other windows, this will allow other windows to be on top of this window
+
             If frmMain.isMinimised Then
                 frmMain.WindowState = If(frmMain.isMaximised, FormWindowState.Maximized, FormWindowState.Normal)
             End If
 
             If e.CommandLine.Count > 0 Then
-                If Application.OpenForms.OfType(Of dlgImportDataset).Any Then
-                    dlgImportDataset.SetDialogStateFromFile(e.CommandLine(0).ToString)
-                Else
-                    dlgImportDataset.strFileToOpenOn = e.CommandLine(0)
-                    dlgImportDataset.bStartOpenDialog = False
-                    dlgImportDataset.ShowDialog()
-                End If
+                frmMain.ImportRDS(e.CommandLine(0).ToString)
             End If
         End Sub
     End Class

--- a/instat/clsRecentFiles.vb
+++ b/instat/clsRecentFiles.vb
@@ -188,8 +188,13 @@ Public Class clsRecentFiles
 
         Dim strFilePathTmp As String = strFilePath.Replace("MRU:", "")
         If File.Exists(strFilePathTmp) Then
-            dlgImportDataset.strFileToOpenOn = strFilePathTmp
-            dlgImportDataset.ShowDialog()
+            If Path.GetExtension(strFilePathTmp).ToLower.Equals(".rds") Then
+                frmMain.ImportRDS(strFilePathTmp)
+            Else
+                dlgImportDataset.strFileToOpenOn = strFilePathTmp
+                dlgImportDataset.ShowDialog()
+            End If
+
         ElseIf DialogResult.Yes = MessageBox.Show(    'else allow the user to remove file from list
                     frmMain, "File not accessible. It may have been renamed, moved or deleted." &
                     Environment.NewLine & Environment.NewLine &

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -205,9 +205,10 @@ Public Class frmMain
         '---------------------------------------
         Try
             If (Environment.GetCommandLineArgs.Length > 1) Then
-                dlgImportDataset.strFileToOpenOn = Environment.GetCommandLineArgs(1)
-                dlgImportDataset.bStartOpenDialog = False
-                dlgImportDataset.ShowDialog()
+                'dlgImportDataset.strFileToOpenOn = Environment.GetCommandLineArgs(1)
+                'dlgImportDataset.bStartOpenDialog = False
+                'dlgImportDataset.ShowDialog()
+                ImportRDS(Environment.GetCommandLineArgs(1))
             End If
         Catch ex As Exception
             MsgBox(ex.Message)
@@ -227,6 +228,26 @@ Public Class frmMain
         '-------------------------------------
         SetAppVersionNumber()
         isMaximised = True 'Need to get the windowstate when the application is loaded
+    End Sub
+
+    Public Sub ImportRDS(strFilePath As String)
+        If Path.GetExtension(strFilePath).ToLower <> ".rds" Then
+            Exit Sub
+        End If
+        Try
+            Dim clsImportRDS As New RFunction
+            Dim clsReadRDS As New RFunction
+
+            clsImportRDS.SetRCommand(clsRLink.strInstatDataObject & "$import_RDS")
+            clsReadRDS.SetRCommand("readRDS")
+
+            clsReadRDS.AddParameter("file", Chr(34) & Replace(strFilePath, "\", "/") & Chr(34))
+            clsImportRDS.AddParameter("data_RDS", clsRFunctionParameter:=clsReadRDS)
+
+            clsRLink.RunScript(clsImportRDS.ToScript, strComment:="Import .RDS file")
+        Catch ex As Exception
+            MsgBox(ex.Message)
+        End Try
     End Sub
 
     Private Sub CheckForUpdates()


### PR DESCRIPTION
@rdstern @ChrisMarsh82 this will load directly the data in the grid after double click on .RDS file. Have a look.
I noticed that each time we double-click an .RDS file, it opens in a new R-Instat instance. This might have been because we allow multiple R-Instat instances. But I think it would be better if, when we double-click, the data always loads into the first opened R-Instat instance if there are multiple open. What do you think?