### PR TITLE
Fixed bug in Labels dialogue

### DIFF
--- a/instat/dlgLabelsLevels.vb
+++ b/instat/dlgLabelsLevels.vb
@@ -80,7 +80,7 @@ Public Class dlgLabelsLevels
         ucrSelectorForLabels.Focus()
 
 
-        clsSumCountMissingFunction.SetRCommand("summary_count_missing")
+        clsSumCountMissingFunction.SetRCommand("summary_count_miss")
 
         clsViewLabelsFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$set_factor_levels")
         ucrBase.clsRsyntax.SetBaseRFunction(clsViewLabelsFunction)


### PR DESCRIPTION
Fixes #9259 
I have  fixed the error caused by the new changes with the name change with the summary options that affected the Label/Levels Dialogue.
@rdstern , @N-thony 
the other dialog which used those name changes were all fixed in PR  #9250 
which are the `Display Daily Data`, `One Variable summarise` and the `Extreme Climatic` dialogue, which work well.
This PR is ready for review
Thanks