### PR TITLE
Moving instat_calculation code from R-Instat into a separate R package

### DIFF
--- a/instat/clsQualityControl.vb
+++ b/instat/clsQualityControl.vb
@@ -66,7 +66,7 @@ Public Class clsQCJumpRCode
         clsPmaxFunction.bToScriptAsRString = True
 
         strCalcName = strlargestJump
-        clsJumpCalcFunction.SetRCommand("instat_calculation$new")
+        clsJumpCalcFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsJumpCalcFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsJumpCalcFunction.AddParameter("function_exp", clsRFunctionParameter:=clsPmaxFunction, iPosition:=1)
         clsJumpCalcFunction.AddParameter("result_name", Chr(34) & strCalcName & Chr(34), iPosition:=4)
@@ -75,7 +75,7 @@ Public Class clsQCJumpRCode
         strTestName = strJumpTest
         clsJumpListFunc.SetRCommand("list")
         clsJumpListFunc.AddParameter("sub1", clsRFunctionParameter:=clsJumpCalcFunction, bIncludeArgumentName:=False)
-        clsJumpTestFunction.SetRCommand("instat_calculation$new")
+        clsJumpTestFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsJumpTestFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsJumpTestFunction.AddParameter("function_exp", clsROperatorParameter:=clsGreaterJumpOperator, iPosition:=1)
         clsJumpTestFunction.AddParameter("result_name", Chr(34) & strTestName & Chr(34), iPosition:=4)
@@ -131,7 +131,7 @@ Public Class clsQCSameRCode
         clsDollarOperator.AddParameter("right", strParameterValue:=strLengths, bIncludeArgumentName:=False, iPosition:=1)
 
         strCalcName = strlargestSame
-        clsSameCalcFunction.SetRCommand("instat_calculation$new")
+        clsSameCalcFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsSameCalcFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsSameCalcFunction.AddParameter("function_exp", clsRFunctionParameter:=clsRepFunc, iPosition:=1)
         clsSameCalcFunction.AddParameter("result_name", Chr(34) & strCalcName & Chr(34), iPosition:=4)
@@ -142,7 +142,7 @@ Public Class clsQCSameRCode
         clsSameListFunc.SetRCommand("list")
         clsSameListFunc.AddParameter("sub1", clsRFunctionParameter:=clsSameCalcFunction, bIncludeArgumentName:=False)
 
-        clsSameTestFunction.SetRCommand("instat_calculation$new")
+        clsSameTestFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsSameTestFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsSameTestFunction.AddParameter("function_exp", clsROperatorParameter:=clsSameGreaterOperator, iPosition:=1)
         clsSameTestFunction.AddParameter("result_name", Chr(34) & strTestName & Chr(34), iPosition:=4)
@@ -179,7 +179,7 @@ Public Class clsQCDifferenceRCode
         clsDiffOperator.SetOperation("-")
         clsDiffOperator.bToScriptAsRString = True
 
-        clsDiffCalcFunction.SetRCommand("instat_calculation$new")
+        clsDiffCalcFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsDiffCalcFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsDiffCalcFunction.AddParameter("function_exp", clsROperatorParameter:=clsDiffOperator, iPosition:=1)
         clsDiffCalcFunction.AddParameter("result_name", Chr(34) & strDiffCalc & Chr(34), iPosition:=4)
@@ -188,7 +188,7 @@ Public Class clsQCDifferenceRCode
         strTestName = strDiffTest
         clsListFunc.SetRCommand("list")
         clsListFunc.AddParameter("sub1", bIncludeArgumentName:=False, clsRFunctionParameter:=clsDiffCalcFunction, iPosition:=0)
-        clsDiffTestFunction.SetRCommand("instat_calculation$new")
+        clsDiffTestFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsDiffTestFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsDiffTestFunction.AddParameter("function_exp", clsROperatorParameter:=clsLessDiffOperator, iPosition:=1)
         clsDiffTestFunction.AddParameter("result_name", Chr(34) & strTestName & Chr(34), iPosition:=4)
@@ -223,7 +223,7 @@ Public Class clsQCAcceptableRange
         clsRangeOrOperator.AddParameter("left", clsROperatorParameter:=clsLessEqualToOperator, iPosition:=0, bIncludeArgumentName:=False)
         clsRangeOrOperator.AddParameter("right", clsROperatorParameter:=clsGreaterEqualToOperator, iPosition:=1, bIncludeArgumentName:=False)
 
-        clsAcceptableRangeTestFunc.SetRCommand("instat_calculation$new")
+        clsAcceptableRangeTestFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsAcceptableRangeTestFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsAcceptableRangeTestFunc.AddParameter("function_exp", clsROperatorParameter:=clsRangeOrOperator, iPosition:=1)
         clsAcceptableRangeTestFunc.AddParameter("result_name", Chr(34) & strRangeName & Chr(34), iPosition:=4)
@@ -265,7 +265,7 @@ Public Class clsQcOutliers
         strUpperTestName = strOutlierUpperTestCalcName
         strLowerTestName = strOutlierLowerTestCalcName
 
-        clsOutlierUpperLimitCalc.SetRCommand("instat_calculation$new")
+        clsOutlierUpperLimitCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsOutlierUpperLimitCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsOutlierUpperLimitCalc.AddParameter("function_exp", clsRFunctionParameter:=clsOutlierUpperLimitFunc, iPosition:=1)
         clsOutlierUpperLimitCalc.AddParameter("result_name", Chr(34) & strUpperCalcName & Chr(34), iPosition:=4)
@@ -275,7 +275,7 @@ Public Class clsQcOutliers
         clsOutlierUpperLimitFunc.AddParameter("bupperlimit", "TRUE")
         clsOutlierUpperLimitFunc.bToScriptAsRString = True
 
-        clsOutlierLowerLimitCalc.SetRCommand("instat_calculation$new")
+        clsOutlierLowerLimitCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsOutlierLowerLimitCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsOutlierLowerLimitCalc.AddParameter("function_exp", clsRFunctionParameter:=clsOutlierLowerLimitFunc, iPosition:=1)
         clsOutlierLowerLimitCalc.AddParameter("result_name", Chr(34) & strLowerCalcName & Chr(34), iPosition:=4)
@@ -285,7 +285,7 @@ Public Class clsQcOutliers
         clsOutlierLowerLimitFunc.AddParameter("bupperlimit", "FALSE")
         clsOutlierLowerLimitFunc.bToScriptAsRString = True
 
-        clsOutlierLowerLimitTestCalc.SetRCommand("instat_calculation$new")
+        clsOutlierLowerLimitTestCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsOutlierLowerLimitTestCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsOutlierLowerLimitTestCalc.AddParameter("function_exp", clsROperatorParameter:=clsOutlierLowerOperator, iPosition:=1)
         clsOutlierLowerLimitTestCalc.AddParameter("sub_calculations", clsRFunctionParameter:=clsOutlierLowerList, iPosition:=2)
@@ -299,7 +299,7 @@ Public Class clsQcOutliers
         clsOutlierLowerOperator.bToScriptAsRString = True
         clsOutlierLowerOperator.AddParameter("right", strLowerCalcName, iPosition:=1)
 
-        clsOutlierUpperLimitTestCalc.SetRCommand("instat_calculation$new")
+        clsOutlierUpperLimitTestCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsOutlierUpperLimitTestCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsOutlierUpperLimitTestCalc.AddParameter("function_exp", clsROperatorParameter:=clsOutlierUpperOperator, iPosition:=1)
         clsOutlierUpperLimitTestCalc.AddParameter("sub_calculations", clsRFunctionParameter:=clsOutlierUpperList, iPosition:=2)

--- a/instat/dlgCalculationsSummary.vb
+++ b/instat/dlgCalculationsSummary.vb
@@ -61,7 +61,7 @@ Public Class dlgCalculationsSummary
         clsApplyCalculation.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$run_instat_calculation")
         clsApplyCalculation.AddParameter("calc", clsRFunctionParameter:=clsNewCalculationFunction)
 
-        clsNewCalculationFunction.SetRCommand("instat_calculation$new")
+        clsNewCalculationFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsNewCalculationFunction.AddParameter("name", Chr(34) & strCalcName & Chr(34))
         clsNewCalculationFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34))
         clsNewCalculationFunction.AddParameter("save", "2")

--- a/instat/dlgClimaticCheckDataRain.vb
+++ b/instat/dlgClimaticCheckDataRain.vb
@@ -292,7 +292,7 @@ Public Class dlgClimaticCheckDataRain
         bResetSubdialog = True
 
         'Group Function
-        clsGroupByFunc.SetRCommand("instat_calculation$new")
+        clsGroupByFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByFunc.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByFunc.SetAssignTo("grouping")
 
@@ -300,7 +300,7 @@ Public Class dlgClimaticCheckDataRain
         clsListFunc.AddParameter("sub1", clsRFunctionParameter:=clsGroupByFunc, bIncludeArgumentName:=False, iPosition:=1)
 
         'Main Filter
-        clsRainFilterFunc.SetRCommand("instat_calculation$new")
+        clsRainFilterFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsRainFilterFunc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsRainFilterFunc.AddParameter("function_exp", clsROperatorParameter:=clsOrOperator, iPosition:=1)
         clsRainFilterFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsListSubCalc, iPosition:=2)
@@ -310,7 +310,7 @@ Public Class dlgClimaticCheckDataRain
         clsManuplationDayListFunction.SetRCommand("list")
         clsManuplationDayListFunction.AddParameter("list", clsRFunctionParameter:=clsRainFilterFunc, iPosition:=0, bIncludeArgumentName:=False)
 
-        clsDayFilterFunc.SetRCommand("instat_calculation$new")
+        clsDayFilterFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsDayFilterFunc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsDayFilterFunc.AddParameter("function_exp", Chr(34) & "day" & Chr(34), iPosition:=1)
         clsDayFilterFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsListDayFunction, iPosition:=2)
@@ -337,7 +337,7 @@ Public Class dlgClimaticCheckDataRain
         clsLargeLessOperator.SetOperation("<")
         clsLargeLessOperator.AddParameter("right", bIncludeArgumentName:=False, strParameterValue:="-1E-8", iPosition:=1)
 
-        clsLargeTestCalcFunc.SetRCommand("instat_calculation$new")
+        clsLargeTestCalcFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsLargeTestCalcFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsLargeTestCalcFunc.AddParameter("function_exp", clsROperatorParameter:=clsOrLargeOperator, iPosition:=1)
         clsLargeTestCalcFunc.AddParameter("result_name", Chr(34) & strLargeTest & Chr(34), iPosition:=3)
