### PR TITLE
changes in the help page links and 2/3 summarize table

### DIFF
--- a/instat/DlgDefineClimaticData.vb
+++ b/instat/DlgDefineClimaticData.vb
@@ -46,7 +46,7 @@ Public Class DlgDefineClimaticData
     End Sub
 
     Private Sub InitialiseDialog()
-        ucrBase.iHelpTopicID = 328
+        ucrBase.iHelpTopicID = 672
         Dim kvpRain As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("rain", {"rain", "prec", "rr", "prcp"}.ToList())
         Dim kvpDate As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("date", {"date", "record"}.ToList())
         Dim kvpStation As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("station", {"station", "id", "name"}.ToList())

--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -1148,7 +1148,7 @@ Public Class dlgDescribeTwoVariable
             If IsFactorByFactor() Then
                 clsSummaryTableFunction.AddParameter("factors", "c(" & ucrReceiverSecondTwoVariableFactor.GetVariableNames & "," & ".x" & ")")
                 clsSummaryTableFunction.AddParameter("columns_to_summarise", ".x")
-                clsPivotWiderFunction.AddParameter("names_from", "{{ .x }}", iPosition:=1)
+                clsPivotWiderFunction.AddParameter("names_from", ucrReceiverSecondTwoVariableFactor.GetVariableNames(bWithQuotes:=False), iPosition:=1)
             ElseIf IsFactorByNumeric() Then
                 clsSummaryTableFunction.AddParameter("factors", ".x")
                 clsPivotWiderFunction.AddParameter("names_from", "{{ .x }}", iPosition:=1)

--- a/instat/dlgImportClimMob.Designer.vb
+++ b/instat/dlgImportClimMob.Designer.vb
@@ -35,9 +35,9 @@ Partial Class dlgImportfromClimMob
         '
         'cmdFindForms
         '
-        Me.cmdFindForms.Location = New System.Drawing.Point(26, 89)
+        Me.cmdFindForms.Location = New System.Drawing.Point(27, 91)
         Me.cmdFindForms.Name = "cmdFindForms"
-        Me.cmdFindForms.Size = New System.Drawing.Size(102, 23)
+        Me.cmdFindForms.Size = New System.Drawing.Size(100, 23)
         Me.cmdFindForms.TabIndex = 9
         Me.cmdFindForms.Text = "Find Forms"
         Me.cmdFindForms.UseVisualStyleBackColor = True
@@ -51,7 +51,7 @@ Partial Class dlgImportfromClimMob
         Me.ucrInputChooseForm.Location = New System.Drawing.Point(139, 91)
         Me.ucrInputChooseForm.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
         Me.ucrInputChooseForm.Name = "ucrInputChooseForm"
-        Me.ucrInputChooseForm.Size = New System.Drawing.Size(167, 21)
+        Me.ucrInputChooseForm.Size = New System.Drawing.Size(167, 23)
         Me.ucrInputChooseForm.TabIndex = 11
         '
         'ucrBase
@@ -66,9 +66,9 @@ Partial Class dlgImportfromClimMob
         '
         'lblServerName
         '
-        Me.lblServerName.Location = New System.Drawing.Point(26, 54)
+        Me.lblServerName.Location = New System.Drawing.Point(27, 54)
         Me.lblServerName.Name = "lblServerName"
-        Me.lblServerName.Size = New System.Drawing.Size(112, 21)
+        Me.lblServerName.Size = New System.Drawing.Size(111, 21)
         Me.lblServerName.TabIndex = 7
         Me.lblServerName.Text = "Server Name:"
         '
@@ -87,7 +87,7 @@ Partial Class dlgImportfromClimMob
         Me.ucrInputServerName.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputServerName.GetSetSelectedIndex = -1
         Me.ucrInputServerName.IsReadOnly = False
