### PR TITLE
Fixed a  minor bug in Line plot dialog 

### DIFF
--- a/instat/dlgLinePlot.vb
+++ b/instat/dlgLinePlot.vb
@@ -536,7 +536,6 @@ Public Class dlgLinePlot
 
         clsGeomLineFunction.SetPackageName("ggplot2")
         clsGeomLineFunction.SetRCommand("geom_line")
-        clsGeomLineFunction.AddParameter("colour", Chr(34) & "blue" & Chr(34))
         clsGeomLineFunction.AddParameter("size", "0.8")
 
         clsAesLinerangeFunction.SetRCommand("aes")


### PR DESCRIPTION
Fixes #9273 
@fagiothree @rdstern @N-thony , it now produces multiple plots after removing  `colour = "blue" in geom_line`