@@ -370,13 +370,13 @@ Public Class dlgClimaticCheckDataRain
         clsRepFunc.AddParameter("second", bIncludeArgumentName:=False, clsROperatorParameter:=clsDollarOperator, iPosition:=1)
         clsRepFunc.bToScriptAsRString = True
 
-        clsSameCalcFunc.SetRCommand("instat_calculation$new")
+        clsSameCalcFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsSameCalcFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsSameCalcFunc.AddParameter("function_exp", clsRFunctionParameter:=clsRepFunc, iPosition:=1)
         clsSameCalcFunc.AddParameter("result_name", Chr(34) & strSameCalc & Chr(34), iPosition:=3)
         clsSameCalcFunc.SetAssignTo("same_calculation")
 
-        clsSameTestFunc.SetRCommand("instat_calculation$new")
+        clsSameTestFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsSameTestFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsSameTestFunc.AddParameter("function_exp", clsROperatorParameter:=clsAndOperator, iPosition:=1)
         clsSameTestFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsSameList, iPosition:=2)
@@ -415,13 +415,13 @@ Public Class dlgClimaticCheckDataRain
         clsMultipleOperator.AddParameter("left", clsROperatorParameter:=clsEqualOperator, iPosition:=0)
         clsMultipleOperator.AddParameter("right", clsRFunctionParameter:=clsCumSumFuc, iPosition:=1)
 
-        clsCumulativeCalcFunc.SetRCommand("instat_calculation$new")
+        clsCumulativeCalcFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsCumulativeCalcFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsCumulativeCalcFunc.AddParameter("function_exp", clsROperatorParameter:=clsMinusOperator, iPosition:=1)
         clsCumulativeCalcFunc.AddParameter("result_name", Chr(34) & strCumulativeCalc & Chr(34), iPosition:=3)
         clsCumulativeCalcFunc.SetAssignTo("cumulative_calculation")
 
-        clsCumulativeTestFunc.SetRCommand("instat_calculation$new")
+        clsCumulativeTestFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsCumulativeTestFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsCumulativeTestFunc.AddParameter("function_exp", clsROperatorParameter:=clsSecondGreaterOperator, iPosition:=1)
         clsCumulativeTestFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsCumulativeList, iPosition:=2)
@@ -438,11 +438,11 @@ Public Class dlgClimaticCheckDataRain
         clsIsNaFunction.SetRCommand("is.na")
 
         'Group By Month 
-        clsGroupByMonth.SetRCommand("instat_calculation$new")
+        clsGroupByMonth.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByMonth.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByMonth.SetAssignTo("grouping_month")
 
-        clsGroupByMonthYearFunction.SetRCommand("instat_calculation$new")
+        clsGroupByMonthYearFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByMonthYearFunction.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByMonthYearFunction.SetAssignTo("grouping_month_year")
 
@@ -459,13 +459,13 @@ Public Class dlgClimaticCheckDataRain
         clsRainyDaysOperator.bBrackets = True
         clsRainyDaysOperator.bToScriptAsRString = True
 
-        clsRainyDaysFunc.SetRCommand("instat_calculation$new")
+        clsRainyDaysFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsRainyDaysFunc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsRainyDaysFunc.AddParameter("function_exp", clsROperatorParameter:=clsRainyDaysOperator, iPosition:=0)
         clsRainyDaysFunc.SetAssignTo("rainydays_filter")
 
         'upper Outlier Limit function
-        clsUpperOutlierLimitValueCalcFunc.SetRCommand("instat_calculation$new")
+        clsUpperOutlierLimitValueCalcFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsUpperOutlierLimitValueCalcFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsUpperOutlierLimitValueCalcFunc.AddParameter("function_exp", clsRFunctionParameter:=clsUpperOutlierLimitFunc, iPosition:=1)
         clsUpperOutlierLimitValueCalcFunc.AddParameter("result_name", Chr(34) & strUpperOutlierLimit & Chr(34), iPosition:=4)
@@ -481,7 +481,7 @@ Public Class dlgClimaticCheckDataRain
         clsUpperOutlierOperator.bBrackets = False
         clsUpperOutlierOperator.bToScriptAsRString = True
 
-        clsUpperOutlierlimitTestFunc.SetRCommand("instat_calculation$new")
+        clsUpperOutlierlimitTestFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsUpperOutlierlimitTestFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsUpperOutlierlimitTestFunc.AddParameter("function_exp", clsROperatorParameter:=clsUpperOutlierOperator, iPosition:=1)
         clsUpperOutlierlimitTestFunc.AddParameter("result_name", Chr(34) & strUpperOutlierTest & Chr(34), iPosition:=3)
@@ -492,7 +492,7 @@ Public Class dlgClimaticCheckDataRain
         clsUpperListOutlier.AddParameter("sub1", clsRFunctionParameter:=clsUpperOutlierLimitValueCalcFunc, bIncludeArgumentName:=False, iPosition:=0)
 
         'lower Outlier Limit function
-        clsLowerOutlierLimitValueCalcFunc.SetRCommand("instat_calculation$new")
+        clsLowerOutlierLimitValueCalcFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsLowerOutlierLimitValueCalcFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsLowerOutlierLimitValueCalcFunc.AddParameter("function_exp", clsRFunctionParameter:=clsLowerOutlierLimitFunc, iPosition:=1)
         clsLowerOutlierLimitValueCalcFunc.AddParameter("result_name", Chr(34) & strLowerOutlierLimit & Chr(34), iPosition:=4)
@@ -508,7 +508,7 @@ Public Class dlgClimaticCheckDataRain
         clsLowerOutlierOperator.bBrackets = False
         clsLowerOutlierOperator.bToScriptAsRString = True
 
-        clsLowerOutlierlimitTestFunc.SetRCommand("instat_calculation$new")
+        clsLowerOutlierlimitTestFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsLowerOutlierlimitTestFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsLowerOutlierlimitTestFunc.AddParameter("function_exp", clsROperatorParameter:=clsLowerOutlierOperator, iPosition:=1)
         clsLowerOutlierlimitTestFunc.AddParameter("result_name", Chr(34) & strLowerOutlierTest & Chr(34), iPosition:=3)
@@ -530,7 +530,7 @@ Public Class dlgClimaticCheckDataRain
         clsOrOperator.bToScriptAsRString = True
 
         'Dry Month Calculations
-        clsFilterMonthFunction.SetRCommand("instat_calculation$new")
+        clsFilterMonthFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsFilterMonthFunction.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsFilterMonthFunction.AddParameter("function_exp", clsROperatorParameter:=clsInOperator, iPosition:=1)
         clsFilterMonthFunction.SetAssignTo("filter_months")
@@ -544,14 +544,14 @@ Public Class dlgClimaticCheckDataRain
         clsNotOperator.bSpaceAroundOperation = False
         clsNotOperator.AddParameter("space", "", iPosition:=0)
 
-        clsDryMonthCalculationFunc.SetRCommand("instat_calculation$new")
+        clsDryMonthCalculationFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsDryMonthCalculationFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsDryMonthCalculationFunc.AddParameter("function_exp", clsROperatorParameter:=clsDryMonthAndOperator, iPosition:=1)
         clsDryMonthCalculationFunc.AddParameter("manipulations", clsRFunctionParameter:=clsListCalcFunction, iPosition:=3)
         clsDryMonthCalculationFunc.AddParameter("result_name", Chr(34) & strDryMonthCalc & Chr(34), iPosition:=4)
         clsDryMonthCalculationFunc.SetAssignTo("dry_month_calculation")
 
-        clsDayFilterCalcFunction.SetRCommand("instat_calculation$new")
+        clsDayFilterCalcFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsDayFilterCalcFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsDayFilterCalcFunction.AddParameter("function_exp", clsROperatorParameter:=clsDayEqualOperator, iPosition:=1)
         clsDayFilterCalcFunction.AddParameter("manipulations", clsRFunctionParameter:=clsManuplationDayListFunction, iPosition:=3)
@@ -590,7 +590,7 @@ Public Class dlgClimaticCheckDataRain
 
         clsNotIsNaFunction.SetRCommand("!is.na")
 
-        clsDryMonthTestCalculationFunc.SetRCommand("instat_calculation$new")
+        clsDryMonthTestCalculationFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsDryMonthTestCalculationFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsDryMonthTestCalculationFunc.AddParameter("function_exp", clsROperatorParameter:=clsDryTestAndOperator, iPosition:=1)
         clsDryMonthTestCalculationFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsListTestFunction, iPosition:=3)

--- a/instat/dlgClimaticCheckDataTemperature.vb
+++ b/instat/dlgClimaticCheckDataTemperature.vb
@@ -213,7 +213,7 @@ Public Class dlgClimaticCheckDataTemperature
         ucrReceiverElement1.SetMeAsReceiver()
 
         'GroupBy
-        clsGroupByFunc.SetRCommand("instat_calculation$new")
+        clsGroupByFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByFunc.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByFunc.SetAssignTo("grouping")
         clsGroupingListFunc.SetRCommand("list")
@@ -244,7 +244,7 @@ Public Class dlgClimaticCheckDataTemperature
         clsDiffOp.SetOperation("|")
 
         'Group By Month for Outliers 
-        clsGroupByMonth.SetRCommand("instat_calculation$new")
+        clsGroupByMonth.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByMonth.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByMonth.SetAssignTo("grouping_month")
 
@@ -267,7 +267,7 @@ Public Class dlgClimaticCheckDataTemperature
         clsDiffListSubCalc.SetOperation(",")
 
         'Main calculation filter
-        clsCalcFilterFunc.SetRCommand("instat_calculation$new")
+        clsCalcFilterFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsCalcFilterFunc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsCalcFilterFunc.AddParameter("function_exp", clsROperatorParameter:=clsOrOperator, iPosition:=1)
         clsCalcFilterFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clsFilterListFunc, iPosition:=2)

--- a/instat/dlgClimaticLengthOfSeason.vb
+++ b/instat/dlgClimaticLengthOfSeason.vb
@@ -112,7 +112,7 @@ Public Class dlgClimaticLengthOfSeason
         ucrReceiverStartofRains.SetMeAsReceiver()
 
         'length of season calculation
-        clsLengthOfSeasonFunction.SetRCommand("instat_calculation$new")
+        clsLengthOfSeasonFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsLengthOfSeasonFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsLengthOfSeasonFunction.AddParameter("function_exp", clsROperatorParameter:=clsMinusOpertor, iPosition:=1)
         clsLengthOfSeasonFunction.AddParameter("result_name", Chr(34) & strLengthName & Chr(34), iPosition:=2)
