### PR TITLE
Auto-Saving Data: Triggering Saves Only on Data Changes

### DIFF
--- a/instat/Model/DataFrame/clsDataFrame.vb
+++ b/instat/Model/DataFrame/clsDataFrame.vb
@@ -181,6 +181,7 @@ Public Class clsDataFrame
             Else
                 bRefreshed = False
             End If
+            _clsVisibleDataFramePage.HasDataChangedForAutoSave = True
         End If
         _clsColumnMetaData.RefreshData()
         Return bRefreshed

--- a/instat/Model/DataFrame/clsDataFramePage.vb
+++ b/instat/Model/DataFrame/clsDataFramePage.vb
@@ -31,6 +31,7 @@ Public Class clsDataFramePage
     Private _lstColumns As List(Of clsColumnHeaderDisplay)
     Private _hasChanged As Boolean
     Private _useColumnSelectionInDataView As Boolean
+    Private _HasDataChangedForAutoSave As Boolean
 
     Private ReadOnly Property iColumnIncrements As Integer
         Get
@@ -141,6 +142,19 @@ Public Class clsDataFramePage
     End Property
 
     ''' <summary>
+    ''' holds whether the dataframe is different from visual grid component and trigger auto save
+    ''' </summary>
+    ''' <returns></returns>
+    Public Property HasDataChangedForAutoSave() As Boolean
+        Get
+            Return _HasDataChangedForAutoSave
+        End Get
+        Set(ByVal value As Boolean)
+            _HasDataChangedForAutoSave = value
+        End Set
+    End Property
+
+    ''' <summary>
     ''' Create a new instance of a dataframe page
     ''' </summary>
     ''' <param name="rLink"></param>
@@ -152,6 +166,7 @@ Public Class clsDataFramePage
         _iColumnStart = 1
         _iRowStart = 1
         _hasChanged = True
+        _HasDataChangedForAutoSave = True
         _useColumnSelectionInDataView = True
     End Sub
 

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1185,7 +1185,7 @@ Public Class frmMain
         Dim strCurrentStatus As String
 
         strCurrentStatus = tstatus.Text
-        If clsRLink.bInstatObjectExists Then
+        If clsRLink.bInstatObjectExists AndAlso ucrDataViewer.HasDataChanged Then
             tstatus.Text = GetTranslation("Auto saving data...")
             Cursor = Cursors.WaitCursor
             If Not Directory.Exists(strAutoSaveDataFolderPath) Then
@@ -1208,6 +1208,7 @@ Public Class frmMain
             tstatus.Text = strCurrentStatus
             Cursor = Cursors.Default
             bFirstBackupDone = True
+            ucrDataViewer.HasDataChanged(False)
         End If
     End Sub
 

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1196,7 +1196,7 @@ Public Class frmMain
             strTempFile = "data_" & DateTime.Now.ToString("yyyyMMdd_HHmmss") & ".rds"
             strCurrentAutoSaveDataFilePath = Path.Combine(strAutoSaveDataFolderPath, strTempFile)
 
-            Dim strBackupMessage As String = $"##########{vbCrLf}## Backing up data and log files on: {DateTime.Now}{vbCrLf}##########"
+            Dim strBackupMessage As String = $"##########{vbCrLf}## Backing up data and metadata on: {DateTime.Now}{vbCrLf}##########"
             Me.ucrScriptWindow.LogText(strBackupMessage)
             clsRLink.AppendToAutoSaveLog(strBackupMessage)
 

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1208,7 +1208,7 @@ Public Class frmMain
             tstatus.Text = strCurrentStatus
             Cursor = Cursors.Default
             bFirstBackupDone = True
-            ucrDataViewer.HasDataChanged(False)
+            ucrDataViewer.HasDataChanged = False
         End If
     End Sub
 

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -187,13 +187,14 @@ Public Class ucrDataView
         Return If(_grid.CurrentWorksheet Is Nothing, Nothing, _grid.CurrentWorksheet.Name)
     End Function
 
