### PR TITLE
Update one variable summarise

### DIFF
--- a/instat/dlgOneVariableSummarise.vb
+++ b/instat/dlgOneVariableSummarise.vb
@@ -33,7 +33,7 @@ Public Class dlgOneVariableSummarise
 
     Private clsPipeOperator, clsJoiningPipeOperator As New ROperator
     Private clsGetGtTableFunction As New RFunction
-    Private clsGtTableROperator As New ROperator
+    Private clsSummaryOperator As New ROperator
     Private bResetSubdialog As Boolean = False
     Private bResetFormatSubdialog As Boolean = False
     Public strDefaultDataFrame As String = ""
@@ -134,7 +134,7 @@ Public Class dlgOneVariableSummarise
 
         clsPipeOperator = New ROperator
 
-        clsGtTableROperator = New ROperator
+        clsSummaryOperator = New ROperator
         clsGetGtTableFunction = New RFunction
 
         ucrSelectorOneVarSummarise.Reset()
@@ -167,13 +167,14 @@ Public Class dlgOneVariableSummarise
 
         clsGtFunction.SetPackageName("gt")
         clsGtFunction.SetRCommand("gt")
-        clsGtTableROperator.SetOperation("%>%")
-        clsGtTableROperator.bBrackets = False
-        clsGtTableROperator.AddParameter("tableFun", clsRFunctionParameter:=clsSummaryTableFunction, iPosition:=0)
-        clsGtTableROperator.AddParameter(strParameterName:="gt_tbl", clsRFunctionParameter:=clsGtFunction, iPosition:=1, bIncludeArgumentName:=False)
+
+        clsSummaryOperator.SetOperation("%>%")
+        clsSummaryOperator.AddParameter("tableFun", clsRFunctionParameter:=clsSummaryTableFunction, iPosition:=0)
+        clsSummaryOperator.AddParameter(strParameterName:="gt_tbl", clsRFunctionParameter:=clsGtFunction, iPosition:=2, bIncludeArgumentName:=False)
+
 
         clsJoiningPipeOperator.SetOperation("%>%")
-        clsJoiningPipeOperator.AddParameter("mutable", clsROperatorParameter:=clsGtTableROperator, iPosition:=0)
+        clsJoiningPipeOperator.AddParameter("mutable", clsROperatorParameter:=clsSummaryOperator, iPosition:=0)
         clsJoiningPipeOperator.SetAssignToOutputObject(strRObjectToAssignTo:="last_table",
                                                strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Table,
                                                strRObjectFormatToAssignTo:=RObjectFormat.Html,
@@ -218,8 +219,6 @@ Public Class dlgOneVariableSummarise
         ucrSelectorOneVarSummarise.SetRCode(clsSummaryTableFunction, bReset)
         ucrInputDisplayMissing.SetRCode(clsSummaryTableFunction, bReset)
         ucrSaveSummary.SetRCode(clsSkimrFunction, bReset)
-        ucrSelectorOneVarSummarise.SetRCode(clsGetGtTableFunction, bReset)
-        ucrReceiverOneVarSummarise.SetRCode(clsGetGtTableFunction, bReset)
 
         If bReset Then
             ucrChkDisplayMissing.SetRCode(clsDummyFunction, bReset)
@@ -368,7 +367,7 @@ Public Class dlgOneVariableSummarise
     End Sub
 
     Private Sub cmdTableOptions_Click(sender As Object, e As EventArgs) Handles cmdTableOptions.Click
-        sdgTableOptions.Setup(ucrSelectorOneVarSummarise.strCurrentDataFrame, clsGtTableROperator)
+        sdgTableOptions.Setup(ucrSelectorOneVarSummarise.strCurrentDataFrame, clsSummaryOperator)
         sdgTableOptions.ShowDialog(Me)
         bResetFormatSubdialog = False
     End Sub
@@ -376,10 +375,10 @@ Public Class dlgOneVariableSummarise
     Private Sub Display_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlColumnFactor.ControlValueChanged
         'If bRCodeSet Then
         If rdoNoColumnFactor.Checked Then
-            clsGtTableROperator.RemoveParameterByName("col_factor")
+            clsSummaryOperator.RemoveParameterByName("col_factor")
             clsDummyFunction.AddParameter("factor_cols", "NoColFactor", iPosition:=1)
         Else
-            clsGtTableROperator.AddParameter("col_factor", clsRFunctionParameter:=clsPivotWiderFunction, iPosition:=1)
+            clsSummaryOperator.AddParameter("col_factor", clsRFunctionParameter:=clsPivotWiderFunction, iPosition:=1)
             If rdoSummary.Checked Then
                 clsDummyFunction.AddParameter("factor_cols", "Sum", iPosition:=1)
                 clsPivotWiderFunction.AddParameter("names_from", "summary", iPosition:=0)

--- a/instat/dlgOneVariableSummarise.vb
+++ b/instat/dlgOneVariableSummarise.vb
@@ -32,7 +32,6 @@ Public Class dlgOneVariableSummarise
         clsSkimrFunction, clsPivotWiderFunction As New RFunction
 
     Private clsPipeOperator, clsJoiningPipeOperator As New ROperator
-    Private clsGetGtTableFunction As New RFunction
     Private clsSummaryOperator As New ROperator
     Private bResetSubdialog As Boolean = False
     Private bResetFormatSubdialog As Boolean = False
@@ -135,15 +134,11 @@ Public Class dlgOneVariableSummarise
         clsPipeOperator = New ROperator
 
         clsSummaryOperator = New ROperator
-        clsGetGtTableFunction = New RFunction
 
         ucrSelectorOneVarSummarise.Reset()
 
         clsPipeOperator.SetOperation("%>%")
         clsPipeOperator.bBrackets = False
-
-        clsGetGtTableFunction.SetPackageName("gt")
-        clsGetGtTableFunction.SetRCommand("gt")
 
         clsSkimrFunction.SetPackageName("skimr")
         clsSkimrFunction.SetRCommand("skim_without_charts")


### PR DESCRIPTION
Fixes #9321 
when i looked at the script code the default produced and pasted them in the standalone versions, they run just fine. 
so what i did was remove the `clsGtTableROperator` which was used to pass the function from Patrick's Gt tables and used the original `clsSummaryOperator` and added the third parameter to the `clsSummaryOperator` which would call Patrick's Gt tables.
We tried that when doing the Gt tables for two/three variables with Vitalis but instead of adding the parameter to the pivot wider operator, in this dialog we passed it to the clsSummaryOperator.
@rdstern , @N-thony can you review this 
Thanks