@@ -123,7 +123,7 @@ Public Class dlgClimaticLengthOfSeason
         clsMinusOpertor.bToScriptAsRString = True
 
         'start status calculation
-        clsStartEndStatusFunction.SetRCommand("instat_calculation$new")
+        clsStartEndStatusFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsStartEndStatusFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsStartEndStatusFunction.AddParameter("function_exp", clsRFunctionParameter:=clsCaseWhenFunction, iPosition:=1)
         clsStartEndStatusFunction.AddParameter("result_name", Chr(34) & strTypeName & Chr(34), iPosition:=2)
@@ -201,7 +201,7 @@ Public Class dlgClimaticLengthOfSeason
         clsOROperator.bBrackets = False
 
         'combination calculation
-        clsCombinationCalcFunction.SetRCommand("instat_calculation$new")
+        clsCombinationCalcFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsCombinationCalcFunction.AddParameter("type", Chr(34) & "combination" & Chr(34), iPosition:=0)
         clsCombinationCalcFunction.AddParameter("sub_calculation", clsRFunctionParameter:=clsCombinationListFunction, iPosition:=2)
         clsCombinationCalcFunction.SetAssignTo("length_rains_combined")

--- a/instat/dlgClimaticSummary.vb
+++ b/instat/dlgClimaticSummary.vb
@@ -177,7 +177,7 @@ Public Class dlgClimaticSummary
 
         'TODO: this changes to from >= receiver and to <= receiver if annual-variable is checekd.
         clsFromAndToConditionOperator.bToScriptAsRString = True
-        clsDayFilterCalc.SetRCommand("instat_calculation$new")
+        clsDayFilterCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsDayFilterCalc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsDayFilterCalc.AddParameter("function_exp", clsROperatorParameter:=clsFromAndToConditionOperator, iPosition:=1)
         clsDayFilterCalc.AddParameter("calculated_from", clsRFunctionParameter:=clsDayFilterCalcFromConvert, iPosition:=2)

--- a/instat/dlgCompare.vb
+++ b/instat/dlgCompare.vb
@@ -139,11 +139,11 @@ Public Class dlgCompare
         ucrSaveSecondCol.Reset()
 
         'group_by_station_day_of_year
-        clsGroupByStationWithinYear.SetRCommand("instat_calculation$new")
+        clsGroupByStationWithinYear.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByStationWithinYear.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByStationWithinYear.SetAssignTo("grouping")
 
-        clsBiasCalculation.SetRCommand("instat_calculation$new")
+        clsBiasCalculation.SetRCommand("instatCalculations::instat_calculation$new")
         clsBiasCalculation.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsBiasCalculation.AddParameter("function_exp", clsROperatorParameter:=clsDiffOperator, iPosition:=1)
         clsBiasCalculation.AddParameter("result_name", Chr(34) & "bias" & Chr(34), iPosition:=2)
@@ -153,7 +153,7 @@ Public Class dlgCompare
         clsDiffOperator.SetOperation("-")
         clsDiffOperator.bToScriptAsRString = True
 
-        clsAbsDevCalculation.SetRCommand("instat_calculation$new")
+        clsAbsDevCalculation.SetRCommand("instatCalculations::instat_calculation$new")
         clsAbsDevCalculation.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsAbsDevCalculation.AddParameter("function_exp", clsRFunctionParameter:=clsAbsDevFunction, iPosition:=1)
         clsAbsDevCalculation.AddParameter("result_name", Chr(34) & "absdev" & Chr(34), iPosition:=2)
@@ -166,7 +166,7 @@ Public Class dlgCompare
         clsAbsDevFunction.bToScriptAsRString = True
         clsAbsDevFunction.AddParameter("diff", clsROperatorParameter:=clsMinusOperator, bIncludeArgumentName:=False)
 
-        clsCombinedCalculation.SetRCommand("instat_calculation$new")
+        clsCombinedCalculation.SetRCommand("instatCalculations::instat_calculation$new")
         clsCombinedCalculation.AddParameter("type", Chr(34) & "combination" & Chr(34), iPosition:=0)
         clsCombinedCalculation.AddParameter("sub_calculation", clsRFunctionParameter:=clsListFunction, iPosition:=2)
         clsCombinedCalculation.SetAssignTo("combined_calculation")
@@ -178,7 +178,7 @@ Public Class dlgCompare
         clsListManipulation.SetRCommand("list")
 
         'Anomalies calculations
-        clsSateliteAnomalies.SetRCommand("instat_calculation$new")
+        clsSateliteAnomalies.SetRCommand("instatCalculations::instat_calculation$new")
         clsSateliteAnomalies.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsSateliteAnomalies.AddParameter("function_exp", clsROperatorParameter:=clsSateliteMinusOperator, iPosition:=1)
         clsSateliteAnomalies.AddParameter("result_name", Chr(34) & "satellite_anom" & Chr(34), iPosition:=2)
@@ -192,7 +192,7 @@ Public Class dlgCompare
         clsSateliteMeanFunction.SetRCommand("mean")
         clsSateliteMeanFunction.AddParameter("na.rm", "TRUE", iPosition:=1)
 
-        clsStationAnomalies.SetRCommand("instat_calculation$new")
+        clsStationAnomalies.SetRCommand("instatCalculations::instat_calculation$new")
         clsStationAnomalies.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsStationAnomalies.AddParameter("function_exp", clsROperatorParameter:=clsStationMinusOperator, iPosition:=1)
         clsStationAnomalies.AddParameter("result_name", Chr(34) & "station_anom" & Chr(34), iPosition:=2)

--- a/instat/dlgDefineCRI.vb
+++ b/instat/dlgDefineCRI.vb
@@ -113,7 +113,7 @@ Public Class dlgCorruptionDefineCRI
         ucrBase.clsRsyntax.AddParameter("calc", clsRFunctionParameter:=clsDefineFunction)
         ucrBase.clsRsyntax.AddParameter("display", "FALSE")
 
-        clsDefineFunction.SetRCommand("instat_calculation$new")
+        clsDefineFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsDefineFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34))
         clsDefineFunction.AddParameter("save", 2)
         clsDefineFunction.AddParameter("result_name", Chr(34) & ucrSaveCRI.GetText() & Chr(34))

--- a/instat/dlgEndOfRainsSeason.vb
+++ b/instat/dlgEndOfRainsSeason.vb
@@ -504,11 +504,11 @@ Public Class dlgEndOfRainsSeason
         clsDummyFunction.AddParameter("sub3", "True", iPosition:=1)
 
         ' Group by
-        clsGroupByStationYearCalc.SetRCommand("instat_calculation$new")
+        clsGroupByStationYearCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByStationYearCalc.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByStationYearCalc.SetAssignTo("grouping_by_station_year")
 
-        clsGroupByStationCalc.SetRCommand("instat_calculation$new")
+        clsGroupByStationCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByStationCalc.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByStationCalc.SetAssignTo("grouping_by_station")
 
@@ -518,7 +518,7 @@ Public Class dlgEndOfRainsSeason
 
         clsDoyFilterCalcFromList.SetRCommand("list")
 
-        clsDoyFilterCalc.SetRCommand("instat_calculation$new")
+        clsDoyFilterCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsDoyFilterCalc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsDoyFilterCalc.AddParameter("function_exp", clsROperatorParameter:=clsDoyFilterOperator, iPosition:=1)
         clsDoyFilterCalc.AddParameter("calculated_from", clsRFunctionParameter:=clsDoyFilterCalcFromConvert, iPosition:=2)
@@ -539,7 +539,7 @@ Public Class dlgEndOfRainsSeason
 #Region "end_of_rains"
 
         ' Rolling sum calculation
-        clsEndRainsRollingSumCalc.SetRCommand("instat_calculation$new")
+        clsEndRainsRollingSumCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndRainsRollingSumCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsEndRainsRollingSumCalc.AddParameter("function_exp", clsRFunctionParameter:=clsRollSumRainFunction, iPosition:=1)
         clsEndRainsRollingSumCalc.AddParameter("result_name", Chr(34) & strRollSumRain & Chr(34), iPosition:=2)
@@ -553,7 +553,7 @@ Public Class dlgEndOfRainsSeason
         clsRollSumRainFunction.bToScriptAsRString = True
 
         ' Conditions filter
-        clsEndRainsConditionsFilterCalc.SetRCommand("instat_calculation$new")
+        clsEndRainsConditionsFilterCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndRainsConditionsFilterCalc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsEndRainsConditionsFilterCalc.AddParameter("function_exp", clsROperatorParameter:=clsEndRainsConditionsOperator, iPosition:=1)
         clsEndRainsConditionsFilterCalc.AddParameter("sub_calculations", clsRFunctionParameter:=clsEndRainsConditionsFilterSubCalcsList, iPosition:=4)
@@ -575,7 +575,7 @@ Public Class dlgEndOfRainsSeason
         clsIsNaRollSumRain.AddParameter("x", strRollSumRain, iPosition:=0)
 
         ' Doy summary
-        clsEndRainsLastDoySummaryCalc.SetRCommand("instat_calculation$new")
+        clsEndRainsLastDoySummaryCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndRainsLastDoySummaryCalc.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsEndRainsLastDoySummaryCalc.AddParameter("function_exp", clsRFunctionParameter:=clsIfElseLastDoyFunction, iPosition:=1)
         clsEndRainsLastDoySummaryCalc.AddParameter("result_name", Chr(34) & strEndRains & Chr(34), iPosition:=2)
@@ -599,7 +599,7 @@ Public Class dlgEndOfRainsSeason
         clsLastDoyFunction.SetRCommand("last")
 
         ' Date summary
-        clsEndRainsLastDateSummaryCalc.SetRCommand("instat_calculation$new")
+        clsEndRainsLastDateSummaryCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndRainsLastDateSummaryCalc.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsEndRainsLastDateSummaryCalc.AddParameter("function_exp", clsRFunctionParameter:=clsIfElseLastDateFunction, iPosition:=1)
         clsEndRainsLastDateSummaryCalc.AddParameter("result_name", Chr(34) & strEndRainsDate & Chr(34), iPosition:=2)
@@ -617,7 +617,7 @@ Public Class dlgEndOfRainsSeason
         clsLastDateFunction.SetRCommand("last")
 
         ' Status summary
