### PR TITLE
Changing the help context # for all three right-click menus

### DIFF
--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -949,7 +949,7 @@ Public Class ucrDataView
     End Sub
 
     Private Sub mnuHelp_Click(sender As Object, e As EventArgs) Handles mnuHelp.Click, mnuHelp1.Click, mnuHelp2.Click, mnuHelp3.Click
-        Help.ShowHelp(frmMain, frmMain.strStaticPath & "/" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "134")
+        Help.ShowHelp(frmMain, frmMain.strStaticPath & "/" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "697")
     End Sub
 
     Public Sub GoToSpecificRowPage(iPage As Integer)


### PR DESCRIPTION
Fixes #9221 
I have changed the Help context number for the right click buttons on the Dataview
@rdstern , @N-thony , this is ready for review