### PR TITLE
Issue when checking all packages installed

### DIFF
--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -179,11 +179,8 @@ Public Class frmMain
         '---------------------------------------
 
         '---------------------------------------
-        'start the R engine and install any missing R packages
-        'only proceed if;
-        '1. R engine has been started
-        '2. All packages have been installed
-        If Not (clsRLink.StartREngine() AndAlso AllPackagesInstalled()) Then
+        'Starts the R engine for the application and exits if initialization fails.
+        If Not clsRLink.StartREngine() Then
             Application.Exit()
             Environment.Exit(0)
         End If
@@ -194,6 +191,12 @@ Public Class frmMain
         ExecuteSetupRScriptsAndSetupRLinkAndDatabook()
         'execute R global options used by R-Instat R data book
         clsInstatOptions.ExecuteRGlobalOptions()
+        '---------------------------------------
+
+        '----------------------------------------
+        'Checks for the existence of all required R packages for the application.
+        'If any packages are missing, attempts to install them.
+        AllPackagesInstalled()
         '---------------------------------------
 
         '---------------------------------------
@@ -385,17 +388,19 @@ Public Class frmMain
         Return clsInstatOptions
     End Function
 
-    Private Function AllPackagesInstalled() As Boolean
-        'check missing R packages and prompt to install them
-        Dim arrMissingPackages() As String = clsRLink.GetRPackagesNotInstalled()
-        If arrMissingPackages IsNot Nothing AndAlso arrMissingPackages.Length > 0 Then
-            frmPackageIssues.SetMissingPackages(arrMissingPackages)
-            frmPackageIssues.ShowDialog()
-            Return Not frmPackageIssues.bCloseRInstat
-        Else
-            Return True
-        End If
-    End Function
+    Private Sub AllPackagesInstalled()
+        Try
+            'check missing R packages and prompt to install them
+            Dim arrMissingPackages() As String = clsRLink.GetRPackagesNotInstalled()
+            If arrMissingPackages IsNot Nothing AndAlso arrMissingPackages.Length > 0 Then
+                frmPackageIssues.SetMissingPackages(arrMissingPackages)
+                frmPackageIssues.ShowDialog()
+            End If
+        Catch ex As Exception
+            MsgBox(ex.Message)
+        End Try
+
+    End Sub
 
     Private Sub CreateAdditionalLibraryDirectory()
         ' Define the custom library path in the ApplicationData folder


### PR DESCRIPTION
@ChrisMarsh82 @rdstern I realized after a discussion on Skype with @Patowhiz that `AllPackagesInstalled()` is called immediately after starting the R engine but before executing setup scripts via `ExecuteSetupRScriptsAndSetupRLinkAndDatabook()`. This ordering causes issues because `AllPackagesInstalled()` depends on R scripts or functions loaded later in the process.

To resolve this, I rearrange the order so that `ExecuteSetupRScriptsAndSetupRLinkAndDatabook()` is executed immediately after starting the R engine, allowing it to configure the necessary R environment before checking for installed packages. Have a look.
Note that this is only for developers to be in track also of installed packages in the development. It is not a big issue because it doesn't affect users. We can leave it open and use it if needed.