-        clsEndRainsStatusSummaryCalc.SetRCommand("instat_calculation$new")
+        clsEndRainsStatusSummaryCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndRainsStatusSummaryCalc.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsEndRainsStatusSummaryCalc.AddParameter("function_exp", Chr(34) & "n() > 0" & Chr(34), iPosition:=1)
         clsEndRainsStatusSummaryCalc.AddParameter("result_name", Chr(34) & strEndRainsStatus & Chr(34), iPosition:=3)
@@ -625,7 +625,7 @@ Public Class dlgEndOfRainsSeason
         clsEndRainsStatusSummaryCalc.SetAssignTo(strEndRainsStatus)
 
         ' Combined
-        clsEndRainsCombinationCalc.SetRCommand("instat_calculation$new")
+        clsEndRainsCombinationCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndRainsCombinationCalc.AddParameter("type", Chr(34) & "combination" & Chr(34), iPosition:=0)
         clsEndRainsCombinationCalc.AddParameter("manipulations", clsRFunctionParameter:=clsEndRainsCombinationManipulationList, iPosition:=1)
         clsEndRainsCombinationCalc.AddParameter("sub_calculations", clsRFunctionParameter:=clsEndRainsCombinationSubCalcList, iPosition:=2)
@@ -664,7 +664,7 @@ Public Class dlgEndOfRainsSeason
         clsEndSeasonIsNaRain.SetRCommand("is.na")
 
         'Rain min
-        clsEndSeasonRainMinCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonRainMinCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonRainMinCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsEndSeasonRainMinCalc.AddParameter("function_exp", clsRFunctionParameter:=clsIfElseRainMinFunction, iPosition:=1)
         clsEndSeasonRainMinCalc.AddParameter("result_name", Chr(34) & strRainMin & Chr(34), iPosition:=2)
@@ -676,7 +676,7 @@ Public Class dlgEndOfRainsSeason
         clsIfElseRainMinFunction.AddParameter("yes", "0", iPosition:=1)
 
         'Rain max
-        clsEndSeasonRainMaxCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonRainMaxCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonRainMaxCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsEndSeasonRainMaxCalc.AddParameter("function_exp", clsRFunctionParameter:=clsIfElseRainMaxFunction, iPosition:=1)
         clsEndSeasonRainMaxCalc.AddParameter("result_name", Chr(34) & strRainMax & Chr(34), iPosition:=2)
@@ -693,7 +693,7 @@ Public Class dlgEndOfRainsSeason
         clsPMaxFunction.AddParameter("1", "0", bIncludeArgumentName:=False)
 
         ' Water Balance min
-        clsEndSeasonWBMinCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonWBMinCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonWBMinCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsEndSeasonWBMinCalc.AddParameter("function_exp", clsRFunctionParameter:=clsReduceWBMinFunction, iPosition:=1)
         clsEndSeasonWBMinCalc.AddParameter("result_name", Chr(34) & strWBMin & Chr(34), iPosition:=2)
@@ -751,7 +751,7 @@ Public Class dlgEndOfRainsSeason
         clsWBMinEvapOperator.AddParameter("0", strRainMin, iPosition:=0)
 
         ' Water Balance max
-        clsEndSeasonWBMaxCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonWBMaxCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonWBMaxCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsEndSeasonWBMaxCalc.AddParameter("function_exp", clsRFunctionParameter:=clsReduceWBMaxFunction, iPosition:=1)
         clsEndSeasonWBMaxCalc.AddParameter("result_name", Chr(34) & strWBMax & Chr(34), iPosition:=2)
@@ -806,7 +806,7 @@ Public Class dlgEndOfRainsSeason
         clsWBMaxEvapOperator.AddParameter("value", "5", iPosition:=1)
 
         ' Water Balance
-        clsEndSeasonWBCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonWBCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonWBCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsEndSeasonWBCalc.AddParameter("function_exp", clsRFunctionParameter:=clsIfElseWBFunction, iPosition:=1)
         clsEndSeasonWBCalc.AddParameter("result_name", Chr(34) & strWB & Chr(34), iPosition:=2)
@@ -839,7 +839,7 @@ Public Class dlgEndOfRainsSeason
         clsIsNaEvaporation.SetRCommand("is.na")
 
         ' Conditions filter
-        clsEndSeasonConditionsFilterCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonConditionsFilterCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonConditionsFilterCalc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsEndSeasonConditionsFilterCalc.AddParameter("function_exp", clsROperatorParameter:=clsEndSeasonConditionsOperator, iPosition:=1)
         clsEndSeasonConditionsFilterCalc.AddParameter("sub_calculations", clsRFunctionParameter:=clsEndSeasonConditionsFilterSubCalcsList, iPosition:=4)
@@ -858,7 +858,7 @@ Public Class dlgEndOfRainsSeason
         clsEndSeasonWBConditionOperator.AddParameter("1", "0.5", iPosition:=1)
 
         ' Doy summary
-        clsEndSeasonFirstDoySummaryCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonFirstDoySummaryCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonFirstDoySummaryCalc.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsEndSeasonFirstDoySummaryCalc.AddParameter("function_exp", clsRFunctionParameter:=clsIfElseFirstDoyFunction, iPosition:=1)
         clsEndSeasonFirstDoySummaryCalc.AddParameter("result_name", Chr(34) & strEndSeason & Chr(34), iPosition:=2)
@@ -882,7 +882,7 @@ Public Class dlgEndOfRainsSeason
         clsFirstDoyFunction.SetRCommand("first")
 
         ' Date summary
-        clsEndSeasonFirstDateSummaryCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonFirstDateSummaryCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonFirstDateSummaryCalc.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsEndSeasonFirstDateSummaryCalc.AddParameter("function_exp", clsRFunctionParameter:=clsIfElseFirstDateFunction, iPosition:=1)
         clsEndSeasonFirstDateSummaryCalc.AddParameter("result_name", Chr(34) & strEndSeasonDate & Chr(34), iPosition:=2)
@@ -900,7 +900,7 @@ Public Class dlgEndOfRainsSeason
         clsFirstDateFunction.SetRCommand("first")
 
         ' Status summary
-        clsEndSeasonStatusSummaryCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonStatusSummaryCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonStatusSummaryCalc.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsEndSeasonStatusSummaryCalc.AddParameter("function_exp", Chr(34) & "n() > 0" & Chr(34), iPosition:=1)
         clsEndSeasonStatusSummaryCalc.AddParameter("result_name", Chr(34) & strEndSeasonStatus & Chr(34), iPosition:=3)
@@ -908,7 +908,7 @@ Public Class dlgEndOfRainsSeason
         clsEndSeasonStatusSummaryCalc.SetAssignTo(strEndSeasonStatus)
 
         ' Combined
-        clsEndSeasonCombinationCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonCombinationCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonCombinationCalc.AddParameter("type", Chr(34) & "combination" & Chr(34), iPosition:=0)
         clsEndSeasonCombinationCalc.AddParameter("manipulations", clsRFunctionParameter:=clsEndSeasonCombinationManipulationList, iPosition:=1)
         clsEndSeasonCombinationCalc.AddParameter("sub_calculations", clsRFunctionParameter:=clsEndSeasonCombinationSubCalcList, iPosition:=2)

--- a/instat/dlgExtremesClimatic.vb
+++ b/instat/dlgExtremesClimatic.vb
@@ -352,7 +352,7 @@ Public Class dlgExtremesClimatic
 
         ' Days
         clsDayFromAndToOperator.bToScriptAsRString = True
-        clsDayFromAndTo.SetRCommand("instat_calculation$new")
+        clsDayFromAndTo.SetRCommand("instatCalculations::instat_calculation$new")
         clsDayFromAndTo.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsDayFromAndTo.AddParameter("function_exp", clsROperatorParameter:=clsDayFromAndToOperator, iPosition:=1)
         clsDayFromAndToOperator.SetOperation("&")
@@ -368,13 +368,13 @@ Public Class dlgExtremesClimatic
         UpdateDayFilterPreview()
 
         ' For the Min/Max option:
-        clsGroupByFunction.SetRCommand("instat_calculation$new")
+        clsGroupByFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByFunction.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByFunction.SetAssignTo("grouping")
 
         clsMinMaxManipulationsFunction.SetRCommand("list")
         clsMinMaxFuncExp.bToScriptAsRString = True
-        clsMinMaxSummariseFunction.SetRCommand("instat_calculation$new")
+        clsMinMaxSummariseFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsMinMaxSummariseFunction.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsMinMaxSummariseFunction.AddParameter("function_exp", clsRFunctionParameter:=clsMinMaxFuncExp, iPosition:=1)
         clsMinMaxFuncExp.SetRCommand("max")
@@ -389,7 +389,7 @@ Public Class dlgExtremesClimatic
         ' For the Peaks option:
         clsDayManipulation.SetRCommand("list")
         clsPeaksFilterOperator.bToScriptAsRString = True
-        clsPeaksFilterFunction.SetRCommand("instat_calculation$new")
+        clsPeaksFilterFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsPeaksFilterFunction.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsPeaksFilterFunction.AddParameter("function_exp", clsROperatorParameter:=clsPeaksFilterOperator, iPosition:=1)
         clsPeaksFilterOperator.SetOperation(">=") ' this value changes depending what is selected in the combo box. Temp. fix in a sub, but needs a proper fix.
@@ -401,7 +401,7 @@ Public Class dlgExtremesClimatic
         clsPeaksFilterFunction.SetAssignTo("peak_filter")
 
         'Code for carry columns
-        clsCombinationCalc.SetRCommand("instat_calculation$new")
+        clsCombinationCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsCombinationCalc.AddParameter("type", Chr(34) & "combination" & Chr(34), iPosition:=0)
         clsCombinationCalc.AddParameter("sub_calculations", clsRFunctionParameter:=clsCombinationSubCalcs, iPosition:=1)
         clsCombinationCalc.AddParameter("manipulations", clsRFunctionParameter:=clsCombinationManipulations, iPosition:=2)
@@ -418,7 +418,7 @@ Public Class dlgExtremesClimatic
 
         clsDateCarryCalcFromList.SetRCommand("list")
 
-        clsFirstDateSummary.SetRCommand("instat_calculation$new")
+        clsFirstDateSummary.SetRCommand("instatCalculations::instat_calculation$new")
         clsFirstDateSummary.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsFirstDateSummary.AddParameter("function_exp", clsRFunctionParameter:=clsFirstFunction, iPosition:=1)
         clsFirstDateSummary.AddParameter("calculated_from", clsRFunctionParameter:=clsDateCarryCalcFromList, iPosition:=2)
@@ -429,7 +429,7 @@ Public Class dlgExtremesClimatic
         clsFirstFunction.SetRCommand("first")
         clsFirstFunction.bToScriptAsRString = True
 