-        Me.ucrInputServerName.Location = New System.Drawing.Point(140, 54)
+        Me.ucrInputServerName.Location = New System.Drawing.Point(139, 54)
         Me.ucrInputServerName.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
         Me.ucrInputServerName.Name = "ucrInputServerName"
         Me.ucrInputServerName.Size = New System.Drawing.Size(167, 21)
@@ -96,10 +96,10 @@ Partial Class dlgImportfromClimMob
         'ucrSaveFile
         '
         Me.ucrSaveFile.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveFile.Location = New System.Drawing.Point(5, 188)
+        Me.ucrSaveFile.Location = New System.Drawing.Point(27, 188)
         Me.ucrSaveFile.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrSaveFile.Name = "ucrSaveFile"
-        Me.ucrSaveFile.Size = New System.Drawing.Size(385, 22)
+        Me.ucrSaveFile.Size = New System.Drawing.Size(375, 22)
         Me.ucrSaveFile.TabIndex = 30
         '
         'ucrChkDefineTricotData
@@ -114,10 +114,10 @@ Partial Class dlgImportfromClimMob
         '
         'cmdTricotData
         '
-        Me.cmdTricotData.Location = New System.Drawing.Point(140, 142)
+        Me.cmdTricotData.Location = New System.Drawing.Point(139, 142)
         Me.cmdTricotData.Margin = New System.Windows.Forms.Padding(2)
         Me.cmdTricotData.Name = "cmdTricotData"
-        Me.cmdTricotData.Size = New System.Drawing.Size(109, 23)
+        Me.cmdTricotData.Size = New System.Drawing.Size(167, 23)
         Me.cmdTricotData.TabIndex = 32
         Me.cmdTricotData.Text = "Options"
         Me.cmdTricotData.UseVisualStyleBackColor = True

--- a/instat/dlgImportClimMob.vb
+++ b/instat/dlgImportClimMob.vb
@@ -44,6 +44,7 @@ Public Class dlgImportfromClimMob
 
     Private Sub InitialiseDialog()
 
+        ucrBase.iHelpTopicID = 650
         ucrInputServerName.SetItems({strClimmob3, str1000FARMS, strAVISA, strRTB})
         ucrInputServerName.SetDropDownStyleAsNonEditable()
         ucrInputServerName.SetLinkedDisplayControl(lblServerName)

--- a/instat/dlgImportClimMob.vb
+++ b/instat/dlgImportClimMob.vb
@@ -164,11 +164,7 @@ Public Class dlgImportfromClimMob
             clsThirdOperator.AddParameter("right", Chr(34) & ucrInputChooseForm.GetText & Chr(34))
         End If
     End Sub
-
-    Private Sub ucrBase_Load(sender As Object, e As EventArgs) Handles ucrBase.Load
-
-    End Sub
-
+    
     Private Sub cmdChooseFile_Click(sender As Object, e As EventArgs) Handles cmdKey.Click
         sdgImportFromClimMob.Setup(clsKeysFunction.GetParameter("key"))
         sdgImportFromClimMob.ShowDialog()

--- a/instat/dlgImportClimMob.vb
+++ b/instat/dlgImportClimMob.vb
@@ -87,7 +87,7 @@ Public Class dlgImportfromClimMob
 
         clsFirstOperator.SetOperation("$")
         clsFirstOperator.AddParameter("left", clsRFunctionParameter:=clsProjectsFunction, iPosition:=0)
-        clsFirstOperator.AddParameter("right", "project_id", iPosition:=1)
+        clsFirstOperator.AddParameter("right", "project_code", iPosition:=1)
         clsFirstOperator.bSpaceAroundOperation = False
 
         clsSecondOperator.SetOperation("%>%")
@@ -97,7 +97,7 @@ Public Class dlgImportfromClimMob
         clsSecondOperator.SetAssignTo("user_owner")
 
         clsThirdOperator.SetOperation("==")
