### PR TITLE
Improvements to Prepare > Column: Factor Dialogues 

### DIFF
--- a/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
+++ b/instat/UserControls/DataGrid/ReoGrid/ucrReoGrid.vb
@@ -231,6 +231,12 @@ Public MustInherit Class ucrReoGrid
     Private Function GetCellValue(iRow As Integer, strColumn As String) As String Implements IGrid.GetCellValue
         For i As Integer = 0 To grdData.CurrentWorksheet.ColumnCount - 1
             Dim strColumnHeader As String = grdData.CurrentWorksheet.ColumnHeaders(i).Text
+
+            ' Ensure strColumnHeader is not Nothing before processing
+            If String.IsNullOrEmpty(strColumnHeader) Then
+                Continue For ' Skip this iteration
+            End If
+
             If strColumnHeader.Contains("(") Then
                 strColumnHeader = strColumnHeader.Split("(")(0)
             End If

--- a/instat/clsRecentFiles.vb
+++ b/instat/clsRecentFiles.vb
@@ -211,6 +211,9 @@ Public Class clsRecentFiles
             'Note: Translate both sides of the comparison in case the 2 sides are in different languages.
             '      This is possible if the language was recently changed.
             If GetTranslation(dfTemp.Text) = GetTranslation(DirectCast(sender, ToolStripMenuItem).Text) Then
+                If dfTemp.Name = "dlgReorderLevels" Then
+                    frmMain.SetDefaultValueInReorderLevels()
+                End If
                 dfTemp.ShowDialog()
                 Exit Sub
             End If

--- a/instat/clsRecentFiles.vb
+++ b/instat/clsRecentFiles.vb
@@ -214,6 +214,15 @@ Public Class clsRecentFiles
                 If dfTemp.Name = "dlgReorderLevels" Then
                     frmMain.SetDefaultValueInReorderLevels()
                 End If
+                If dfTemp.Name = "dlgRecodeFactor" Then
+                    frmMain.SetDefaultValueInReorderLevels()
+                End If
+                If dfTemp.Name = "dlgDummyVariables" Then
+                    frmMain.SetDefaultValueInReorderLevels()
+                End If
+                If dfTemp.Name = "dlgLabelsLevels" Then
+                    frmMain.SetDefaultValueInReorderLevels()
+                End If
                 dfTemp.ShowDialog()
                 Exit Sub
             End If

--- a/instat/dlgDummyVariables.vb
+++ b/instat/dlgDummyVariables.vb
@@ -20,6 +20,9 @@ Public Class dlgDummyVariables
     Private bReset As Boolean = True
     Private clsDummyColsFunction As New RFunction
     Private clsDummyFunction As New RFunction
+    Private _strSelectedColumn As String
+
+
     Private Sub dlgIndicatorVariable_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
             InitialiseDialog()
@@ -29,6 +32,7 @@ Public Class dlgDummyVariables
             SetDefaults()
         End If
         SetRCodeForControls(bReset)
+        SetSelectedColumn()
         bReset = False
         TestOkEnabled()
         autoTranslate(Me)
@@ -110,6 +114,30 @@ Public Class dlgDummyVariables
             clsDummyColsFunction.AddParameter("remove_first_dummy", "FALSE", iPosition:=2)
             clsDummyColsFunction.AddParameter("remove_most_frequent_dummy", "TRUE", iPosition:=3)
         End If
+    End Sub
+
+    Public Property SelectedColumn As String
+        Get
+            Return _strSelectedColumn
+        End Get
+        Set(value As String)
+            _strSelectedColumn = value
+        End Set
+    End Property
+
+    Private Sub SetSelectedColumn()
+        Dim strTempSelectedVariable As String = ""
+        Dim strDataName As String = ucrSelectorDummyVariable.strCurrentDataFrame
+        If Not String.IsNullOrEmpty(_strSelectedColumn) AndAlso frmMain.clsRLink.GetDataType(strDataName, _strSelectedColumn).Contains("factor") Then
+            strTempSelectedVariable = _strSelectedColumn
+        ElseIf ucrSelectorDummyVariable.lstAvailableVariable.Items.Count > 0 Then
+            strTempSelectedVariable = ucrSelectorDummyVariable.lstAvailableVariable.Items(0).Text
+        Else
+            ' Handle the case where there are no available variables
+            Exit Sub
+        End If
+
+        ucrReceiverFactor.Add(strTempSelectedVariable, strDataName)
     End Sub
 
     Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverFactor.ControlContentsChanged

