### PR TITLE
Tidy code for Prepare > Dataframe > View Dialog

### DIFF
--- a/instat/dlgView.vb
+++ b/instat/dlgView.vb
@@ -158,6 +158,11 @@ Public Class dlgView
 
         clsViewColumnsFunction.SetPackageName("utils")
         clsViewColumnsFunction.SetRCommand("View")
+        clsViewColumnsFunction.SetAssignToOutputObject(strRObjectToAssignTo:="last_table",
+                                      strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Table,
+                                      strRObjectFormatToAssignTo:=RObjectFormat.Html,
+                                      strRDataFrameNameToAddObjectTo:=ucrSelectorForView.strCurrentDataFrame,
+                                      strObjectName:="last_table")
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
@@ -271,6 +276,9 @@ Public Class dlgView
 
     Private Sub ucrSelectorForView_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorForView.ControlValueChanged
         DataFrameLength()
+        clsOutputWindowFunction.AddParameter("data", clsRFunctionParameter:=ucrSelectorForView.ucrAvailableDataFrames.clsCurrDataFrame, iPosition:=0)
+        clsHeadRFunction.AddParameter("data", clsRFunctionParameter:=ucrSelectorForView.ucrAvailableDataFrames.clsCurrDataFrame, iPosition:=0)
+        'clsViewColumnsFunction.AddParameter("data", clsRFunctionParameter:=ucrSelectorForView.ucrAvailableDataFrames.clsCurrDataFrame, iPosition:=1)
     End Sub
 
     Private Sub cmdTableOptions_Click(sender As Object, e As EventArgs) Handles cmdTableOptions.Click


### PR DESCRIPTION
Fixes #9324 
This PR implements the naming system for the View dialogue
The Naming system works for the Display HTML in Output window and Display in Output window
For the Display in R Viewer Window i get an error which states that `data=survey` is an `unused argument`, so that option only does; 
b) do something, c) present results.
@rdstern , @N-thony this is ready for review.
Thanks