-        clsThirdOperator.AddParameter("left", "project_id", iPosition:=0)
+        clsThirdOperator.AddParameter("left", "project_code", iPosition:=0)
         clsThirdOperator.AddParameter("right", Chr(34) & ucrInputChooseForm.GetText & Chr(34), iPosition:=1) ' right = value in the ucrInputBox
         clsThirdOperator.bSpaceAroundOperation = False
 
@@ -163,6 +163,10 @@ Public Class dlgImportfromClimMob
         Else
             clsThirdOperator.AddParameter("right", Chr(34) & ucrInputChooseForm.GetText & Chr(34))
         End If
+    End Sub
+
+    Private Sub ucrBase_Load(sender As Object, e As EventArgs) Handles ucrBase.Load
+
     End Sub
 
     Private Sub cmdChooseFile_Click(sender As Object, e As EventArgs) Handles cmdKey.Click

--- a/instat/dlgTraitCorrelations.vb
+++ b/instat/dlgTraitCorrelations.vb
@@ -38,6 +38,7 @@ Public Class dlgTraitCorrelations
 
     Private Sub InitialiseDialog()
 
+        ucrBase.iHelpTopicID = 703
         ucrReceiverTrait.SetParameterIsRFunction()
         ucrReceiverTrait.Selector = ucrSelecetorTraits
 

--- a/instat/dlgTraits.vb
+++ b/instat/dlgTraits.vb
@@ -37,6 +37,8 @@ Public Class dlgTraits
     End Sub
 
     Private Sub InitialiseDialog()
+
+        ucrBase.iHelpTopicID = 701
         ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
         ucrBase.clsRsyntax.iCallType = 3
 

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -3566,6 +3566,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="sdgImportFromClimMob.resx">
       <DependentUpon>sdgImportFromClimMob.vb</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="sdgLocation.resx">
       <DependentUpon>sdgLocation.vb</DependentUpon>

--- a/instat/sdgImportFromClimMob.vb
+++ b/instat/sdgImportFromClimMob.vb
@@ -25,7 +25,7 @@ Public Class sdgImportFromClimMob
 
     Public Sub Setup(clsNewKeyParameter As RParameter)
 
-        ucrBaseSubdialog.iHelpTopicID = 716
+        ucrBaseSubdialog.iHelpTopicID = 715
         ucrInputKeyPath.SetParameter(clsNewKeyParameter, 0)
     End Sub
 

--- a/instat/sdgImportFromClimMob.vb
+++ b/instat/sdgImportFromClimMob.vb
@@ -24,6 +24,8 @@ Public Class sdgImportFromClimMob
     End Sub
 
     Public Sub Setup(clsNewKeyParameter As RParameter)
+
+        ucrBaseSubdialog.iHelpTopicID = 716
         ucrInputKeyPath.SetParameter(clsNewKeyParameter, 0)
     End Sub
 

--- a/instat/sdgImportFromClimMob.vb
+++ b/instat/sdgImportFromClimMob.vb
@@ -24,8 +24,7 @@ Public Class sdgImportFromClimMob
     End Sub
 
     Public Sub Setup(clsNewKeyParameter As RParameter)
-
-        ucrBaseSubdialog.iHelpTopicID = 715
+        ucrBaseSubdialog.iHelpTopicID = 716
         ucrInputKeyPath.SetParameter(clsNewKeyParameter, 0)
     End Sub
 


### PR DESCRIPTION
@lilyclements Added Help Page Links and Fixed Display in Summary Dialog

- Linked help pages to the following dialogs and sub-dialog:
    dlgTraits (701)
    dlgClimBoxCorrelations (703)
    dlgImportClimOb (650)
    sdgImport (716)
    changed the define 328  to 672

- Corrected display logic in the 2/3-Way Summary dialog (`dlgDescribeTwoVariable`) under the Describe menu:
    • Ensured correct alignment of row and column variables in summary tables
    • Fixed mapping of receiver variable (`.x`) to match expected R output

Note: This change includes cleanup after help ID mix-up from earlier commit #9551.