--- a/instat/dlgLabelsLevels.vb
+++ b/instat/dlgLabelsLevels.vb
@@ -22,6 +22,7 @@ Public Class dlgLabelsLevels
     Public strSelectedDataFrame As String = ""
     Private bUseSelectedColumn As Boolean = False
     Private strSelectedColumn As String = ""
+    Private _strSelectedColumn As String
 
     Private Sub dlgLabels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
@@ -32,6 +33,7 @@ Public Class dlgLabelsLevels
             SetDefaults()
         End If
         SetRCodeforControls(bReset)
+        SetSelectedColumn()
         bReset = False
         If bUseSelectedColumn Then
             SetDefaultColumn()
@@ -155,6 +157,30 @@ Public Class dlgLabelsLevels
         ucrChkIncludeLevelNumbers.Checked = frmMain.clsRLink.IsVariablesMetadata(
                 ucrReceiverLabels.GetDataName(), "labels", ucrReceiverLabels.GetVariableNames(False))
         ucrChkIncludeLevelNumbers.Enabled = Not ucrChkIncludeLevelNumbers.Checked
+    End Sub
+
+    Public Property SelectedColumn As String
+        Get
+            Return _strSelectedColumn
+        End Get
+        Set(value As String)
+            _strSelectedColumn = value
+        End Set
+    End Property
+
+    Private Sub SetSelectedColumn()
+        Dim strTempSelectedVariable As String = ""
+        Dim strDataName As String = ucrSelectorForLabels.strCurrentDataFrame
+        If Not String.IsNullOrEmpty(_strSelectedColumn) AndAlso frmMain.clsRLink.GetDataType(strDataName, _strSelectedColumn).Contains("factor") Then
+            strTempSelectedVariable = _strSelectedColumn
+        ElseIf ucrSelectorForLabels.lstAvailableVariable.Items.Count > 0 Then
+            strTempSelectedVariable = ucrSelectorForLabels.lstAvailableVariable.Items(0).Text
+        Else
+            ' Handle the case where there are no available variables
+            Exit Sub
+        End If
+
+        ucrReceiverLabels.Add(strTempSelectedVariable, strDataName)
     End Sub
 
     Private Sub ucrFactorLabels_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrFactorLabels.ControlValueChanged, ucrChkIncludeLevelNumbers.ControlValueChanged

--- a/instat/dlgRecodeFactor.vb
+++ b/instat/dlgRecodeFactor.vb
@@ -27,6 +27,7 @@ Public Class dlgRecodeFactor
     Private clsDummyFunction As New RFunction
     Private bReset As Boolean = True
     Private Const strNewLabelColName As String = "New Label"
+    Private _strSelectedColumn As String
 
     Private Sub dlgRecodeFactor_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
@@ -37,6 +38,7 @@ Public Class dlgRecodeFactor
             SetDefaults()
         End If
         SetRCodeforControls(bReset)
+        SetSelectedColumn()
         bReset = False
         autoTranslate(Me)
         TestOKEnabled()
@@ -235,6 +237,30 @@ Public Class dlgRecodeFactor
         ElseIf rdoLump.Checked Then
             ucrBase.OKEnabled(rdoLevels.Checked OrElse rdoCommonValues.Checked OrElse rdoFrequentValues.Checked OrElse rdoMore.Checked)
         End If
