### PR TITLE
Improving summary system for ordered factors

### DIFF
--- a/instat/sdgSummaries.vb
+++ b/instat/sdgSummaries.vb
@@ -217,8 +217,6 @@ Public Class sdgSummaries
         ucrInputComboPropTest.SetDropDownStyleAsNonEditable()
 
         ucrInputPropValue.SetParameter(New RParameter("prop_value", 6))
-        'ucrInputPropValue.SetValidationTypeAsNumeric()
-        'ucrInputPropValue.AddQuotesIfUnrecognised = False
 
         ucrInputComboCountTest.SetParameter(New RParameter("count_test", 7))
         Dim dctCountTest As New Dictionary(Of String, String)
@@ -231,8 +229,6 @@ Public Class sdgSummaries
         ucrInputComboCountTest.SetDropDownStyleAsNonEditable()
 
         ucrInputCountValue.SetParameter(New RParameter("count_value", 8))
-        'ucrInputCountValue.SetValidationTypeAsNumeric()
-        'ucrInputCountValue.AddQuotesIfUnrecognised = False
 
         ucrChkProportion.SetParameter(New RParameter("proportion_calc", 42), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "proportion_calc" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
         ucrChkProportion.SetText("Proportion")
@@ -441,9 +437,7 @@ Public Class sdgSummaries
             ucrPnlPosition.SetRCode(clsDummyFunction, bReset)
         End If
         ucrChkPercentage.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
-        'ucrInputPropValue.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
         ucrInputComboPropTest.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
-        'ucrInputCountValue.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
         ucrInputComboCountTest.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
         ucrInputPercentile.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
         ucrNudFraction.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)

--- a/instat/sdgSummaries.vb
+++ b/instat/sdgSummaries.vb
@@ -217,8 +217,8 @@ Public Class sdgSummaries
         ucrInputComboPropTest.SetDropDownStyleAsNonEditable()
 
         ucrInputPropValue.SetParameter(New RParameter("prop_value", 6))
-        ucrInputPropValue.SetValidationTypeAsNumeric()
-        ucrInputPropValue.AddQuotesIfUnrecognised = False
+        'ucrInputPropValue.SetValidationTypeAsNumeric()
+        'ucrInputPropValue.AddQuotesIfUnrecognised = False
 
         ucrInputComboCountTest.SetParameter(New RParameter("count_test", 7))
         Dim dctCountTest As New Dictionary(Of String, String)
@@ -231,8 +231,8 @@ Public Class sdgSummaries
         ucrInputComboCountTest.SetDropDownStyleAsNonEditable()
 
         ucrInputCountValue.SetParameter(New RParameter("count_value", 8))
-        ucrInputCountValue.SetValidationTypeAsNumeric()
-        ucrInputCountValue.AddQuotesIfUnrecognised = False
+        'ucrInputCountValue.SetValidationTypeAsNumeric()
+        'ucrInputCountValue.AddQuotesIfUnrecognised = False
 
         ucrChkProportion.SetParameter(New RParameter("proportion_calc", 42), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "proportion_calc" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
         ucrChkProportion.SetText("Proportion")
@@ -441,9 +441,9 @@ Public Class sdgSummaries
             ucrPnlPosition.SetRCode(clsDummyFunction, bReset)
         End If
         ucrChkPercentage.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
-        ucrInputPropValue.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
+        'ucrInputPropValue.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
         ucrInputComboPropTest.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
-        ucrInputCountValue.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
+        'ucrInputCountValue.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
         ucrInputComboCountTest.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
         ucrInputPercentile.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
         ucrNudFraction.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
@@ -455,7 +455,6 @@ Public Class sdgSummaries
 
         ucrChkCount.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkProportion.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
-        ucrChkPercentile.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkTrimmedMean.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkNTotal.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkNonMissing.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
@@ -467,6 +466,8 @@ Public Class sdgSummaries
             ucrChkWhichmin.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
             ucrChkWhereMax.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
             ucrChkWhereMin.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
+            ucrChkPercentile.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
+            ucrChkQuantile.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         End If
         ucrChkMode.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkMaximum.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
@@ -508,7 +509,6 @@ Public Class sdgSummaries
         ucrChkMax.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkQ1.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkQ3.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
-        ucrChkQuantile.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkSd.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkVar.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkAngVar.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
@@ -708,4 +708,35 @@ Public Class sdgSummaries
         AddRemoveSummaryWhereY()
         IncludeControlsEnabled()
     End Sub
+
+    Private Sub ucrInputPropValue_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputPropValue.ControlValueChanged, ucrChkProportion.ControlValueChanged
+
+        Dim strValue As String = ucrInputPropValue.GetText()
+
+        If ucrChkProportion.Checked AndAlso Not ucrInputPropValue.IsEmpty Then
+            If IsNumeric(strValue) Then
+                clsDefaultFunction.AddParameter("prop_value", strValue, iPosition:=6)
+            Else
+                clsDefaultFunction.AddParameter("prop_value", Chr(34) & "'" & strValue & "'" & Chr(34), iPosition:=6)
+            End If
+        Else
+            clsDefaultFunction.RemoveParameterByName("prop_value")
+        End If
+    End Sub
+
+    Private Sub ucrInputCountValue_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputCountValue.ControlValueChanged, ucrChkCount.ControlValueChanged
+
+        Dim strValue As String = ucrInputCountValue.GetText()
+
+        If ucrChkCount.Checked AndAlso Not ucrInputCountValue.IsEmpty Then
+            If IsNumeric(strValue) Then
+                clsDefaultFunction.AddParameter("count_value", strValue, iPosition:=8)
+            Else
+                clsDefaultFunction.AddParameter("count_value", Chr(34) & "'" & strValue & "'" & Chr(34), iPosition:=8)
+            End If
+        Else
+            clsDefaultFunction.RemoveParameterByName("count_value")
+        End If
+    End Sub
+
 End Class


### PR DESCRIPTION
Fixes partly #9440 

@rdstern @lilyclements @N-thony , allowed proportion and count input to accept factor labels. If a non-numeric value is entered, quotes are  correctly added. Also fixed a bug where selecting quantile automatically activated the percentile checkbox.