-        clsLastDateSummary.SetRCommand("instat_calculation$new")
+        clsLastDateSummary.SetRCommand("instatCalculations::instat_calculation$new")
         clsLastDateSummary.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsLastDateSummary.AddParameter("function_exp", clsRFunctionParameter:=clsLastFunction, iPosition:=1)
         clsLastDateSummary.AddParameter("calculated_from", clsRFunctionParameter:=clsDateCarryCalcFromList, iPosition:=2)
@@ -440,7 +440,7 @@ Public Class dlgExtremesClimatic
         clsLastFunction.SetRCommand("last")
         clsLastFunction.bToScriptAsRString = True
 
-        clsNSummary.SetRCommand("instat_calculation$new")
+        clsNSummary.SetRCommand("instatCalculations::instat_calculation$new")
         clsNSummary.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsNSummary.AddParameter("function_exp", clsRFunctionParameter:=clsNFunction, iPosition:=1)
         clsNSummary.AddParameter("calculated_from", clsRFunctionParameter:=clsDateCarryCalcFromList, iPosition:=2)
@@ -450,7 +450,7 @@ Public Class dlgExtremesClimatic
         clsNFunction.SetRCommand("summary_count_all")
         clsNFunction.bToScriptAsRString = True
 
-        clsFilterExtremeCalc.SetRCommand("instat_calculation$new")
+        clsFilterExtremeCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsFilterExtremeCalc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsFilterExtremeCalc.AddParameter("function_exp", clsROperatorParameter:=clsFilterExtremeExp, iPosition:=1)
         clsFilterExtremeCalc.AddParameter("sub_calculations", clsRFunctionParameter:=clsFilterExtremeSubCalcs, iPosition:=2)

--- a/instat/dlgFindNonnumericValues.vb
+++ b/instat/dlgFindNonnumericValues.vb
@@ -116,13 +116,13 @@ Public Class dlgFindNonnumericValues
         clsAsNumericFunction.SetRCommand("as.numeric")
         clsAsNumericFunction.AddParameter("x", clsRFunctionParameter:=clsAsCharacterFunction, bIncludeArgumentName:=False, iPosition:=1)
 
-        clsNonNumericCalcFunc.SetRCommand("instat_calculation$new")
+        clsNonNumericCalcFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsNonNumericCalcFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsNonNumericCalcFunc.AddParameter("function_exp", clsROperatorParameter:=clsNotEqualToOperator, iPosition:=1)
         clsNonNumericCalcFunc.AddParameter("result_name", Chr(34) & strLogicalColumn & Chr(34), iPosition:=3)
         clsNonNumericCalcFunc.AddParameter("save", 2, iPosition:=4)
 
-        clsNonNumericFilterFunc.SetRCommand("instat_calculation$new")
+        clsNonNumericFilterFunc.SetRCommand("instatCalculations::instat_calculation$new")
         clsNonNumericFilterFunc.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsNonNumericFilterFunc.AddParameter("sub_calculations", clsRFunctionParameter:=clslSubCalcListFunc, iPosition:=2)
         clsNonNumericFilterFunc.AddParameter("result_data_frame", Chr(34) & "Filter" & Chr(34), iPosition:=3)

--- a/instat/dlgNewMarkovChains.vb
+++ b/instat/dlgNewMarkovChains.vb
@@ -85,19 +85,19 @@ Public Class dlgNewMarkovChains
         clsIfelseFunction.SetRCommand("ifelse")
 
         clsRunCalcFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$run_instat_calculation")
-        clsWDCalcFunction.SetRCommand("instat_calculation$new")
+        clsWDCalcFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsWDCalcFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34))
 
         clsLagFunction.SetRCommand("lag")
-        clsWDCalcFunction.SetRCommand("instat_calculation$new")
+        clsWDCalcFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsWDCalcFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34))
 
-        clsLagCalcFunction.SetRCommand("instat_calculation$new")
+        clsLagCalcFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsLagCalcFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34))
 
         clsSubCalcsList.SetRCommand("list")
 
-        clsOverallLagCalcFunction.SetRCommand("instat_calculation$new")
+        clsOverallLagCalcFunction.SetRCommand("instatCalculations::instat_calculation$new")
 
         clsFormulaOp.SetOperation("~")
 

--- a/instat/dlgSpells.vb
+++ b/instat/dlgSpells.vb
@@ -182,7 +182,7 @@ Public Class dlgSpells
 
         'DayFromandTo
         clsDayFromAndToOperator.bToScriptAsRString = True
-        clsDayFilter.SetRCommand("instat_calculation$new")
+        clsDayFilter.SetRCommand("instatCalculations::instat_calculation$new")
         clsDayFilter.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsDayFilter.AddParameter("function_exp", clsROperatorParameter:=clsDayFromAndToOperator, iPosition:=1)
         clsDayFromAndToOperator.SetOperation("&")
@@ -197,16 +197,16 @@ Public Class dlgSpells
         clsDayFilter.AddParameter("calculated_from", clsRFunctionParameter:=clsDayFilterCalcFromConvert, iPosition:=2)
 
         ' group
-        clsGroupBy.SetRCommand("instat_calculation$new")
+        clsGroupBy.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupBy.AddParameter("type", Chr(34) & "by" & Chr(34))
         clsGroupBy.SetAssignTo("grouping")
 
-        clsGroupByStation.SetRCommand("instat_calculation$new")
+        clsGroupByStation.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByStation.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByStation.SetAssignTo("group_by_station")
 
         ' rain_day
-        clsSpellLogicalCalc.SetRCommand("instat_calculation$new")
+        clsSpellLogicalCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsSpellLogicalCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsSpellLogicalCalc.AddParameter("function_exp", clsROperatorParameter:=clsSpellLogicalAndOperator, iPosition:=1)
         clsSpellLogicalCalc.AddParameter("result_name", Chr(34) & strSpellLogical & Chr(34), iPosition:=2)
@@ -224,7 +224,7 @@ Public Class dlgSpells
         clsLessThanOperator.SetOperation("<")
 
         ' Spell Length
-        clsSpellLength.SetRCommand("instat_calculation$new")
+        clsSpellLength.SetRCommand("instatCalculations::instat_calculation$new")
         clsSpellLength.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsSpellLength.AddParameter("result_name", Chr(34) & strSpellName & Chr(34), iPosition:=2)
         clsSpellLength.AddParameter("function_exp", clsRFunctionParameter:=clsSpellsFunction)
@@ -236,7 +236,7 @@ Public Class dlgSpells
         clsSpellsManipulationsFunc.SetRCommand("list")
         clsSpellsManipulationsFunc.AddParameter("group_by_year", clsRFunctionParameter:=clsGroupBy, bIncludeArgumentName:=False, iPosition:=0)
 
-        clsSpellsLogicalCalc.SetRCommand("instat_calculation$new")
+        clsSpellsLogicalCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsSpellsLogicalCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsSpellsLogicalCalc.AddParameter("function_exp", clsROperatorParameter:=clsSpellLogicalAndOperator, iPosition:=1)
         clsSpellsLogicalCalc.AddParameter("result_name", Chr(34) & strSpellDay & Chr(34), iPosition:=2)
@@ -245,7 +245,7 @@ Public Class dlgSpells
         clsSpellManipulationsFunc.SetRCommand("list")
         clsSpellManipulationsFunc.AddParameter("group_by_station", clsRFunctionParameter:=clsGroupByStation, bIncludeArgumentName:=False, iPosition:=0)
 
-        'clsSpellsLogCalcFunc.SetRCommand("instat_calculation$new")
+        'clsSpellsLogCalcFunc.SetRCommand("instatCalculations::instat_calculation$new")
         'clsSpellsLogCalcFunc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         'clsSpellsLogCalcFunc.AddParameter("function_exp", clsROperatorParameter:=clsSpellLogicalAndOperator, iPosition:=1)
         'clsSpellsLogCalcFunc.AddParameter("result_name", Chr(34) & strSpellDay & Chr(34), iPosition:=2)
@@ -260,7 +260,7 @@ Public Class dlgSpells
         clsDotSpellsFunction.SetRCommand(".spells")
         clsDotSpellsFunction.AddParameter("x", clsROperatorParameter:=clsSpellLogicalAndOperator, iPosition:=0)
 
-        clsSpellFunction.SetRCommand("instat_calculation$new")
+        clsSpellFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsSpellFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsSpellFunction.AddParameter("function_exp", clsRFunctionParameter:=clsDotSpellsFunction, iPosition:=1) ' changes depending on the rdo
         clsSpellFunction.AddParameter("result_name", Chr(34) & "spell" & Chr(34), iPosition:=2)
@@ -271,7 +271,7 @@ Public Class dlgSpells
         clsRSpellFilterSubFunct.SetRCommand("list")
         clsRSpellFilterSubFunct.AddParameter("sub1", clsRFunctionParameter:=clsSpellFunction, bIncludeArgumentName:=False, iPosition:=0)
 
-        clsSpellFilterFunction.SetRCommand("instat_calculation$new")
+        clsSpellFilterFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsSpellFilterFunction.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsSpellFilterFunction.AddParameter("function_exp", Chr(34) & "dplyr::lead(c(NA,diff(spell)))<0" & Chr(34), iPosition:=1) ' changes depending on the rdo
         clsSpellFilterFunction.AddParameter("sub_calculations", clsRFunctionParameter:=clsRSpellFilterSubFunct, iPosition:=2)
@@ -280,7 +280,7 @@ Public Class dlgSpells
 
         ' Additional Checkbox
         'clsAdditionalConditionReplaceFunction.bToScriptAsRString = True
-        'clsAdditionalCondition.SetRCommand("instat_calculation$new")
+        'clsAdditionalCondition.SetRCommand("instatCalculations::instat_calculation$new")
         'clsAdditionalCondition.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         'clsAdditionalCondition.AddParameter("function_exp", clsRFunctionParameter:=clsAdditionalConditionReplaceFunction, iPosition:=1)
         'clsAdditionalCondition.AddParameter("result_name", Chr(34) & strSpellDay & Chr(34), iPosition:=2)
@@ -294,7 +294,7 @@ Public Class dlgSpells
         'clsAdditionalCondition.AddParameter("sub_calculation", clsRFunctionParameter:=clsAdditionalConditionList)
 
         'Max Summary
