### PR TITLE
Fixes bug in adding variable in multiple receiver

### DIFF
--- a/instat/ucrReceiverMultiple.vb
+++ b/instat/ucrReceiverMultiple.vb
@@ -47,7 +47,8 @@ Public Class ucrReceiverMultiple
         'first eliminate all items that already exist
         'this improves perfomance significantly for wide data sets
         For Each kvpTempItem As KeyValuePair(Of String, String) In lstItems
-            If lstSelectedVariables.FindItemWithText(kvpTempItem.Value) Is Nothing Then
+            Dim item As ListViewItem = lstSelectedVariables.FindItemWithText(kvpTempItem.Value)
+            If item Is Nothing OrElse Not item.Text.Equals(kvpTempItem.Value, StringComparison.Ordinal) Then
                 lstActualItemsToAdd.Add(kvpTempItem)
             End If
         Next

--- a/instat/ucrReceiverMultiple.vb
+++ b/instat/ucrReceiverMultiple.vb
@@ -47,11 +47,18 @@ Public Class ucrReceiverMultiple
         'first eliminate all items that already exist
         'this improves perfomance significantly for wide data sets
         For Each kvpTempItem As KeyValuePair(Of String, String) In lstItems
-            Dim item As ListViewItem = lstSelectedVariables.FindItemWithText(kvpTempItem.Value)
-            If item Is Nothing OrElse Not item.Text.Equals(kvpTempItem.Value, StringComparison.Ordinal) Then
+            Dim isMatchFound As Boolean = False
+            For Each item As ListViewItem In lstSelectedVariables.Items
+                If item.Text.Equals(kvpTempItem.Value, StringComparison.Ordinal) Then
+                    isMatchFound = True
+                    Exit For
+                End If
+            Next
+            If Not isMatchFound Then
                 lstActualItemsToAdd.Add(kvpTempItem)
             End If
         Next
+
 
         If lstActualItemsToAdd.Count = 0 Then
             Exit Sub


### PR DESCRIPTION
Fixes #9306 I hope!

@derekagorhom have a look of this PR, it attempts to fix b) from the issue by adding of variable in the multipe reveiver, I think the issue was in the code with `FindItemWithText` which might only check for the beginning of the text (prefix matching) instead of the full string, or it could be performing partial matches therefore we were not able to add another variable.
You can work on item a)
