### PR TITLE
Changes column summaries

### DIFF
--- a/instat/dlgClimaticSummary.vb
+++ b/instat/dlgClimaticSummary.vb
@@ -194,7 +194,7 @@ Public Class dlgClimaticSummary
 
         'TODO: what defaults do we want?
         clsSummariesList.SetRCommand("c")
-        clsSummariesList.AddParameter("summary_count_name", Chr(34) & "summary_count_name" & Chr(34), bIncludeArgumentName:=False, iPosition:=1)
+        clsSummariesList.AddParameter("summary_count", Chr(34) & "summary_count" & Chr(34), bIncludeArgumentName:=False, iPosition:=1)
         clsSummariesList.AddParameter("summary_sum", Chr(34) & "summary_sum" & Chr(34), bIncludeArgumentName:=False, iPosition:=11)
 
         clsDefaultFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$calculate_summary")

--- a/instat/dlgClimaticSummary.vb
+++ b/instat/dlgClimaticSummary.vb
@@ -194,8 +194,7 @@ Public Class dlgClimaticSummary
 
         'TODO: what defaults do we want?
         clsSummariesList.SetRCommand("c")
-        clsSummariesList.AddParameter("summary_count_non_missing", Chr(34) & "summary_count_non_missing" & Chr(34), bIncludeArgumentName:=False, iPosition:=1)
-        clsSummariesList.AddParameter("summary_count", Chr(34) & "summary_count" & Chr(34), bIncludeArgumentName:=False, iPosition:=3)
+        clsSummariesList.AddParameter("summary_count_name", Chr(34) & "summary_count_name" & Chr(34), bIncludeArgumentName:=False, iPosition:=1)
         clsSummariesList.AddParameter("summary_sum", Chr(34) & "summary_sum" & Chr(34), bIncludeArgumentName:=False, iPosition:=11)
 
         clsDefaultFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$calculate_summary")

--- a/instat/dlgColumnStats.vb
+++ b/instat/dlgColumnStats.vb
@@ -109,7 +109,7 @@ Public Class dlgColumnStats
         clsConcFunction.SetRCommand("c")
 
         clsSummariesList.SetRCommand("c")
-        clsSummariesList.AddParameter("summary_count_non_missing", Chr(34) & "summary_count_non_missing" & Chr(34), bIncludeArgumentName:=False, iPosition:=1)
+        clsSummariesList.AddParameter("summary_count_name", Chr(34) & "summary_count_name" & Chr(34), bIncludeArgumentName:=False, iPosition:=1)
         clsSummariesList.AddParameter("summary_sum", Chr(34) & "summary_sum" & Chr(34), bIncludeArgumentName:=False, iPosition:=11)
 
         clsDefaultFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$calculate_summary")

--- a/instat/dlgColumnStats.vb
+++ b/instat/dlgColumnStats.vb
@@ -109,7 +109,7 @@ Public Class dlgColumnStats
         clsConcFunction.SetRCommand("c")
 
         clsSummariesList.SetRCommand("c")
-        clsSummariesList.AddParameter("summary_count_name", Chr(34) & "summary_count_name" & Chr(34), bIncludeArgumentName:=False, iPosition:=1)
+        clsSummariesList.AddParameter("summary_count", Chr(34) & "summary_count" & Chr(34), bIncludeArgumentName:=False, iPosition:=1)
         clsSummariesList.AddParameter("summary_sum", Chr(34) & "summary_sum" & Chr(34), bIncludeArgumentName:=False, iPosition:=11)
 
         clsDefaultFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$calculate_summary")