-        clsMaxSpellSummary.SetRCommand("instat_calculation$new")
+        clsMaxSpellSummary.SetRCommand("instatCalculations::instat_calculation$new")
         clsMaxSpellSummary.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsMaxSpellSummary.AddParameter("function_exp", clsRFunctionParameter:=clsMaxFunction, iPosition:=1)
         clsMaxSpellSummary.AddParameter("save", 2, iPosition:=6)

--- a/instat/dlgStartofRains.vb
+++ b/instat/dlgStartofRains.vb
@@ -352,7 +352,7 @@ Public Class dlgStartofRains
         clsDummyFunction.AddParameter("additional", "False", iPosition:=2)
 
         'Day From and To
-        clsDayFromAndTo.SetRCommand("instat_calculation$new")
+        clsDayFromAndTo.SetRCommand("instatCalculations::instat_calculation$new")
         clsDayFromAndTo.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsDayFromAndTo.AddParameter("function_exp", clsROperatorParameter:=clsDayFromAndToOperator, iPosition:=1)
         clsDayFromAndTo.AddParameter("calculated_from", clsRFunctionParameter:=clsDayFilterCalcFromConvert, iPosition:=2)
@@ -371,12 +371,12 @@ Public Class dlgStartofRains
         clsDayToOperator.AddParameter("to", 366, iPosition:=1)
 
         ' group_by_station
-        clsGroupByStation.SetRCommand("instat_calculation$new")
+        clsGroupByStation.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByStation.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByStation.SetAssignTo("grouping_by_station")
 
         ' group_by_year
-        clsGroupByYear.SetRCommand("instat_calculation$new")
+        clsGroupByYear.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByYear.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByYear.SetAssignTo("grouping_by_year")
 
@@ -393,7 +393,7 @@ Public Class dlgStartofRains
         clsConvertColumnType1Function.AddParameter("to_type", "year_type", iPosition:=2)
 
         'TOTAL RAIN: associated with ucrChkTotalRainfall
-        clsCalcRainRollingSum.SetRCommand("instat_calculation$new")
+        clsCalcRainRollingSum.SetRCommand("instatCalculations::instat_calculation$new")
         clsCalcRainRollingSum.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsCalcRainRollingSum.AddParameter("function_exp", clsRFunctionParameter:=clsRainRollingSumFunction, iPosition:=1)
         clsCalcRainRollingSum.AddParameter("result_name", Chr(34) & strRollSumRain & Chr(34), iPosition:=2)
@@ -414,7 +414,7 @@ Public Class dlgStartofRains
         clsIsNaFirstRollSumRain.AddParameter("x", clsRFunctionParameter:=clsFirstRollSumRain, iPosition:=0)
 
         ' RAINY DAY associated with ucrChkNumberOfRainyDays
-        clsCalcRainDay.SetRCommand("instat_calculation$new")
+        clsCalcRainDay.SetRCommand("instatCalculations::instat_calculation$new")
         clsCalcRainDay.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsCalcRainDay.AddParameter("function_exp", clsROperatorParameter:=clsRainDayOperator, iPosition:=1)
         clsCalcRainDay.AddParameter("result_name", Chr(34) & strRainDay & Chr(34), iPosition:=2)
@@ -424,7 +424,7 @@ Public Class dlgStartofRains
         clsRainDayOperator.bToScriptAsRString = True
         clsRainDayOperator.AddParameter("threshold", 0.85, iPosition:=1)
 
-        clsCalcRainDayRollingSum.SetRCommand("instat_calculation$new")
+        clsCalcRainDayRollingSum.SetRCommand("instatCalculations::instat_calculation$new")
         clsCalcRainDayRollingSum.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsCalcRainDayRollingSum.AddParameter("function_exp", clsRFunctionParameter:=clsRainDayRollingSumFunction, iPosition:=1)
         clsCalcRainDayRollingSum.AddParameter("result_name", Chr(34) & strRollSumRainDay & Chr(34), iPosition:=2)
@@ -456,7 +456,7 @@ Public Class dlgStartofRains
         clsListToTalRain.SetRCommand("list")
 
         'SOR_Filter
-        clsSORFilter.SetRCommand("instat_calculation$new")
+        clsSORFilter.SetRCommand("instatCalculations::instat_calculation$new")
         clsSORFilter.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsSORFilter.AddParameter("function_exp", clsROperatorParameter:=clsLessFilterOperator, iPosition:=1)
         clsSORFilter.AddParameter("sub_calculations", clsRFunctionParameter:=clsListSubCalc, iPosition:=4)
@@ -482,7 +482,7 @@ Public Class dlgStartofRains
         clsTRWetSpellFunction.bToScriptAsRString = True
         clsTRWetSpellList.SetRCommand("list")
         clsTRWetSpellList.AddParameter("sub1", clsRFunctionParameter:=clsCalcRainRollingSum, bIncludeArgumentName:=False)
-        clsTRWetSpell.SetRCommand("instat_calculation$new")
+        clsTRWetSpell.SetRCommand("instatCalculations::instat_calculation$new")
         clsTRWetSpell.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsTRWetSpell.AddParameter("function_exp", clsRFunctionParameter:=clsTRWetSpellFunction, iPosition:=1)
         clsTRWetSpellFunction.SetRCommand("quantile")
@@ -494,7 +494,7 @@ Public Class dlgStartofRains
         clsTRWetSpell.SetAssignTo("total_rainfall_wet_spell")
 
         'DRY SPELL associated with ucrChkDrySpell
-        clsCalcDrySpell.SetRCommand("instat_calculation$new")
+        clsCalcDrySpell.SetRCommand("instatCalculations::instat_calculation$new")
         clsCalcDrySpell.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsCalcDrySpell.AddParameter("function_exp", clsRFunctionParameter:=clsSpellsFunction, iPosition:=1)
         clsCalcDrySpell.AddParameter("result_name", Chr(34) & strDrySpell & Chr(34), iPosition:=2)
@@ -512,7 +512,7 @@ Public Class dlgStartofRains
         clsRainDaySpellsOperator.AddParameter("0", strRainDay, iPosition:=0)
         clsRainDaySpellsOperator.AddParameter("1", "0", iPosition:=1)
 
-        clsCalcDrySpellRollMax.SetRCommand("instat_calculation$new")
+        clsCalcDrySpellRollMax.SetRCommand("instatCalculations::instat_calculation$new")
         clsCalcDrySpellRollMax.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsCalcDrySpellRollMax.AddParameter("function_exp", clsRFunctionParameter:=clsDrySpellPeriodLeadFunction, iPosition:=1)
         clsCalcDrySpellRollMax.AddParameter("result_name", Chr(34) & strRollMaxDrySpell & Chr(34), iPosition:=2)
@@ -540,7 +540,7 @@ Public Class dlgStartofRains
         clsIsNaFirstDrySpell.SetRCommand("is.na")
         clsIsNaFirstDrySpell.AddParameter("x", clsRFunctionParameter:=clsFirstDrySpell, iPosition:=0)
 
-        clsFractionEvapFunction.SetRCommand("instat_calculation$new")
+        clsFractionEvapFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsFractionEvapFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsFractionEvapFunction.AddParameter("function_exp", clsROperatorParameter:=clsEvapOperator, iPosition:=1)
         clsFractionEvapFunction.AddParameter("result_name", Chr(34) & strFactionEvap & Chr(34), iPosition:=2)
@@ -549,7 +549,7 @@ Public Class dlgStartofRains
         clsEvapOperator.SetOperation("*")
         clsEvapOperator.bToScriptAsRString = True
 
-        clsSumEvapFunction.SetRCommand("instat_calculation$new")
+        clsSumEvapFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsSumEvapFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsSumEvapFunction.AddParameter("function_exp", clsRFunctionParameter:=clsRollEvaporationFunction, iPosition:=1)
         clsSumEvapFunction.AddParameter("result_name", Chr(34) & strSumFractionEvap & Chr(34), iPosition:=2)
@@ -567,7 +567,7 @@ Public Class dlgStartofRains
         clsRollEvaporationFunction.bToScriptAsRString = True
 
         'DRY PERIOD
-        clsCalcRainRollingSumDryPeriod.SetRCommand("instat_calculation$new")
+        clsCalcRainRollingSumDryPeriod.SetRCommand("instatCalculations::instat_calculation$new")
         clsCalcRainRollingSumDryPeriod.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsCalcRainRollingSumDryPeriod.AddParameter("function_exp", clsRFunctionParameter:=clsLeadRollingSumRainDryPeriodFunction, iPosition:=1)
         clsCalcRainRollingSumDryPeriod.AddParameter("result_name", Chr(34) & strRollSumRainDryPeriod & Chr(34), iPosition:=2)
@@ -582,7 +582,7 @@ Public Class dlgStartofRains
         clsRollingSumRainDryPeriodFunction.AddParameter("n", 30, iPosition:=1)
         clsRollingSumRainDryPeriodFunction.AddParameter("fill", "NA", iPosition:=2)
 
-        clsCalcRollSumNumberDryPeriod.SetRCommand("instat_calculation$new")
+        clsCalcRollSumNumberDryPeriod.SetRCommand("instatCalculations::instat_calculation$new")
         clsCalcRollSumNumberDryPeriod.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsCalcRollSumNumberDryPeriod.AddParameter("function_exp", clsRFunctionParameter:=clsRollSumNumberDryPeriodFunction, iPosition:=1)
         clsCalcRollSumNumberDryPeriod.AddParameter("sub_calculations", clsRFunctionParameter:=clsRollSumNumberDryPeriodSubCalcList, iPosition:=4)
@@ -620,7 +620,7 @@ Public Class dlgStartofRains
         clsIsNaFirstDryPeriod.AddParameter("x", clsRFunctionParameter:=clsFirstDryPeriod, iPosition:=0)
 
         ' Combined filter
-        clsConditionsFilter.SetRCommand("instat_calculation$new")
+        clsConditionsFilter.SetRCommand("instatCalculations::instat_calculation$new")
         clsConditionsFilter.AddParameter("type", Chr(34) & "filter" & Chr(34), iPosition:=0)
         clsConditionsFilter.AddParameter("function_exp", clsROperatorParameter:=clsConditionsOrOverallOperator, iPosition:=1)
         clsConditionsFilter.AddParameter("sub_calculations", clsRFunctionParameter:=clsCombinedList, iPosition:=4)
@@ -669,7 +669,7 @@ Public Class dlgStartofRains
         clsDPCombineOperator.AddParameter("dp_max", 0, iPosition:=1)
 
         ' First DOY
