### PR TITLE
Fixed bug in Append Dialogue

### DIFF
--- a/instat/ucrReceiver.vb
+++ b/instat/ucrReceiver.vb
@@ -475,9 +475,9 @@ Public Class ucrReceiver
                 End If
                 Clear()
                 If lstCurrentVariables IsNot Nothing Then
-                    If Selector IsNot Nothing Then
-                        strTempDataName = Selector.strCurrentDataFrame
-                    End If
+
+                    strTempDataName = If(Selector?.strCurrentDataFrame?.Trim() <> "", Selector.strCurrentDataFrame, "data_names")
+
                     If TypeOf Me Is ucrReceiverMultiple Then
 
                         'TODO This only works if the selector is updated before receivers and dialog only uses one data frame!


### PR DESCRIPTION
Fixes #9352
@rdstern @derekagorhom The issue was in `ucrReceiver.vb` at line 499. When setting or updating the R code, the `SetControlValue` sub is called, which attempts to auto-fill the control.

In the case of a multiple receiver, values are added as a group, typically using a `dataframe` name from the `selector's tag` or the current selector's dataframe name. However, in this dialogue, the selector only contains a list of data names, leading to the anticipated group name being set as `data_names` for values added to the multiple receiver. Have a look.