### PR TITLE
Ensures the name and version number are displayed in Programs and Features

### DIFF
--- a/inno_install_script_64bit.iss
+++ b/inno_install_script_64bit.iss
@@ -7,8 +7,8 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppVersion= {#GetStringFileInfo("instat\bin\x64\Release\instat.exe", "FileVersion")}
 AppId={{5455FC1A-85BE-4679-B600-8A1A4FC3CDD9-{#SetupSetting("AppVersion")}}
-AppName=R-Instat
-AppVerName ={code:GetShortAppVersion|{#SetupSetting("AppVersion")}}
+AppName=R-Instat {#SetupSetting("AppVersion")}
+AppVerName =R-Instat {#SetupSetting("AppVersion")}
 
 AppPublisher=African Maths Initiative
 AppPublisherURL=http://r-instat.org/


### PR DESCRIPTION
@ChrisMarsh82, the changes I made, do the following

- AppName=R-Instat {#SetupSetting("AppVersion")}: This ensures the name and version number are displayed in Programs and Features as R-Instat 0.7.6 (or whatever version you're using).

- AppVerName=R-Instat {#SetupSetting("AppVersion")}: This ensures the version number is displayed during the installation process (and used for output filenames) as R-Instat 0.7.6.