-        clsCalcStartDOY.SetRCommand("instat_calculation$new")
+        clsCalcStartDOY.SetRCommand("instatCalculations::instat_calculation$new")
         clsCalcStartDOY.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsCalcStartDOY.AddParameter("function_exp", clsRFunctionParameter:=clsIfelseStartDOY, iPosition:=1)
         clsCalcStartDOY.AddParameter("result_name", Chr(34) & strStartDoy & Chr(34), iPosition:=2)
@@ -696,7 +696,7 @@ Public Class dlgStartofRains
         clsFirstRain.SetRCommand("first")
 
         'First Date
-        clsCalcStartDate.SetRCommand("instat_calculation$new")
+        clsCalcStartDate.SetRCommand("instatCalculations::instat_calculation$new")
         clsCalcStartDate.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsCalcStartDate.AddParameter("function_exp", clsRFunctionParameter:=clsIfelseStartDate, iPosition:=1)
         clsCalcStartDate.AddParameter("result_name", Chr(34) & strStartDate & Chr(34), iPosition:=2)
@@ -715,7 +715,7 @@ Public Class dlgStartofRains
         clsFirstDate.AddParameter("default", "NA", iPosition:=1)
 
         ' Status
-        clsCalcStatus.SetRCommand("instat_calculation$new")
+        clsCalcStatus.SetRCommand("instatCalculations::instat_calculation$new")
         clsCalcStatus.AddParameter("type", Chr(34) & "summary" & Chr(34), iPosition:=0)
         clsCalcStatus.AddParameter("function_exp", clsRFunctionParameter:=clsIfelseStatusFunction, iPosition:=1)
         clsCalcStatus.AddParameter("result_name", Chr(34) & strStartStatus & Chr(34), iPosition:=3)
@@ -741,7 +741,7 @@ Public Class dlgStartofRains
         clsIsNAStatusFunction.AddParameter("x", strRollSumRain, iPosition:=0, bIncludeArgumentName:=False)
 
         'Combination
-        clsCombinationCalc.SetRCommand("instat_calculation$new")
+        clsCombinationCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsCombinationCalc.AddParameter("type", Chr(34) & "combination" & Chr(34), iPosition:=0)
         clsCombinationCalc.AddParameter("manipulations", clsRFunctionParameter:=clsCombinationManipList, iPosition:=1)
         clsCombinationCalc.AddParameter("sub_calculation", clsRFunctionParameter:=clsCombinationSubCalcList, iPosition:=2)

--- a/instat/dlgTransformClimatic.vb
+++ b/instat/dlgTransformClimatic.vb
@@ -176,10 +176,10 @@ Public Class dlgTransformClimatic
         ttRdoGdd.SetToolTip(rdoGrowingDegreeDays, "Growing (or Cooling) Degree Days. If the baseline = 15 degrees, then GDD = (tmean - 15), or 0 if tmean is less than 15")
         ttRdoMgdd.SetToolTip(rdoModifiedGDD, "Modified GDD is just GDD if tmean is less than the upper limit. If baseline = 15 degrees and limit = 30 degrees, then Modified GDD = 30 - 15 if tmean is more than 30 degrees.")
 
-        'ucrPnlTransform.AddParameterValueFunctionNamesCondition(rdoMoving, "sub1", "instat_calculation$new", False) ' clsRRainday
-        'ucrPnlTransform.AddParameterValueFunctionNamesCondition(rdoCount, "sub1", "instat_calculation$new")
-        'ucrPnlTransform.AddParameterValueFunctionNamesCondition(rdoSpell, "sub1", "instat_calculation$new")
-        'ucrPnlTransform.AddParameterValueFunctionNamesCondition(rdoWaterBalance, "sub1", "instat_calculation$new", False)
+        'ucrPnlTransform.AddParameterValueFunctionNamesCondition(rdoMoving, "sub1", "instatCalculations::instat_calculation$new", False) ' clsRRainday
+        'ucrPnlTransform.AddParameterValueFunctionNamesCondition(rdoCount, "sub1", "instatCalculations::instat_calculation$new")
+        'ucrPnlTransform.AddParameterValueFunctionNamesCondition(rdoSpell, "sub1", "instatCalculations::instat_calculation$new")
+        'ucrPnlTransform.AddParameterValueFunctionNamesCondition(rdoWaterBalance, "sub1", "instatCalculations::instat_calculation$new", False)
 
         ' Setting receivers
         ucrReceiverStation.Selector = ucrSelectorTransform
@@ -502,7 +502,7 @@ Public Class dlgTransformClimatic
         clsDoyFilterCalcFromList.Clear()
 
         ' Count and Spells: Rainday
-        clsRRainday.SetRCommand("instat_calculation$new")
+        clsRRainday.SetRCommand("instatCalculations::instat_calculation$new")
         clsRRainday.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsRRainday.AddParameter("function_exp", clsROperatorParameter:=clsRRaindayAndOperator, iPosition:=1)
         clsRRainday.AddParameter("result_name", Chr(34) & strRainDay & Chr(34), iPosition:=2)
@@ -578,11 +578,11 @@ Public Class dlgTransformClimatic
         clsRasterFuction.AddParameter("na.rm", "TRUE", iPosition:=5)
         clsRasterFuction.bToScriptAsRString = True
 
-        clsGroupByStationCalc.SetRCommand("instat_calculation$new")
+        clsGroupByStationCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByStationCalc.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByStationCalc.SetAssignTo("grouping_by_station")
 
-        clsGroupByStationYearCalc.SetRCommand("instat_calculation$new")
+        clsGroupByStationYearCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByStationYearCalc.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByStationYearCalc.SetAssignTo("grouping_by_station_year")
 
@@ -620,7 +620,7 @@ Public Class dlgTransformClimatic
         clsEndSeasonWBConditionOperator.AddParameter("0", strWB, iPosition:=0)
         clsEndSeasonWBConditionOperator.AddParameter("1", "0.5", iPosition:=1)
 
-        clsEndSeasonWBCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonWBCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonWBCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsEndSeasonWBCalc.AddParameter("function_exp", clsRFunctionParameter:=clsRoundFunction, iPosition:=1)
         clsEndSeasonWBCalc.AddParameter("save", "2", iPosition:=2)
@@ -665,14 +665,14 @@ Public Class dlgTransformClimatic
         clsIfElseRainMaxFunction.AddParameter("yes", 100, iPosition:=0)
 
         ' Water Balance min
-        clsEndSeasonWBMinCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonWBMinCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonWBMinCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsEndSeasonWBMinCalc.AddParameter("function_exp", clsRFunctionParameter:=clsReduceWBMinFunction, iPosition:=1)
         clsEndSeasonWBMinCalc.AddParameter("result_name", Chr(34) & strWBMin & Chr(34), iPosition:=2)
         clsEndSeasonWBMinCalc.AddParameter("sub_calculations", clsRFunctionParameter:=clsEndSeasonWBMinCalcSubCalcsList, iPosition:=3)
         clsEndSeasonWBMinCalc.SetAssignTo(strWBMin)
 
-        clsEndSeasonRainMinCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonRainMinCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonRainMinCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsEndSeasonRainMinCalc.AddParameter("function_exp", clsRFunctionParameter:=clsIfElseRainMinFunction, iPosition:=1)
         clsEndSeasonRainMinCalc.AddParameter("result_name", Chr(34) & strRainMin & Chr(34), iPosition:=2)
@@ -739,14 +739,14 @@ Public Class dlgTransformClimatic
         clsWBMinEvapOperator.AddParameter("value", "5", iPosition:=1)
 
         ' Water Balance max
-        clsEndSeasonWBMaxCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonWBMaxCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonWBMaxCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsEndSeasonWBMaxCalc.AddParameter("function_exp", clsRFunctionParameter:=clsReduceWBMaxFunction, iPosition:=1)
         clsEndSeasonWBMaxCalc.AddParameter("result_name", Chr(34) & strWBMax & Chr(34), iPosition:=2)
         clsEndSeasonWBMaxCalc.AddParameter("sub_calculations", clsRFunctionParameter:=clsEndSeasonWBMaxCalcSubCalcsList, iPosition:=3)
         clsEndSeasonWBMaxCalc.SetAssignTo(strWBMax)
 
-        clsEndSeasonRainMaxCalc.SetRCommand("instat_calculation$new")
+        clsEndSeasonRainMaxCalc.SetRCommand("instatCalculations::instat_calculation$new")
         clsEndSeasonRainMaxCalc.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsEndSeasonRainMaxCalc.AddParameter("function_exp", clsRFunctionParameter:=clsIfElseRainMaxFunction, iPosition:=1)
         clsEndSeasonRainMaxCalc.AddParameter("result_name", Chr(34) & strRainMax & Chr(34), iPosition:=2)
@@ -879,12 +879,12 @@ Public Class dlgTransformClimatic
         clsDummyFunction.AddParameter("checked", "rollapply", iPosition:=2)
 
         ' Group options 
-        clsGroupByYear.SetRCommand("instat_calculation$new")
+        clsGroupByYear.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByYear.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByYear.AddParameter("result_name", Chr(34) & "group_by_year" & Chr(34), iPosition:=2)
         clsGroupByYear.SetAssignTo("group_by_year")
 
-        clsGroupByStation.SetRCommand("instat_calculation$new")
+        clsGroupByStation.SetRCommand("instatCalculations::instat_calculation$new")
         clsGroupByStation.AddParameter("type", Chr(34) & "by" & Chr(34), iPosition:=0)
         clsGroupByStation.SetAssignTo("group_by_station")
 
@@ -894,7 +894,7 @@ Public Class dlgTransformClimatic
 
         clsTransformManipulationsFunc.SetRCommand("list")
 
-        clsRTransform.SetRCommand("instat_calculation$new")
+        clsRTransform.SetRCommand("instatCalculations::instat_calculation$new")
         clsRTransform.AddParameter("type", Chr(34) & "calculation" & Chr(34), iPosition:=0)
         clsRTransform.AddParameter("result_name", Chr(34) & "count" & Chr(34), iPosition:=2)
         clsRTransform.AddParameter("sub_calculations", clsRFunctionParameter:=clsRTransformCountSpellSub, iPosition:=4)

--- a/instat/sdgCalculationsSummmary.vb
+++ b/instat/sdgCalculationsSummmary.vb
@@ -291,7 +291,7 @@ Public Class sdgCalculationsSummmary
 
         iSubCalcCount = iSubCalcCount + 1
         strCalcName = "sub_cal" & iSubCalcCount
-        clsSubCalcFunction.SetRCommand("instat_calculation$new")
+        clsSubCalcFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsSubCalcFunction.AddParameter("name", Chr(34) & strCalcName & Chr(34))
         clsSubCalcFunction.AddParameter("type", Chr(34) & "calculation" & Chr(34))
         clsSubCalcFunction.AddParameter("save", "0")