+    End Sub
+
+    Public Property SelectedColumn As String
+        Get
+            Return _strSelectedColumn
+        End Get
+        Set(value As String)
+            _strSelectedColumn = value
+        End Set
+    End Property
+
+    Private Sub SetSelectedColumn()
+        Dim strTempSelectedVariable As String = ""
+        Dim strDataName As String = ucrSelectorForRecode.strCurrentDataFrame
+        If Not String.IsNullOrEmpty(_strSelectedColumn) AndAlso frmMain.clsRLink.GetDataType(strDataName, _strSelectedColumn).Contains("factor") Then
+            strTempSelectedVariable = _strSelectedColumn
+        ElseIf ucrSelectorForRecode.lstAvailableVariable.Items.Count > 0 Then
+            strTempSelectedVariable = ucrSelectorForRecode.lstAvailableVariable.Items(0).Text
+        Else
+            ' Handle the case where there are no available variables
+            Exit Sub
+        End If
+
+        ucrReceiverFactor.Add(strTempSelectedVariable, strDataName)
     End Sub
 
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset

--- a/instat/dlgReorderLevels.vb
+++ b/instat/dlgReorderLevels.vb
@@ -34,6 +34,8 @@ Public Class dlgReorderLevels
 
     Private ReadOnly strAscending As String = "Ascending"
     Private ReadOnly strDescending As String = "Descending"
+    Private _strSelectedColumn As String
+
 
     Private Sub dlgReorderLevels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
@@ -44,6 +46,7 @@ Public Class dlgReorderLevels
             SetDefaults()
         End If
         SetRCodeForControls(bReset)
+        SetSelectedColumn()
         bReset = False
         autoTranslate(Me)
     End Sub
@@ -270,6 +273,30 @@ Public Class dlgReorderLevels
                 ucrBase.OKEnabled(False)
             End If
         End If
+    End Sub
+
+    Public Property SelectedColumn As String
+        Get
+            Return _strSelectedColumn
+        End Get
+        Set(value As String)
+            _strSelectedColumn = value
+        End Set
+    End Property
+
+    Private Sub SetSelectedColumn()
+        Dim strTempSelectedVariable As String = ""
+        Dim strDataName As String = ucrSelectorFactorLevelsToReorder.strCurrentDataFrame
+        If Not String.IsNullOrEmpty(_strSelectedColumn) AndAlso frmMain.clsRLink.GetDataType(strDataName, _strSelectedColumn).Contains("factor") Then
+            strTempSelectedVariable = _strSelectedColumn
+        ElseIf ucrSelectorFactorLevelsToReorder.lstAvailableVariable.Items.Count > 0 Then
+            strTempSelectedVariable = ucrSelectorFactorLevelsToReorder.lstAvailableVariable.Items(0).Text
+        Else
+            ' Handle the case where there are no available variables
+            Exit Sub
+        End If
+
+        ucrReceiverFactor.Add(strTempSelectedVariable, strDataName)
     End Sub
 
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -886,6 +886,9 @@ Public Class frmMain
 
     Private Sub mnuTbLast10Dialogs_ButtonClick(sender As Object, e As EventArgs) Handles mnuTbLast10Dialogs.ButtonClick
         If clsRecentItems.lstRecentDialogs.Count > 0 Then
+            If clsRecentItems.lstRecentDialogs.Last.Name = "dlgReorderLevels" Then
+                SetDefaultValueInReorderLevels()
+            End If
             clsRecentItems.lstRecentDialogs.Last.ShowDialog()
         End If
     End Sub
@@ -965,7 +968,18 @@ Public Class frmMain
         dlgConvertColumns.ShowDialog()
     End Sub
 
+    Public Sub SetDefaultValueInReorderLevels()
+        Dim strSelectedColumn As String = ""
+        If Not String.IsNullOrEmpty(ucrColumnMeta.GetFirstSelectedDataframeColumnFromSelectedRow) AndAlso ucrColumnMeta.IsVisible Then
+            strSelectedColumn = ucrColumnMeta.GetFirstSelectedDataframeColumnFromSelectedRow
+        ElseIf Not String.IsNullOrEmpty(ucrDataViewer.GetFirstSelectedColumnName) Then
+            strSelectedColumn = ucrDataViewer.GetFirstSelectedColumnName
+        End If
+        dlgReorderLevels.SelectedColumn = strSelectedColumn
+    End Sub
+
     Private Sub mnuPrepareFactorReorderLevels_Click(sender As Object, e As EventArgs) Handles mnuPrepareColumnFactorReorderLevels.Click
