### PR TITLE
Fixed feature of shortening names in multiple receivers not being consistent

### DIFF
--- a/instat/ucrReceiverMultiple.vb
+++ b/instat/ucrReceiverMultiple.vb
@@ -524,12 +524,6 @@ Public Class ucrReceiverMultiple
         CheckSingleType()
     End Sub
 
-    Private Sub lstSelectedVariables_ClientSizeChanged(ByVal sender As Object, ByVal e As EventArgs) Handles lstSelectedVariables.ClientSizeChanged
-        If lstSelectedVariables.Columns.Count > 0 Then
-            lstSelectedVariables.Columns(0).Width = lstSelectedVariables.ClientSize.Width
-        End If
-    End Sub
-
     Private Sub ucrReceiverMultiple_SelectionChanged(sender As Object, e As EventArgs) Handles Me.SelectionChanged
         CheckSingleType()
     End Sub


### PR DESCRIPTION
Fixes #9497 
This should fix the problem of the shortening names feature not being inconsistent in the multiple receivers
@rdstern , @N-thony can you review this 
Thanks 