### PR TITLE
Fixed Issue with Convert Numeric dialog not popping up

### DIFF
--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -699,7 +699,7 @@ Public Class ucrDataView
                     frmConvertToNumeric.CheckLabels(bCheckLabels)
                     frmConvertToNumeric.SetNonNumeric(iNonNumericValues)
                     frmConvertToNumeric.ShowDialog()
-                    ' Yes for "normal" convert and No for "ordinal" convert
+                    ' Yes for "normal" convert and No for "labelled" convert
                     Select Case frmConvertToNumeric.DialogResult
                         Case DialogResult.Yes
                             GetCurrentDataFrameFocus().clsPrepareFunctions.ConvertToNumeric(strColumn, True)

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -694,7 +694,20 @@ Public Class ucrDataView
             Else
                 Dim bCheckLabels As Boolean = GetCurrentDataFrameFocus().clsPrepareFunctions.CheckHasLabels(strColumn)
                 If bCheckLabels Then
-                    GetCurrentDataFrameFocus().clsPrepareFunctions.ConvertToNumeric(strColumn, True)
+                    frmConvertToNumeric.SetDataFrameName(GetCurrentDataFrameFocus().strName)
+                    frmConvertToNumeric.SetColumnName(strColumn)
+                    frmConvertToNumeric.CheckLabels(bCheckLabels)
+                    frmConvertToNumeric.SetNonNumeric(iNonNumericValues)
+                    frmConvertToNumeric.ShowDialog()
+                    ' Yes for "normal" convert and No for "ordinal" convert
+                    Select Case frmConvertToNumeric.DialogResult
+                        Case DialogResult.Yes
+                            GetCurrentDataFrameFocus().clsPrepareFunctions.ConvertToNumeric(strColumn, True)
+                        Case DialogResult.No
+                            GetCurrentDataFrameFocus().clsPrepareFunctions.ConvertToNumeric(strColumn, False)
+                        Case DialogResult.Cancel
+                            Continue For
+                    End Select
                 Else
                     frmConvertToNumeric.SetDataFrameName(GetCurrentDataFrameFocus().strName)
                     frmConvertToNumeric.SetColumnName(strColumn)


### PR DESCRIPTION
Fixes partly #9325 
While going through the issue i realised the frmConvertoNumeric's cmdLabelledConvert alternates between labelled convert and ordinal convert. it seems the ordinal convert option works because the frmConvertoNumeric is able to pop up when the column being convert to numeric is not labelled but does not for the case where column is labelled. This PR should fix that issue (I hope) without causing any regression. 
@rdstern , @N-thony can your review this PR 
Thanks