--- a/instat/dlgDisplayDailyData.vb
+++ b/instat/dlgDisplayDailyData.vb
@@ -156,7 +156,7 @@ Public Class dlgDisplayDailyData
         ucrChkIQR.SetParameter(New RParameter("IQR", 5), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "IQR" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
         ucrChkIQR.SetText("IQR")
 
-        ucrChkSumMissing.SetParameter(New RParameter("summary_count_missing", 6), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "summary_count_missing" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
+        ucrChkSumMissing.SetParameter(New RParameter("summary_count_miss", 6), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "summary_count_miss" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
         ucrChkSumMissing.SetText("N Missing")
 
         ucrNudNumberOfColumns.SetParameter(New RParameter("ncol", 1))

--- a/instat/dlgExtremesClimatic.vb
+++ b/instat/dlgExtremesClimatic.vb
@@ -447,7 +447,7 @@ Public Class dlgExtremesClimatic
         clsNSummary.AddParameter("save", "2", iPosition:=4)
         clsNSummary.SetAssignTo("n_dates_summary")
 
-        clsNFunction.SetRCommand("summary_count")
+        clsNFunction.SetRCommand("summary_count_all")
         clsNFunction.bToScriptAsRString = True
 
         clsFilterExtremeCalc.SetRCommand("instat_calculation$new")

--- a/instat/dlgOneVariableSummarise.vb
+++ b/instat/dlgOneVariableSummarise.vb
@@ -248,7 +248,7 @@ Public Class dlgOneVariableSummarise
                                                strObjectName:="last_table")
 
         clsSummariesList.SetRCommand("c")
-        clsSummariesList.AddParameter("summary_count_name", Chr(34) & "summary_count_name" & Chr(34), bIncludeArgumentName:=False)
+        clsSummariesList.AddParameter("summary_count", Chr(34) & "summary_count" & Chr(34), bIncludeArgumentName:=False)
         clsSummariesList.AddParameter("summary_count_all", Chr(34) & "summary_count_all" & Chr(34), bIncludeArgumentName:=False)
         clsSummariesList.AddParameter("summary_sum", Chr(34) & "summary_sum" & Chr(34), bIncludeArgumentName:=False)
 

--- a/instat/dlgOneVariableSummarise.vb
+++ b/instat/dlgOneVariableSummarise.vb
@@ -248,8 +248,8 @@ Public Class dlgOneVariableSummarise
                                                strObjectName:="last_table")
 
         clsSummariesList.SetRCommand("c")
-        clsSummariesList.AddParameter("summary_count_non_missing", Chr(34) & "summary_count_non_missing" & Chr(34), bIncludeArgumentName:=False)
-        clsSummariesList.AddParameter("summary_count", Chr(34) & "summary_count" & Chr(34), bIncludeArgumentName:=False)
+        clsSummariesList.AddParameter("summary_count_name", Chr(34) & "summary_count_name" & Chr(34), bIncludeArgumentName:=False)
+        clsSummariesList.AddParameter("summary_count_all", Chr(34) & "summary_count_all" & Chr(34), bIncludeArgumentName:=False)
         clsSummariesList.AddParameter("summary_sum", Chr(34) & "summary_sum" & Chr(34), bIncludeArgumentName:=False)
 
         clsSummaryFunction.SetRCommand("summary")

--- a/instat/sdgSummaries.vb
+++ b/instat/sdgSummaries.vb
@@ -45,7 +45,7 @@ Public Class sdgSummaries
         ucrPnlPosition.AddToLinkedControls({ucrChkFirst, ucrSelectorOrderBy, ucrReceiverOrderBy, ucrChkOrderBy, ucrChkLast, ucrChknth, ucrChkSample}, {rdoUsePositions}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlPosition.AddToLinkedControls({ucrChkWhichmin, ucrChkWhereMax, ucrChkWhereMin, ucrReceiverInclude, ucrSelectorInclude, ucrChkWhichmax}, {rdoDisplay}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
 
-        ucrChkNonMissing.SetParameter(New RParameter("summary_count_name", 1), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "summary_count_name" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
+        ucrChkNonMissing.SetParameter(New RParameter("summary_count", 1), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "summary_count" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
         ucrChkNonMissing.SetText("N Non Missing")
 
         ucrChkNMissing.SetParameter(New RParameter("summary_count_miss", 2), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "summary_count_miss" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))

--- a/instat/sdgSummaries.vb
+++ b/instat/sdgSummaries.vb
@@ -45,13 +45,13 @@ Public Class sdgSummaries
         ucrPnlPosition.AddToLinkedControls({ucrChkFirst, ucrSelectorOrderBy, ucrReceiverOrderBy, ucrChkOrderBy, ucrChkLast, ucrChknth, ucrChkSample}, {rdoUsePositions}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlPosition.AddToLinkedControls({ucrChkWhichmin, ucrChkWhereMax, ucrChkWhereMin, ucrReceiverInclude, ucrSelectorInclude, ucrChkWhichmax}, {rdoDisplay}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
 
-        ucrChkNonMissing.SetParameter(New RParameter("summary_count_non_missing", 1), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "summary_count_non_missing" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
+        ucrChkNonMissing.SetParameter(New RParameter("summary_count_name", 1), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "summary_count_name" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
         ucrChkNonMissing.SetText("N Non Missing")
 
-        ucrChkNMissing.SetParameter(New RParameter("summary_count_missing", 2), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "summary_count_missing" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
+        ucrChkNMissing.SetParameter(New RParameter("summary_count_miss", 2), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "summary_count_miss" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
         ucrChkNMissing.SetText("N Missing")
 
-        ucrChkNTotal.SetParameter(New RParameter("summary_count", 3), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "summary_count" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
+        ucrChkNTotal.SetParameter(New RParameter("summary_count_all", 3), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "summary_count_all" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
         ucrChkNTotal.SetText("N Total")
 
         ucrChkMean.SetParameter(New RParameter("summary_mean", 4), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "summary_mean" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))

--- a/instat/static/ClimateObject/R/BackendComponents/summary_functions.R
+++ b/instat/static/ClimateObject/R/BackendComponents/summary_functions.R
@@ -1,7 +1,7 @@
 # summary function labels
 sum_label="summary_sum"
 mode_label="summary_mode"
-count_label="summary_count"
+count_label="summary_count_all"
 count_over_threshold_label="summary_count_over_threshold"
 sd_label = "summary_sd"
 median_label = "summary_median"

--- a/instat/static/InstatObject/R/Backend_Components/DisplayDaily.R
+++ b/instat/static/InstatObject/R/Backend_Components/DisplayDaily.R
@@ -221,9 +221,9 @@ DisplayDaily <- function(Datain,Stations,Variables,option=1,Years,Misscode,Trace
               outstats[st,(m+1)] <- gsub("\\s+","",outstats[st,(m+1)]) 
             }
           }
-          # If all the data is NA, set the stats to NA (except summary_count_missing)
+          # If all the data is NA, set the stats to NA (except summary_count_miss)
           if(length(dat[,loc])==length(which(is.na(dat[,loc]==TRUE)))){
-            outstats[which(monstats != "summary_count_missing"),(m+1)] <- "NA"
+            outstats[which(monstats != "summary_count_miss"),(m+1)] <- "NA"
           }
 		  # If there's no data, set all the stats to NA
           if(length(dat[,loc]) == 0) outstats[,(m+1)] <- "NA"
@@ -278,7 +278,7 @@ DisplayDaily <- function(Datain,Stations,Variables,option=1,Years,Misscode,Trace
         out[dim(out)[1]+1,] <- "____"
         out[dim(out)[1],1] <- "STATS"
         # temp fix to shorten display name of summary function
-        outstats[,1][outstats[,1] == "summary_count_missing"] <- "n_miss"
+        outstats[,1][outstats[,1] == "summary_count_miss"] <- "n_miss"
         out <- rbind(out,outstats)
         
         #----------------------------------------------------------#

--- a/instat/static/InstatObject/R/Backend_Components/calculations.R
+++ b/instat/static/InstatObject/R/Backend_Components/calculations.R
@@ -494,7 +494,7 @@ DataBook$set("public", "apply_instat_calculation", function(calc, curr_data_list
       # if it is a ordered factor...
       if (any(stringr::str_detect("ordered", col_data_type))){
         # put in here the ones that DO work for ordered factor
-        if (any(grepl("summary_count_non_missing|summary_count_missing|summary_count|summary_min|summary_max|summary_range|summary_median|summary_quantile|p10|p20|p25|p30|p33|p40|p60|p67|p70|p75|p80|p90", formula_fn_exp))){
+        if (any(grepl("summary_count_name|summary_count_miss|summary_count_all|summary_min|summary_max|summary_range|summary_median|summary_quantile|p10|p20|p25|p30|p33|p40|p60|p67|p70|p75|p80|p90", formula_fn_exp))){
           curr_data_list[[c_data_label]] <- curr_data_list[[c_data_label]] %>%
             dplyr::summarise(!!calc$result_name := !!rlang::parse_expr(calc$function_exp))
         } else {
@@ -505,7 +505,7 @@ DataBook$set("public", "apply_instat_calculation", function(calc, curr_data_list
         # if it is a factor or character, do not work for anything except...
       } else if (any(stringr::str_detect("factor | character", col_data_type))){
         # put in here the ones that DO work for factor or character
-        if (any(grepl("summary_count_non_missing|summary_count_missing|summary_count", formula_fn_exp))){
+        if (any(grepl("summary_count_name|summary_count_miss|summary_count_all", formula_fn_exp))){
           curr_data_list[[c_data_label]] <- curr_data_list[[c_data_label]] %>%
             dplyr::summarise(!!calc$result_name := !!rlang::parse_expr(calc$function_exp)) 
         } else {

--- a/instat/static/InstatObject/R/Backend_Components/calculations.R
+++ b/instat/static/InstatObject/R/Backend_Components/calculations.R
@@ -494,7 +494,7 @@ DataBook$set("public", "apply_instat_calculation", function(calc, curr_data_list
       # if it is a ordered factor...
       if (any(stringr::str_detect("ordered", col_data_type))){
         # put in here the ones that DO work for ordered factor
-        if (any(grepl("summary_count_name|summary_count_miss|summary_count_all|summary_min|summary_max|summary_range|summary_median|summary_quantile|p10|p20|p25|p30|p33|p40|p60|p67|p70|p75|p80|p90", formula_fn_exp))){
+        if (any(grepl("summary_count|summary_count_miss|summary_count_all|summary_min|summary_max|summary_range|summary_median|summary_quantile|p10|p20|p25|p30|p33|p40|p60|p67|p70|p75|p80|p90", formula_fn_exp))){
           curr_data_list[[c_data_label]] <- curr_data_list[[c_data_label]] %>%
             dplyr::summarise(!!calc$result_name := !!rlang::parse_expr(calc$function_exp))
         } else {
@@ -505,7 +505,7 @@ DataBook$set("public", "apply_instat_calculation", function(calc, curr_data_list
         # if it is a factor or character, do not work for anything except...
       } else if (any(stringr::str_detect("factor | character", col_data_type))){
         # put in here the ones that DO work for factor or character
-        if (any(grepl("summary_count_name|summary_count_miss|summary_count_all", formula_fn_exp))){
+        if (any(grepl("summary_count|summary_count_miss|summary_count_all", formula_fn_exp))){
           curr_data_list[[c_data_label]] <- curr_data_list[[c_data_label]] %>%
             dplyr::summarise(!!calc$result_name := !!rlang::parse_expr(calc$function_exp)) 
         } else {

--- a/instat/static/InstatObject/R/Backend_Components/summary_functions.R
+++ b/instat/static/InstatObject/R/Backend_Components/summary_functions.R
@@ -446,7 +446,7 @@ sum_label <- "summary_sum"
 mode_label <- "summary_mode"
 count_label <- "summary_count_all"
 count_missing_label <- "summary_count_miss"
-count_non_missing_label <- "summary_count_name"
+count_non_missing_label <- "summary_count"
 sd_label <- "summary_sd"
 var_label <- "summary_var"
 median_label <- "summary_median"
@@ -581,7 +581,7 @@ na_check <- function(x, na_type = c(), na_consecutive_n = NULL, na_max_n = NULL,
       res[i] <- (summary_count_miss(x) / summary_count(x)) <= na_max_prop / 100
     }
     else if (type %in% c("n_non_miss","'n_non_miss'")) {
-      res[i] <- summary_count_name(x) >= na_min_n
+      res[i] <- summary_count(x) >= na_min_n
     }
     else if (type %in% c("FUN","'FUN'")) {
       res[i] <- na_FUN(x, ...)
@@ -728,7 +728,7 @@ summary_count_miss <- function(x, ...) {
   return(sum(is.na(x)))
 }
 
-summary_count_name <- function(x, ...) {
+summary_count <- function(x, ...) {
   return(sum(!is.na(x)))
 }
 

--- a/instat/static/InstatObject/R/Backend_Components/summary_functions.R
+++ b/instat/static/InstatObject/R/Backend_Components/summary_functions.R
@@ -281,7 +281,7 @@ DataBook$set("public", "summary", function(data_name, columns_to_summarise, summ
   calculated_from[[1]] <- list(data_name = data_name, columns = columns_to_summarise)
   summaries <- unique(summaries)
   summaries <- summaries[order(match(summaries, all_summaries))]
-  summaries_count <- summaries[startsWith(summaries, "summary_count")]
+  summaries_count <- summaries[startsWith(summaries, "summary_count_all")]
   summaries_other <- setdiff(summaries, summaries_count)
   summaries <- c(summaries_count, summaries_other)
   count_summaries_max <- length(summaries_count)
@@ -444,9 +444,9 @@ missing_values_check <- function(x) {
 # summary function labels
 sum_label <- "summary_sum"
 mode_label <- "summary_mode"
-count_label <- "summary_count"
-count_missing_label <- "summary_count_missing"
-count_non_missing_label <- "summary_count_non_missing"
+count_label <- "summary_count_all"
+count_missing_label <- "summary_count_miss"
+count_non_missing_label <- "summary_count_name"
 sd_label <- "summary_sd"
 var_label <- "summary_var"
 median_label <- "summary_median"
@@ -575,13 +575,13 @@ na_check <- function(x, na_type = c(), na_consecutive_n = NULL, na_max_n = NULL,
   for (i in seq_along(na_type)) {
     type <- na_type[i]
     if (type %in% c("n","'n'")) {
-      res[i] <- summary_count_missing(x) <= na_max_n
+      res[i] <- summary_count_miss(x) <= na_max_n
     }
     else if (type %in% c("prop","'prop'")) {
-      res[i] <- (summary_count_missing(x) / summary_count(x)) <= na_max_prop / 100
+      res[i] <- (summary_count_miss(x) / summary_count(x)) <= na_max_prop / 100
     }
     else if (type %in% c("n_non_miss","'n_non_miss'")) {
-      res[i] <- summary_count_non_missing(x) >= na_min_n
+      res[i] <- summary_count_name(x) >= na_min_n
     }
     else if (type %in% c("FUN","'FUN'")) {
       res[i] <- na_FUN(x, ...)
@@ -719,16 +719,16 @@ summary_sum <- function (x, weights = NULL, na.rm = FALSE, na_type = "", ...) {
 }
 
 
-summary_count <- function(x, ...) {
+summary_count_all <- function(x, ...) {
   return(length(x))
 }
 
 
-summary_count_missing <- function(x, ...) {
+summary_count_miss <- function(x, ...) {
   return(sum(is.na(x)))
 }
 
-summary_count_non_missing <- function(x, ...) {
+summary_count_name <- function(x, ...) {
   return(sum(!is.na(x)))
 }
 

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -4458,8 +4458,8 @@ DataSheet$set("public", "patch_climate_element", function(date_col_name = "", va
   }
   if (length(col) == dim(curr_data)[[1]]) {
     self$add_columns_to_data(col_name = column_name, col_data = col)
-    gaps_remaining <- summary_count_missing(col)
-    gaps_filled <- (summary_count_missing(curr_data[, var]) - gaps_remaining)
+    gaps_remaining <- summary_count_miss(col)
+    gaps_filled <- (summary_count_miss(curr_data[, var]) - gaps_remaining)
     cat(gaps_filled, " gaps filled", gaps_remaining, " remaining.", "\n")
   } else if (gaps != 0) {
     cat(gaps, " rows for date gaps are missing, fill date gaps before proceeding.", "\n")


### PR DESCRIPTION
Fixes #9241
@rdstern , @lilyclements 
I have unchecked the N-Total checkbox in the Climatic > Prepare > Summarise (by default) 
I have also changed the naming for:
1.` summary_count_non_missing` to` summary_count`
2.` summary_count` to `summary_count_all`
3. `summary_count_missing` to` summary_count_miss`

Apart from the original summarise dialogues, I also changed them in some dialogues that use these names:
`dlgOneVariablesummarise`
`dlgDisplayDailyData`
`dlgExtremesClimatic`

This PR is ready for review