@@ -318,7 +318,7 @@ Public Class sdgCalculationsSummmary
 
         iManipCount = iManipCount + 1
         strCalcName = "manip" & iManipCount
-        clsManipFunction.SetRCommand("instat_calculation$new")
+        clsManipFunction.SetRCommand("instatCalculations::instat_calculation$new")
         clsManipFunction.AddParameter("name", Chr(34) & strCalcName & Chr(34))
         clsManipFunction.AddParameter("type", Chr(34) & "by" & Chr(34))
         clsManipFunction.AddParameter("save", "0")

--- a/instat/static/InstatObject/R/Backend_Components/summary_functions.R
+++ b/instat/static/InstatObject/R/Backend_Components/summary_functions.R
@@ -153,7 +153,7 @@ DataBook$set("public", "calculate_summary", function(data_name, columns_to_summa
     calculated_from <- as.list(manip_factors)
     names(calculated_from) <- rep(data_name, length(manip_factors))
     calculated_from <- as.list(calculated_from)
-    factor_by <- instat_calculation$new(type = "by", calculated_from = calculated_from, param_list = list(drop = drop))
+    factor_by <- instatCalculations::instat_calculation$new(type = "by", calculated_from = calculated_from, param_list = list(drop = drop))
     manipulations <- list(factor_by)
   }
   else manipulations <- list()
@@ -163,7 +163,7 @@ DataBook$set("public", "calculate_summary", function(data_name, columns_to_summa
       calculated_from <- as.list(value_factors)
       names(calculated_from) <- rep(data_name, length(value_factors))
       calculated_from <- as.list(calculated_from)
-      factor_by <- instat_calculation$new(type = "by", calculated_from = calculated_from, param_list = list(drop = drop))
+      factor_by <- instatCalculations::instat_calculation$new(type = "by", calculated_from = calculated_from, param_list = list(drop = drop))
       value_manipulations <- list(factor_by)
     }
     else value_manipulations <- list()
@@ -201,18 +201,18 @@ DataBook$set("public", "calculate_summary", function(data_name, columns_to_summa
       else result_name <- result_names[i,j]
       if(percentage_type == "none") {
         summary_function_exp <- paste0(summary_type, "(x = ", column_names, function_exp)
-        summary_calculation <- instat_calculation$new(type = type, result_name = result_name,
+        summary_calculation <- instatCalculations::instat_calculation$new(type = type, result_name = result_name,
                                                       function_exp = summary_function_exp,
                                                       calculated_from = calculated_from, save = save)
       }
       else {
-        values_calculation <- instat_calculation$new(type = type, result_name = result_name,
+        values_calculation <- instatCalculations::instat_calculation$new(type = type, result_name = result_name,
                                                      function_exp = paste0(summary_type, "(x = ", column_names, function_exp),
                                                      calculated_from = calculated_from, save = save)
         if(percentage_type == "columns") {
           if(length(perc_total_columns) == 1) perc_col_name <- perc_total_columns
           else perc_col_name <- perc_total_columns[i]
-          totals_calculation <- instat_calculation$new(type = type, result_name = paste0(summaries_display[j], sep, perc_total_columns, "_totals"),
+          totals_calculation <- instatCalculations::instat_calculation$new(type = type, result_name = paste0(summaries_display[j], sep, perc_total_columns, "_totals"),
                                                        function_exp = paste0(summary_type, "(x = ", perc_col_name, function_exp),
                                                        calculated_from = calculated_from, save = save)
         }
@@ -221,7 +221,7 @@ DataBook$set("public", "calculate_summary", function(data_name, columns_to_summa
         }
         else if(percentage_type == "factors") {
           values_calculation$manipulations <- value_manipulations
-          totals_calculation <- instat_calculation$new(type = "summary", result_name = paste0(result_name, "_totals"),
+          totals_calculation <- instatCalculations::instat_calculation$new(type = "summary", result_name = paste0(result_name, "_totals"),
                                                        function_exp = paste0(summary_type, "(x = ", column_names, function_exp),
                                                        calculated_from = calculated_from, save = save)
         }
@@ -230,7 +230,7 @@ DataBook$set("public", "calculate_summary", function(data_name, columns_to_summa
           function_exp <- paste0("(", function_exp, ") * 100")
         }
         perc_result_name <- paste0("perc_", result_name)
-        summary_calculation <- instat_calculation$new(type = "calculation", result_name = perc_result_name,
+        summary_calculation <- instatCalculations::instat_calculation$new(type = "calculation", result_name = perc_result_name,
                                                       function_exp = function_exp,
                                                       calculated_from = list(), save = save, sub_calculations = list(totals_calculation, values_calculation))
       }
@@ -246,7 +246,7 @@ DataBook$set("public", "calculate_summary", function(data_name, columns_to_summa
   if(!missing(additional_filter)) {
     manipulations <- c(additional_filter, manipulations)
   }
-  combined_calc_sum <- instat_calculation$new(type="combination", sub_calculations = sub_calculations, manipulations = manipulations)
+  combined_calc_sum <- instatCalculations::instat_calculation$new(type="combination", sub_calculations = sub_calculations, manipulations = manipulations)
 
   # setting up param_list. Here we read in .drop and .preserve
   param_list <- list()

--- a/instat/static/InstatObject/R/data_object_R6.R
+++ b/instat/static/InstatObject/R/data_object_R6.R
@@ -2158,7 +2158,7 @@ DataSheet$set("public", "get_filter_as_instat_calculation", function(filter_name
     calc_from[[length(calc_from) + 1]] <- condition[["column"]]
   }
   names(calc_from) <- rep(self$get_metadata(data_name_label), length(calc_from))
-  calc <- instat_calculation$new(type="filter", function_exp = filter_string, calculated_from = calc_from)
+  calc <- instatCalculations::instat_calculation$new(type="filter", function_exp = filter_string, calculated_from = calc_from)
   return(calc)
 }
 )

--- a/instat/static/InstatObject/R/instat_object_R6.R
+++ b/instat/static/InstatObject/R/instat_object_R6.R
@@ -280,7 +280,7 @@ DataBook$set("public", "clone_instat_calculation", function(curr_instat_calculat
   
   new_manips <- lapply(curr_instat_calculation$manipulations, function(x) self$clone_instat_calculation(x))
   new_subs <- lapply(curr_instat_calculation$sub_calculations, function(x) self$clone_instat_calculation(x))
-  new_instat_calculation <- instat_calculation$new(function_exp = curr_instat_calculation$function_exp, 
+  new_instat_calculation <- instatCalculations::instat_calculation$new(function_exp = curr_instat_calculation$function_exp, 
                                                    type = curr_instat_calculation$type,
                                                    name = curr_instat_calculation$name, 
                                                    result_name = curr_instat_calculation$result_name, 
@@ -2331,12 +2331,12 @@ DataBook$set("public", "crops_definitions", function(data_name, year, station, r
     calc_from[[length(calc_from) + 1]] <- plant_length_name
     calc_from[[length(calc_from) + 1]] <- rain_total_name
     names(calc_from) <- rep(crops_name, length(calc_from))
-    grouping <- instat_calculation$new(type = "by", calculated_from = calc_from)
+    grouping <- instatCalculations::instat_calculation$new(type = "by", calculated_from = calc_from)
     
     if (start_check %in% c("yes", "no")){
       prop_calc_from <- list("overall_cond")
       names(prop_calc_from) <- crops_name
-      propor_table <- instat_calculation$new(function_exp="sum(overall_cond, na.rm = TRUE)/length(na.omit(overall_cond))",
+      propor_table <- instatCalculations::instat_calculation$new(function_exp="sum(overall_cond, na.rm = TRUE)/length(na.omit(overall_cond))",
                                              save = 2, calculated_from = prop_calc_from,
                                              manipulations = list(grouping),
                                              type="summary", result_name = "prop_success", result_data_frame = "crop_prop")
@@ -2352,7 +2352,7 @@ DataBook$set("public", "crops_definitions", function(data_name, year, station, r
     } else {
       prop_calc_from_with_start <- list("overall_cond_with_start")
       names(prop_calc_from_with_start) <- crops_name
-      propor_table_with_start <- instat_calculation$new(function_exp="sum(overall_cond_with_start, na.rm = TRUE)/length(na.omit(overall_cond_with_start))",
+      propor_table_with_start <- instatCalculations::instat_calculation$new(function_exp="sum(overall_cond_with_start, na.rm = TRUE)/length(na.omit(overall_cond_with_start))",
                                                         save = 2, calculated_from = prop_calc_from_with_start,
                                                         manipulations = list(grouping),
                                                         type="summary", result_name = "prop_success", result_data_frame = "crop_prop_with_start")
@@ -2360,7 +2360,7 @@ DataBook$set("public", "crops_definitions", function(data_name, year, station, r
       
       prop_calc_from_no_start <- list("overall_cond_no_start")
       names(prop_calc_from_no_start) <- crops_name
-      propor_table_no_start <- instat_calculation$new(function_exp="sum(overall_cond_no_start, na.rm = TRUE)/length(na.omit(overall_cond_no_start))",
+      propor_table_no_start <- instatCalculations::instat_calculation$new(function_exp="sum(overall_cond_no_start, na.rm = TRUE)/length(na.omit(overall_cond_no_start))",
                                                       save = 2, calculated_from = prop_calc_from_no_start,
                                                       manipulations = list(grouping),
                                                       type="summary", result_name = "prop_success", result_data_frame = "crop_prop_no_start")


### PR DESCRIPTION
I was too anxious to wait, so I tried it out for the `instatCalculations.R` file, and it worked for the testing I did. 

**The method:**
* Removed `instat_calculation` and `calculation` R6 files
* Removed all instances of `instat_calculation$set`, and `calculation$set`
* Replaced all instances of `instat_calculation$new` with `instatCalculations::instat_calculation$new`

**To-do:**

1. Where do we add in the `devtools::install_github("IDEMSInternational/instatCalculations")` line so that we can be sure that it is correctly loaded into R-Instat (presumably in `Rsetup.R`).
2. Where do we add in the `library(instatCalculations)` R code (presumably in `Rsetup.R`)
3. Currently I have set it up that it runs as the function is `instatCalculations::instat_calculation$new` in our dlg R code. We want to separate this out to be 

```
XXX.SetPackageName(instatCalculations)
XXX.SetRCommand(instat_calculation$new)
```

This is just a draft/test illustration of the approach to do this, and a test to see if it works!