### PR TITLE
adding help numbers 

### DIFF
--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -1148,7 +1148,7 @@ Public Class dlgDescribeTwoVariable
             If IsFactorByFactor() Then
                 clsSummaryTableFunction.AddParameter("factors", "c(" & ucrReceiverSecondTwoVariableFactor.GetVariableNames & "," & ".x" & ")")
                 clsSummaryTableFunction.AddParameter("columns_to_summarise", ".x")
-                clsPivotWiderFunction.AddParameter("names_from", "{{ .x }}", iPosition:=1)
+                clsPivotWiderFunction.AddParameter("names_from", ucrReceiverSecondTwoVariableFactor.GetVariableNames(bWithQuotes:=False), iPosition:=1)
             ElseIf IsFactorByNumeric() Then
                 clsSummaryTableFunction.AddParameter("factors", ".x")
                 clsPivotWiderFunction.AddParameter("names_from", "{{ .x }}", iPosition:=1)

--- a/instat/dlgImportClimMob.vb
+++ b/instat/dlgImportClimMob.vb
@@ -44,6 +44,7 @@ Public Class dlgImportfromClimMob
 
     Private Sub InitialiseDialog()
 
+        ucrBase.iHelpTopicID = 650
         ucrInputServerName.SetItems({strClimmob3, str1000FARMS, strAVISA, strRTB})
         ucrInputServerName.SetDropDownStyleAsNonEditable()
         ucrInputServerName.SetLinkedDisplayControl(lblServerName)

--- a/instat/dlgTraitCorrelations.vb
+++ b/instat/dlgTraitCorrelations.vb
@@ -38,6 +38,7 @@ Public Class dlgTraitCorrelations
 
     Private Sub InitialiseDialog()
 
+        ucrBase.iHelpTopicID = 703
         ucrReceiverTrait.SetParameterIsRFunction()
         ucrReceiverTrait.Selector = ucrSelecetorTraits
 

--- a/instat/dlgTraits.vb
+++ b/instat/dlgTraits.vb
@@ -37,6 +37,8 @@ Public Class dlgTraits
     End Sub
 
     Private Sub InitialiseDialog()
+
+        ucrBase.iHelpTopicID = 701
         ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
         ucrBase.clsRsyntax.iCallType = 3
 

--- a/instat/sdgImportFromClimMob.vb
+++ b/instat/sdgImportFromClimMob.vb
@@ -24,6 +24,8 @@ Public Class sdgImportFromClimMob
     End Sub
 
     Public Sub Setup(clsNewKeyParameter As RParameter)
+
+        ucrBaseSubdialog.iHelpTopicID = 716
         ucrInputKeyPath.SetParameter(clsNewKeyParameter, 0)
     End Sub
 


### PR DESCRIPTION
Added Help Page Links and Fixed Display in Summary Dialog

 Linked help pages to the following dialogs and sub-dialog:
    dlgTraits (701)
    dlgClimBoxCorrelations (703)
    dlgImportClimOb (650)
    sdgImport (716)

Corrected display logic in the 2/3-Way Summary dialog (`dlgDescribeTwoVariable`) under the Describe menu:
    Ensured correct alignment of row and column variables in summary tables
    Fixed mapping of receiver variable (`.x`) to match expected R output

Note: This change includes cleanup after help ID mix-up from earlier commit #9551.
