### PR TITLE
Fixed bug in Append dialog

### DIFF
--- a/instat/dlgAppend.vb
+++ b/instat/dlgAppend.vb
@@ -36,6 +36,7 @@ Public Class dlgAppend
         End If
         SetRCodeForControls(bReset)
         SetHelpOptions()
+        ReopenDialog()
         bReset = False
         autoTranslate(Me)
     End Sub
@@ -98,6 +99,7 @@ Public Class dlgAppend
     End Sub
 
     Private Sub ReopenDialog()
+        ucrReceiverAppendDataframe.Clear()
     End Sub
 
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset


### PR DESCRIPTION
Fixes #9352 
The fix ensures that the dialog on reopening clears the receiver of the previously selected dataframes.
@rdstern , @N-thony this is ready for review