-    Public Function HasDataChanged() As Boolean
-        Return GetCurrentDataFrameFocus.clsVisibleDataFramePage.HasDataChangedForAutoSave
-    End Function
-
-    Public Sub HasDataChanged(bChange As Boolean)
-        GetCurrentDataFrameFocus.clsVisibleDataFramePage.HasDataChangedForAutoSave = bChange
-    End Sub
+    Public Property HasDataChanged() As Boolean
+        Get
+            Return GetCurrentDataFrameFocus.clsVisibleDataFramePage.HasDataChangedForAutoSave
+        End Get
+        Set(ByVal value As Boolean)
+            GetCurrentDataFrameFocus.clsVisibleDataFramePage.HasDataChangedForAutoSave = value
+        End Set
+    End Property
 
     Private Sub mnuDeleteCol_Click(sender As Object, e As EventArgs) Handles mnuDeleteCol.Click
         If GetSelectedColumns.Count = GetCurrentDataFrameFocus()?.iTotalColumnCount Then

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -189,10 +189,18 @@ Public Class ucrDataView
 
     Public Property HasDataChanged() As Boolean
         Get
-            Return GetCurrentDataFrameFocus.clsVisibleDataFramePage.HasDataChangedForAutoSave
+            Dim currentDataFrame = GetCurrentDataFrameFocus()
+            If currentDataFrame IsNot Nothing AndAlso currentDataFrame.clsVisibleDataFramePage IsNot Nothing Then
+                Return currentDataFrame.clsVisibleDataFramePage.HasDataChangedForAutoSave
+            End If
+            Return False ' Or a default value
         End Get
         Set(ByVal value As Boolean)
-            GetCurrentDataFrameFocus.clsVisibleDataFramePage.HasDataChangedForAutoSave = value
+            Dim currentDataFrame = GetCurrentDataFrameFocus()
+            If currentDataFrame IsNot Nothing AndAlso currentDataFrame.clsVisibleDataFramePage IsNot Nothing Then
+                currentDataFrame.clsVisibleDataFramePage.HasDataChangedForAutoSave = value
+            End If
+            ' Optionally handle the case where currentDataFrame is Nothing
         End Set
     End Property
 

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -23,6 +23,7 @@ Public Class ucrDataView
     Private _clsDataBook As clsDataBook
     Private _grid As IDataViewGrid
     Private bOnlyUpdateOneCell As Boolean = False
+    Private _hasChanged As Boolean
 
     Public WriteOnly Property DataBook() As clsDataBook
         Set(value As clsDataBook)
@@ -157,6 +158,7 @@ Public Class ucrDataView
                 RefreshDisplayInformation()
             End If
         End If
+        _hasChanged = True
         EnableDisableUndoMenu()
         _grid.Focus()
     End Sub
@@ -184,6 +186,14 @@ Public Class ucrDataView
     Public Function GetCurrentDataFrameNameFocus() As String
         Return If(_grid.CurrentWorksheet Is Nothing, Nothing, _grid.CurrentWorksheet.Name)
     End Function
+
+    Public Function HasDataChanged() As Boolean
+        Return GetCurrentDataFrameFocus.clsVisibleDataFramePage.HasDataChangedForAutoSave
+    End Function
+
+    Public Sub HasDataChanged(bChange As Boolean)
+        GetCurrentDataFrameFocus.clsVisibleDataFramePage.HasDataChangedForAutoSave = bChange
+    End Sub
 
     Private Sub mnuDeleteCol_Click(sender As Object, e As EventArgs) Handles mnuDeleteCol.Click
         If GetSelectedColumns.Count = GetCurrentDataFrameFocus()?.iTotalColumnCount Then


### PR DESCRIPTION
Fixes #9236
@rdstern I hope this fixes what you have suggested in issue #9236, and replaces PR #9283 Have a look.
I have maintained the timer and in addition, the auto save will be triggered only if the data have been previously changed.