### PR TITLE
Fixed a bug in the Insert dialog

### DIFF
--- a/instat/dlgScript.Designer.vb
+++ b/instat/dlgScript.Designer.vb
@@ -159,7 +159,7 @@ Partial Class dlgScript
         'rdoFromRFile
         '
         Me.rdoFromRFile.AutoSize = True
-        Me.rdoFromRFile.Location = New System.Drawing.Point(49, 202)
+        Me.rdoFromRFile.Location = New System.Drawing.Point(49, 206)
         Me.rdoFromRFile.Margin = New System.Windows.Forms.Padding(2)
         Me.rdoFromRFile.Name = "rdoFromRFile"
         Me.rdoFromRFile.Size = New System.Drawing.Size(81, 17)
@@ -174,7 +174,7 @@ Partial Class dlgScript
         Me.ucrInputSaveRFile.AutoSize = True
         Me.ucrInputSaveRFile.IsMultiline = False
         Me.ucrInputSaveRFile.IsReadOnly = False
-        Me.ucrInputSaveRFile.Location = New System.Drawing.Point(67, 228)
+        Me.ucrInputSaveRFile.Location = New System.Drawing.Point(67, 231)
         Me.ucrInputSaveRFile.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrInputSaveRFile.Name = "ucrInputSaveRFile"
         Me.ucrInputSaveRFile.Size = New System.Drawing.Size(145, 21)
@@ -259,7 +259,7 @@ Partial Class dlgScript
         '
         Me.ucrChkDisplayGraph.AutoSize = True
         Me.ucrChkDisplayGraph.Checked = False
-        Me.ucrChkDisplayGraph.Location = New System.Drawing.Point(88, 217)
+        Me.ucrChkDisplayGraph.Location = New System.Drawing.Point(88, 225)
         Me.ucrChkDisplayGraph.Margin = New System.Windows.Forms.Padding(6)
         Me.ucrChkDisplayGraph.Name = "ucrChkDisplayGraph"
         Me.ucrChkDisplayGraph.Size = New System.Drawing.Size(113, 34)

--- a/instat/dlgScript.vb
+++ b/instat/dlgScript.vb
@@ -237,6 +237,11 @@ Public Class dlgScript
             ucrInputSaveDataFrame.SetVisible(False)
             ucrChkSaveDataFrameSingle.SetVisible(False)
             ucrPnlSaveDataFrame.SetVisible(False)
+            ucrInputSaveColumn.SetVisible(False)
+            ucrInputDataframeColumn.SetVisible(False)
+            lblSaveColumn.Visible = False
+            lblSaveDataFrame.Visible = False
+            lblSaveText.Visible = False
             SetupSaveDataControl("Column", RObjectTypeLabel.Column, "")
         ElseIf rdoSaveOutputObject.Checked Then
             ucrSaveObject.Location = New Point(ucrSaveObject.Location.X, ucrCboSaveOutputObjectFormat.Location.Y + 33)
@@ -249,6 +254,11 @@ Public Class dlgScript
             ucrCboSaveOutputObjectFormat.SetVisible(True)
             ucrChkSaveDataFrameSingle.SetVisible(False)
             ucrPnlSaveDataFrame.SetVisible(False)
+            ucrInputSaveColumn.SetVisible(False)
+            ucrInputDataframeColumn.SetVisible(False)
+            lblSaveColumn.Visible = False
+            lblSaveDataFrame.Visible = False
+            lblSaveText.Visible = False
             SetupSaveDataControl(ucrCboSaveOutputObjectType.GetText(), dctOutputObjectTypes.Item(ucrCboSaveOutputObjectType.GetText()), dctOutputObjectFormats.Item(ucrCboSaveOutputObjectFormat.GetText()))
         End If
     End Sub


### PR DESCRIPTION
While looking to start working on #8800
I realized the if the from variable checkbox on the savedataframe was still check and you move to a option (say the column option). the textboxes from the variable appear on top on the original textboxes on the new option.
This PR fixes that bug
@rdstern , @N-thony can you review and approve
Thanks