+        SetDefaultValueInReorderLevels()
         dlgReorderLevels.ShowDialog()
     End Sub
 

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -889,6 +889,15 @@ Public Class frmMain
             If clsRecentItems.lstRecentDialogs.Last.Name = "dlgReorderLevels" Then
                 SetDefaultValueInReorderLevels()
             End If
+            If clsRecentItems.lstRecentDialogs.Last.Name = "dlgRecodeFactor" Then
+                SetDefaultValueInReorderLevels()
+            End If
+            If clsRecentItems.lstRecentDialogs.Last.Name = "dlgDummyVariables" Then
+                SetDefaultValueInReorderLevels()
+            End If
+            If clsRecentItems.lstRecentDialogs.Last.Name = "dlgLabelsLevels" Then
+                SetDefaultValueInReorderLevels()
+            End If
             clsRecentItems.lstRecentDialogs.Last.ShowDialog()
         End If
     End Sub
@@ -932,6 +941,7 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuPrepareFactorRecode_Click(sender As Object, e As EventArgs) Handles mnuPrepareColumnFactorRecodeFactor.Click
+        SetDefaultValueInReorderLevels()
         dlgRecodeFactor.ShowDialog()
     End Sub
 
@@ -960,6 +970,7 @@ Public Class frmMain
     End Sub
 
     Private Sub mnuPrepareFactorLabel_Click(sender As Object, e As EventArgs) Handles mnuPrepareColumnFactorLevelsLabels.Click
+        SetDefaultValueInReorderLevels()
         dlgLabelsLevels.ShowDialog()
     End Sub
 
@@ -976,6 +987,9 @@ Public Class frmMain
             strSelectedColumn = ucrDataViewer.GetFirstSelectedColumnName
         End If
         dlgReorderLevels.SelectedColumn = strSelectedColumn
+        dlgRecodeFactor.SelectedColumn = strSelectedColumn
+        dlgDummyVariables.SelectedColumn = strSelectedColumn
+        dlgLabelsLevels.SelectedColumn = strSelectedColumn
     End Sub
 
     Private Sub mnuPrepareFactorReorderLevels_Click(sender As Object, e As EventArgs) Handles mnuPrepareColumnFactorReorderLevels.Click

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -341,7 +341,11 @@ Public Class ucrColumnMetadata
         Cursor = Cursors.Default
     End Sub
 
-    Private Function GetFirstSelectedDataframeColumnFromSelectedRow() As String
+    Public Function IsVisible() As Boolean
+        Return _grid.bVisible
+    End Function
+
+    Public Function GetFirstSelectedDataframeColumnFromSelectedRow() As String
         Return _grid.GetCellValue(_grid.GetSelectedRows(0) - 1, strNameLabel)
     End Function
 

--- a/instat/ucrDataView.vb
+++ b/instat/ucrDataView.vb
@@ -506,7 +506,7 @@ Public Class ucrDataView
         Return GetSelectedColumns().Select(Function(x) x.strName).ToList()
     End Function
 
-    Private Function GetFirstSelectedColumnName() As String
+    Public Function GetFirstSelectedColumnName() As String
         Return GetSelectedColumns().FirstOrDefault().strName
     End Function
 


### PR DESCRIPTION
Fixes partly #9451 
Replaces #9489
This is the continuation of work done in #9474 
The dialogues with the new changes are;
Recode Factor 
Dummy Variable and 
Levels/Labels

@rdstern , @N-thony this is ready for review.

@berylwaswa, In this PR the column which will appear on the Receiver when the dialog is closed and reopened do not come from the variable click on the selector but rather from focus on the main grid itself. So you choose any of the factor columns on the reogrid then you select any of dialogues above and that column should appear in the receiver.
I hope that makes sense to you