### PR TITLE
Refined Help Menu 2. Added 2 extra elements in Tricot 3. Added new menu Tidy 4. Deleted "Genotype Data"

### DIFF
--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -177,11 +177,6 @@ Partial Class frmMain
         Me.PrepareToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.DescribeToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ModelToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ToolStripSeparator83 = New System.Windows.Forms.ToolStripSeparator()
-        Me.StructuredToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ClimaticToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ProcurementToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ExperimentsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ViewToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuHelpAboutR = New System.Windows.Forms.ToolStripMenuItem()
@@ -748,6 +743,13 @@ Partial Class frmMain
         Me.DuplicatesKeyVariableCheckToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.TwoThreeVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.GraphSummariseToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.OptionalMenuToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.StructuredToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ClimaticToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ProcurementToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ExperimentsToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
+        Me.TricotMenuToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.TricotXPMenuToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.stsStrip.SuspendLayout()
         Me.Tool_strip.SuspendLayout()
         Me.mnuBar.SuspendLayout()
@@ -1631,7 +1633,7 @@ Partial Class frmMain
         '
         'mnuHelp
         '
-        Me.mnuHelp.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuHelpHelpIntroduction, Me.mnuHelpFAQ, Me.mnuHelpGetingStarted, Me.mnuHelpData, Me.ToolStripSeparator28, Me.mnuHelpWindows, Me.ToolStripSeparator81, Me.mnuHelpMenus, Me.mnuHelpAboutR, Me.mnuHelpLearningStatistics, Me.mnuHelpRPackages, Me.mnuHelpGlossary, Me.mnuHelpLicence, Me.ToolStripSeparator29, Me.mnuHelpResourcesSite, Me.mnuHelpPackagesDocumentation})
+        Me.mnuHelp.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuHelpHelpIntroduction, Me.mnuHelpFAQ, Me.mnuHelpGetingStarted, Me.mnuHelpData, Me.ToolStripSeparator28, Me.mnuHelpWindows, Me.ToolStripSeparator81, Me.mnuHelpMenus, Me.OptionalMenuToolStripMenuItem, Me.mnuHelpAboutR, Me.mnuHelpLearningStatistics, Me.mnuHelpRPackages, Me.mnuHelpGlossary, Me.mnuHelpLicence, Me.ToolStripSeparator29, Me.mnuHelpResourcesSite, Me.mnuHelpPackagesDocumentation})
         Me.mnuHelp.Name = "mnuHelp"
         Me.mnuHelp.Size = New System.Drawing.Size(44, 22)
         Me.mnuHelp.Tag = "Help"
@@ -1679,10 +1681,10 @@ Partial Class frmMain
         '
         'mnuHelpMenus
         '
-        Me.mnuHelpMenus.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.MenusAndDialogsToolStripMenuItem, Me.ToolStripSeparator82, Me.FileToolStripMenuItem, Me.EditToolStripMenuItem, Me.PrepareToolStripMenuItem, Me.DescribeToolStripMenuItem, Me.ModelToolStripMenuItem, Me.ToolStripSeparator83, Me.StructuredToolStripMenuItem, Me.ClimaticToolStripMenuItem, Me.ProcurementToolStripMenuItem, Me.ExperimentsToolStripMenuItem, Me.ToolsToolStripMenuItem, Me.ViewToolStripMenuItem})
+        Me.mnuHelpMenus.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.MenusAndDialogsToolStripMenuItem, Me.ToolStripSeparator82, Me.FileToolStripMenuItem, Me.EditToolStripMenuItem, Me.PrepareToolStripMenuItem, Me.DescribeToolStripMenuItem, Me.ModelToolStripMenuItem, Me.ToolsToolStripMenuItem, Me.ViewToolStripMenuItem})
         Me.mnuHelpMenus.Name = "mnuHelpMenus"
         Me.mnuHelpMenus.Size = New System.Drawing.Size(239, 22)
-        Me.mnuHelpMenus.Text = "Menus and Dialogs"
+        Me.mnuHelpMenus.Text = "Menu"
         '
         'MenusAndDialogsToolStripMenuItem
         '
@@ -1724,35 +1726,6 @@ Partial Class frmMain
         Me.ModelToolStripMenuItem.Name = "ModelToolStripMenuItem"
         Me.ModelToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.ModelToolStripMenuItem.Text = "Model..."
-        '
-        'ToolStripSeparator83
-        '
-        Me.ToolStripSeparator83.Name = "ToolStripSeparator83"
-        Me.ToolStripSeparator83.Size = New System.Drawing.Size(181, 6)
-        '
-        'StructuredToolStripMenuItem
-        '
-        Me.StructuredToolStripMenuItem.Name = "StructuredToolStripMenuItem"
-        Me.StructuredToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
-        Me.StructuredToolStripMenuItem.Text = "Structured..."
-        '
-        'ClimaticToolStripMenuItem
-        '
-        Me.ClimaticToolStripMenuItem.Name = "ClimaticToolStripMenuItem"
-        Me.ClimaticToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
-        Me.ClimaticToolStripMenuItem.Text = "Climatic..."
-        '
-        'ProcurementToolStripMenuItem
-        '
-        Me.ProcurementToolStripMenuItem.Name = "ProcurementToolStripMenuItem"
-        Me.ProcurementToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
-        Me.ProcurementToolStripMenuItem.Text = "Procurement..."
-        '
-        'ExperimentsToolStripMenuItem
-        '
-        Me.ExperimentsToolStripMenuItem.Name = "ExperimentsToolStripMenuItem"
-        Me.ExperimentsToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
-        Me.ExperimentsToolStripMenuItem.Text = "Experiments..."
         '
         'ToolsToolStripMenuItem
         '
@@ -5580,6 +5553,49 @@ Partial Class frmMain
         Me.GraphSummariseToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
         Me.GraphSummariseToolStripMenuItem.Text = "graph summarise"
         '
+        'OptionalMenuToolStripMenuItem
+        '
+        Me.OptionalMenuToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.StructuredToolStripMenuItem1, Me.ClimaticToolStripMenuItem1, Me.ProcurementToolStripMenuItem1, Me.ExperimentsToolStripMenuItem1, Me.TricotMenuToolStripMenuItem, Me.TricotXPMenuToolStripMenuItem})
+        Me.OptionalMenuToolStripMenuItem.Name = "OptionalMenuToolStripMenuItem"
+        Me.OptionalMenuToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
+        Me.OptionalMenuToolStripMenuItem.Text = "Optional Menu"
+        '
+        'StructuredToolStripMenuItem1
+        '
+        Me.StructuredToolStripMenuItem1.Name = "StructuredToolStripMenuItem1"
+        Me.StructuredToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
+        Me.StructuredToolStripMenuItem1.Text = "Structured"
+        '
+        'ClimaticToolStripMenuItem1
+        '
+        Me.ClimaticToolStripMenuItem1.Name = "ClimaticToolStripMenuItem1"
+        Me.ClimaticToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
+        Me.ClimaticToolStripMenuItem1.Text = "Climatic"
+        '
+        'ProcurementToolStripMenuItem1
+        '
+        Me.ProcurementToolStripMenuItem1.Name = "ProcurementToolStripMenuItem1"
+        Me.ProcurementToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
+        Me.ProcurementToolStripMenuItem1.Text = "Procurement"
+        '
+        'ExperimentsToolStripMenuItem1
+        '
+        Me.ExperimentsToolStripMenuItem1.Name = "ExperimentsToolStripMenuItem1"
+        Me.ExperimentsToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
+        Me.ExperimentsToolStripMenuItem1.Text = "Experiments"
+        '
+        'TricotMenuToolStripMenuItem
+        '
+        Me.TricotMenuToolStripMenuItem.Name = "TricotMenuToolStripMenuItem"
+        Me.TricotMenuToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.TricotMenuToolStripMenuItem.Text = "Tricot Menu"
+        '
+        'TricotXPMenuToolStripMenuItem
+        '
+        Me.TricotXPMenuToolStripMenuItem.Name = "TricotXPMenuToolStripMenuItem"
+        Me.TricotXPMenuToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.TricotXPMenuToolStripMenuItem.Text = "Tricot XP Menu"
+        '
         'frmMain
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -6284,13 +6300,8 @@ Partial Class frmMain
     Friend WithEvents PrepareToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents DescribeToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ModelToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents StructuredToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents ClimaticToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ToolStripSeparator81 As ToolStripSeparator
     Friend WithEvents ToolStripSeparator82 As ToolStripSeparator
-    Friend WithEvents ToolStripSeparator83 As ToolStripSeparator
-    Friend WithEvents ProcurementToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents ExperimentsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ToolsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ViewToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents mnuSwapDataLogScript As ToolStripMenuItem
@@ -6349,4 +6360,11 @@ Partial Class frmMain
     Friend WithEvents DuplicatesKeyVariableCheckToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents TwoThreeVariableToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents GraphSummariseToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents OptionalMenuToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents StructuredToolStripMenuItem1 As ToolStripMenuItem
+    Friend WithEvents ClimaticToolStripMenuItem1 As ToolStripMenuItem
+    Friend WithEvents ProcurementToolStripMenuItem1 As ToolStripMenuItem
+    Friend WithEvents ExperimentsToolStripMenuItem1 As ToolStripMenuItem
+    Friend WithEvents TricotMenuToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents TricotXPMenuToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -636,10 +636,11 @@ Partial Class frmMain
         Me.OneVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.DuplicatesKeyVariableCheckToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotDescribe = New System.Windows.Forms.ToolStripMenuItem()
+        Me.GraphTwoThreeVariablesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.TwoThreeVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator83 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuTricotDescribeTraits = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotDescribeCorrelations = New System.Windows.Forms.ToolStripMenuItem()
-        Me.TwoThreeVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.GraphSummariseToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotModelPlackettLuce = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotModelWithoutCovariates = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotModelTree = New System.Windows.Forms.ToolStripMenuItem()
@@ -738,11 +739,7 @@ Partial Class frmMain
         Me.splOverall = New System.Windows.Forms.SplitContainer()
         Me.splExtraWindows = New System.Windows.Forms.SplitContainer()
         Me.splMetadata = New System.Windows.Forms.SplitContainer()
-        Me.ucrColumnMeta = New instat.ucrColumnMetadata()
-        Me.ucrDataFrameMeta = New instat.ucrDataFrameMetadata()
-        Me.ucrScriptWindow = New instat.ucrScript()
         Me.splDataOutput = New System.Windows.Forms.SplitContainer()
-        Me.ucrDataViewer = New instat.ucrDataView()
         Me.ucrOutput = New instat.ucrOutputWindow()
         Me.mnuPlotly = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuColumnMetadata = New System.Windows.Forms.ToolStripMenuItem()
@@ -758,14 +755,10 @@ Partial Class frmMain
         Me.splOverall.SuspendLayout()
         CType(Me.splExtraWindows, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.splExtraWindows.Panel1.SuspendLayout()
-        Me.splExtraWindows.Panel2.SuspendLayout()
         Me.splExtraWindows.SuspendLayout()
         CType(Me.splMetadata, System.ComponentModel.ISupportInitialize).BeginInit()
-        Me.splMetadata.Panel1.SuspendLayout()
-        Me.splMetadata.Panel2.SuspendLayout()
         Me.splMetadata.SuspendLayout()
         CType(Me.splDataOutput, System.ComponentModel.ISupportInitialize).BeginInit()
-        Me.splDataOutput.Panel1.SuspendLayout()
         Me.splDataOutput.Panel2.SuspendLayout()
         Me.splDataOutput.SuspendLayout()
         Me.SuspendLayout()
@@ -789,18 +782,18 @@ Partial Class frmMain
         'mnuDescribeOneVariableVisualiseData
         '
         Me.mnuDescribeOneVariableVisualiseData.Name = "mnuDescribeOneVariableVisualiseData"
-        Me.mnuDescribeOneVariableVisualiseData.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeOneVariableVisualiseData.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableVisualiseData.Text = "Visualise Data..."
         '
         'ToolStripSeparator72
         '
         Me.ToolStripSeparator72.Name = "ToolStripSeparator72"
-        Me.ToolStripSeparator72.Size = New System.Drawing.Size(177, 6)
+        Me.ToolStripSeparator72.Size = New System.Drawing.Size(152, 6)
         '
         'mnuDescribeOneVariableSummarise
         '
         Me.mnuDescribeOneVariableSummarise.Name = "mnuDescribeOneVariableSummarise"
-        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableSummarise.Tag = "Summarise..."
         Me.mnuDescribeOneVariableSummarise.Text = "Summarise..."
         Me.mnuDescribeOneVariableSummarise.ToolTipText = "One Variable Summarise, Skim and Customised"
@@ -808,26 +801,26 @@ Partial Class frmMain
         'mnuDescribeOneVariableGraph
         '
         Me.mnuDescribeOneVariableGraph.Name = "mnuDescribeOneVariableGraph"
-        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableGraph.Tag = "Graph..."
         Me.mnuDescribeOneVariableGraph.Text = "Graph..."
         '
         'ToolStripSeparator33
         '
         Me.ToolStripSeparator33.Name = "ToolStripSeparator33"
-        Me.ToolStripSeparator33.Size = New System.Drawing.Size(177, 6)
+        Me.ToolStripSeparator33.Size = New System.Drawing.Size(152, 6)
         '
         'mnuDescribeOneVariableFrequencies
         '
         Me.mnuDescribeOneVariableFrequencies.Name = "mnuDescribeOneVariableFrequencies"
-        Me.mnuDescribeOneVariableFrequencies.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeOneVariableFrequencies.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableFrequencies.Text = "Frequencies..."
         Me.mnuDescribeOneVariableFrequencies.ToolTipText = "Table or Graph. Also Stem and Leaf Plots"
         '
         'mnuDescribeOneVariableRatingData
         '
         Me.mnuDescribeOneVariableRatingData.Name = "mnuDescribeOneVariableRatingData"
-        Me.mnuDescribeOneVariableRatingData.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeOneVariableRatingData.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableRatingData.Text = "Rating Data..."
         Me.mnuDescribeOneVariableRatingData.ToolTipText = "Table, Stacked Graph or Likert Graph"
         '
@@ -1688,59 +1681,59 @@ Partial Class frmMain
         'MenusAndDialogsToolStripMenuItem
         '
         Me.MenusAndDialogsToolStripMenuItem.Name = "MenusAndDialogsToolStripMenuItem"
-        Me.MenusAndDialogsToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
-        Me.MenusAndDialogsToolStripMenuItem.Text = "Menus and Dialogs..."
+        Me.MenusAndDialogsToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.MenusAndDialogsToolStripMenuItem.Text = "Menus ..."
         '
         'ToolStripSeparator82
         '
         Me.ToolStripSeparator82.Name = "ToolStripSeparator82"
-        Me.ToolStripSeparator82.Size = New System.Drawing.Size(181, 6)
+        Me.ToolStripSeparator82.Size = New System.Drawing.Size(177, 6)
         '
         'FileToolStripMenuItem
         '
         Me.FileToolStripMenuItem.Name = "FileToolStripMenuItem"
-        Me.FileToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
+        Me.FileToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
         Me.FileToolStripMenuItem.Text = "File..."
         '
         'EditToolStripMenuItem
         '
         Me.EditToolStripMenuItem.Name = "EditToolStripMenuItem"
-        Me.EditToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
+        Me.EditToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
         Me.EditToolStripMenuItem.Text = "Edit..."
         '
         'PrepareToolStripMenuItem
         '
         Me.PrepareToolStripMenuItem.Name = "PrepareToolStripMenuItem"
-        Me.PrepareToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
+        Me.PrepareToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
         Me.PrepareToolStripMenuItem.Text = "Prepare..."
         '
         'DescribeToolStripMenuItem
         '
         Me.DescribeToolStripMenuItem.Name = "DescribeToolStripMenuItem"
-        Me.DescribeToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
+        Me.DescribeToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
         Me.DescribeToolStripMenuItem.Text = "Describe..."
         '
         'ModelToolStripMenuItem
         '
         Me.ModelToolStripMenuItem.Name = "ModelToolStripMenuItem"
-        Me.ModelToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
+        Me.ModelToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
         Me.ModelToolStripMenuItem.Text = "Model..."
         '
         'ToolsToolStripMenuItem
         '
         Me.ToolsToolStripMenuItem.Name = "ToolsToolStripMenuItem"
-        Me.ToolsToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
+        Me.ToolsToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
         Me.ToolsToolStripMenuItem.Text = "Tools..."
         '
         'ViewToolStripMenuItem
         '
         Me.ViewToolStripMenuItem.Name = "ViewToolStripMenuItem"
-        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
+        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
         Me.ViewToolStripMenuItem.Text = "View..."
         '
         'OptionalMenuToolStripMenuItem
         '
-        Me.OptionalMenuToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.StructuredToolStripMenuItem1, Me.ClimaticToolStripMenuItem1, Me.ProcurementToolStripMenuItem1, Me.ExperimentsToolStripMenuItem1, Me.TricotMenuToolStripMenuItem, Me.TricotXPMenuToolStripMenuItem})
+        Me.OptionalMenuToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.StructuredToolStripMenuItem1, Me.ClimaticToolStripMenuItem1, Me.TricotXPMenuToolStripMenuItem, Me.TricotMenuToolStripMenuItem, Me.ExperimentsToolStripMenuItem1, Me.ProcurementToolStripMenuItem1})
         Me.OptionalMenuToolStripMenuItem.Name = "OptionalMenuToolStripMenuItem"
         Me.OptionalMenuToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
         Me.OptionalMenuToolStripMenuItem.Text = "Optional Menu"
@@ -1749,37 +1742,37 @@ Partial Class frmMain
         '
         Me.StructuredToolStripMenuItem1.Name = "StructuredToolStripMenuItem1"
         Me.StructuredToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.StructuredToolStripMenuItem1.Text = "Structured"
+        Me.StructuredToolStripMenuItem1.Text = "Structured..."
         '
         'ClimaticToolStripMenuItem1
         '
         Me.ClimaticToolStripMenuItem1.Name = "ClimaticToolStripMenuItem1"
         Me.ClimaticToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.ClimaticToolStripMenuItem1.Text = "Climatic"
+        Me.ClimaticToolStripMenuItem1.Text = "Climatic..."
         '
         'ProcurementToolStripMenuItem1
         '
         Me.ProcurementToolStripMenuItem1.Name = "ProcurementToolStripMenuItem1"
         Me.ProcurementToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.ProcurementToolStripMenuItem1.Text = "Procurement"
+        Me.ProcurementToolStripMenuItem1.Text = "Procurement..."
         '
         'ExperimentsToolStripMenuItem1
         '
         Me.ExperimentsToolStripMenuItem1.Name = "ExperimentsToolStripMenuItem1"
         Me.ExperimentsToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.ExperimentsToolStripMenuItem1.Text = "Experiments"
+        Me.ExperimentsToolStripMenuItem1.Text = "Experiments..."
         '
         'TricotMenuToolStripMenuItem
         '
         Me.TricotMenuToolStripMenuItem.Name = "TricotMenuToolStripMenuItem"
         Me.TricotMenuToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.TricotMenuToolStripMenuItem.Text = "Tricot Menu"
+        Me.TricotMenuToolStripMenuItem.Text = "Tricot Menu..."
         '
         'TricotXPMenuToolStripMenuItem
         '
         Me.TricotXPMenuToolStripMenuItem.Name = "TricotXPMenuToolStripMenuItem"
         Me.TricotXPMenuToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.TricotXPMenuToolStripMenuItem.Text = "Tricot XP Menu"
+        Me.TricotXPMenuToolStripMenuItem.Text = "Tricot XP Menu..."
         '
         'mnuHelpAboutR
         '
@@ -4792,35 +4785,39 @@ Partial Class frmMain
         '
         'mnuTricotDescribe
         '
-        Me.mnuTricotDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotDescribeTraits, Me.mnuTricotDescribeCorrelations, Me.TwoThreeVariableToolStripMenuItem})
+        Me.mnuTricotDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.GraphTwoThreeVariablesToolStripMenuItem, Me.TwoThreeVariableToolStripMenuItem, Me.ToolStripSeparator83, Me.mnuTricotDescribeTraits, Me.mnuTricotDescribeCorrelations})
         Me.mnuTricotDescribe.Name = "mnuTricotDescribe"
         Me.mnuTricotDescribe.Size = New System.Drawing.Size(201, 22)
         Me.mnuTricotDescribe.Text = "Describe"
         '
+        'GraphTwoThreeVariablesToolStripMenuItem
+        '
+        Me.GraphTwoThreeVariablesToolStripMenuItem.Name = "GraphTwoThreeVariablesToolStripMenuItem"
+        Me.GraphTwoThreeVariablesToolStripMenuItem.Size = New System.Drawing.Size(249, 22)
+        Me.GraphTwoThreeVariablesToolStripMenuItem.Text = "Graph Two/Three Variables..."
+        '
+        'TwoThreeVariableToolStripMenuItem
+        '
+        Me.TwoThreeVariableToolStripMenuItem.Name = "TwoThreeVariableToolStripMenuItem"
+        Me.TwoThreeVariableToolStripMenuItem.Size = New System.Drawing.Size(249, 22)
+        Me.TwoThreeVariableToolStripMenuItem.Text = "Summarise Two/ Three Variable..."
+        '
+        'ToolStripSeparator83
+        '
+        Me.ToolStripSeparator83.Name = "ToolStripSeparator83"
+        Me.ToolStripSeparator83.Size = New System.Drawing.Size(246, 6)
+        '
         'mnuTricotDescribeTraits
         '
         Me.mnuTricotDescribeTraits.Name = "mnuTricotDescribeTraits"
-        Me.mnuTricotDescribeTraits.Size = New System.Drawing.Size(180, 22)
+        Me.mnuTricotDescribeTraits.Size = New System.Drawing.Size(249, 22)
         Me.mnuTricotDescribeTraits.Text = "Traits..."
         '
         'mnuTricotDescribeCorrelations
         '
         Me.mnuTricotDescribeCorrelations.Name = "mnuTricotDescribeCorrelations"
-        Me.mnuTricotDescribeCorrelations.Size = New System.Drawing.Size(180, 22)
+        Me.mnuTricotDescribeCorrelations.Size = New System.Drawing.Size(249, 22)
         Me.mnuTricotDescribeCorrelations.Text = "Correlations..."
-        '
-        'TwoThreeVariableToolStripMenuItem
-        '
-        Me.TwoThreeVariableToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.GraphSummariseToolStripMenuItem})
-        Me.TwoThreeVariableToolStripMenuItem.Name = "TwoThreeVariableToolStripMenuItem"
-        Me.TwoThreeVariableToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.TwoThreeVariableToolStripMenuItem.Text = "Two/ Three Variable"
-        '
-        'GraphSummariseToolStripMenuItem
-        '
-        Me.GraphSummariseToolStripMenuItem.Name = "GraphSummariseToolStripMenuItem"
-        Me.GraphSummariseToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.GraphSummariseToolStripMenuItem.Text = "graph summarise"
         '
         'mnuTricotModelPlackettLuce
         '
@@ -4899,13 +4896,13 @@ Partial Class frmMain
         'mnuTricotXpDescribeTraits
         '
         Me.mnuTricotXpDescribeTraits.Name = "mnuTricotXpDescribeTraits"
-        Me.mnuTricotXpDescribeTraits.Size = New System.Drawing.Size(180, 22)
+        Me.mnuTricotXpDescribeTraits.Size = New System.Drawing.Size(147, 22)
         Me.mnuTricotXpDescribeTraits.Text = "Traits..."
         '
         'ToolStripMenuItem9
         '
         Me.ToolStripMenuItem9.Name = "ToolStripMenuItem9"
-        Me.ToolStripMenuItem9.Size = New System.Drawing.Size(180, 22)
+        Me.ToolStripMenuItem9.Size = New System.Drawing.Size(147, 22)
         Me.ToolStripMenuItem9.Text = "Correlations..."
         '
         'ToolStripMenuItem10
@@ -4950,7 +4947,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextCheckData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCheckDataDuplicateRows, Me.mnuOptionsByContextCheckDataCompareColumns, Me.ToolStripSeparator47, Me.mnuOptionsByContextCheckDataOneVariableSummarise, Me.mnuOptionsByContextCheckDataOneVariableGraph, Me.mnuOptionsByContextCheckDataOneVariableFrequencies})
         Me.mnuOptionsByContextCheckData.Name = "mnuOptionsByContextCheckData"
-        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(180, 22)
+        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(137, 22)
         Me.mnuOptionsByContextCheckData.Text = "Check Data"
         '
         'mnuOptionsByContextCheckDataDuplicateRows
@@ -4992,7 +4989,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextDefine.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDefineOnStation, Me.mnuOptionsByContextDefineOnFarm})
         Me.mnuOptionsByContextDefine.Name = "mnuOptionsByContextDefine"
-        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(180, 22)
+        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(137, 22)
         Me.mnuOptionsByContextDefine.Text = "Define"
         '
         'mnuOptionsByContextDefineOnStation
@@ -5011,7 +5008,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions, Me.ToolStripSeparator48, Me.mnuOptionsByContextMergeAdditionalData, Me.mnuOptionsByContextPrepareStack, Me.mnuOptionsByContextPrepareUnstack})
         Me.mnuOptionsByContextPrepare.Name = "mnuOptionsByContextPrepare"
-        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(180, 22)
+        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(137, 22)
         Me.mnuOptionsByContextPrepare.Text = "Prepare"
         '
         'mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions
@@ -5047,7 +5044,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDescribeCompareTwoTreatments, Me.mnuOptionsByContextDescribeCompareMultipleTreatments, Me.mnuOptionsByContextDescribeBoxplot})
         Me.mnuOptionsByContextDescribe.Name = "mnuOptionsByContextDescribe"
-        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(180, 22)
+        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(137, 22)
         Me.mnuOptionsByContextDescribe.Text = "Describe"
         '
         'mnuOptionsByContextDescribeCompareTwoTreatments
@@ -5073,7 +5070,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextModelFitModel, Me.mnuOptionsByContextGeneralFitModel})
         Me.mnuOptionsByContextModel.Name = "mnuOptionsByContextModel"
-        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(180, 22)
+        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(137, 22)
         Me.mnuOptionsByContextModel.Text = "Model"
         '
         'mnuOptionsByContextModelFitModel
@@ -5092,7 +5089,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextCropModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCropModelApsimxExamples})
         Me.mnuOptionsByContextCropModel.Name = "mnuOptionsByContextCropModel"
-        Me.mnuOptionsByContextCropModel.Size = New System.Drawing.Size(180, 22)
+        Me.mnuOptionsByContextCropModel.Size = New System.Drawing.Size(137, 22)
         Me.mnuOptionsByContextCropModel.Text = "Crop Model"
         '
         'mnuOptionsByContextCropModelApsimxExamples
@@ -5446,7 +5443,6 @@ Partial Class frmMain
         'splExtraWindows.Panel2
         '
         Me.splExtraWindows.Panel2.BackColor = System.Drawing.SystemColors.Control
-        Me.splExtraWindows.Panel2.Controls.Add(Me.ucrScriptWindow)
         Me.splExtraWindows.Size = New System.Drawing.Size(834, 155)
         Me.splExtraWindows.SplitterDistance = 252
         Me.splExtraWindows.SplitterWidth = 5
@@ -5459,55 +5455,13 @@ Partial Class frmMain
         Me.splMetadata.Location = New System.Drawing.Point(0, 0)
         Me.splMetadata.Name = "splMetadata"
         '
-        'splMetadata.Panel1
-        '
-        Me.splMetadata.Panel1.Controls.Add(Me.ucrColumnMeta)
-        '
         'splMetadata.Panel2
         '
         Me.splMetadata.Panel2.BackColor = System.Drawing.SystemColors.Control
-        Me.splMetadata.Panel2.Controls.Add(Me.ucrDataFrameMeta)
         Me.splMetadata.Size = New System.Drawing.Size(252, 155)
         Me.splMetadata.SplitterDistance = 68
         Me.splMetadata.SplitterWidth = 5
         Me.splMetadata.TabIndex = 0
-        '
-        'ucrColumnMeta
-        '
-        Me.ucrColumnMeta.AutoSize = True
-        Me.ucrColumnMeta.BackColor = System.Drawing.SystemColors.Control
-        Me.ucrColumnMeta.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-        Me.ucrColumnMeta.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.ucrColumnMeta.IsEnabled = False
-        Me.ucrColumnMeta.Location = New System.Drawing.Point(0, 0)
-        Me.ucrColumnMeta.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.ucrColumnMeta.Name = "ucrColumnMeta"
-        Me.ucrColumnMeta.Size = New System.Drawing.Size(68, 155)
-        Me.ucrColumnMeta.TabIndex = 0
-        '
-        'ucrDataFrameMeta
-        '
-        Me.ucrDataFrameMeta.AutoSize = True
-        Me.ucrDataFrameMeta.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-        Me.ucrDataFrameMeta.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.ucrDataFrameMeta.Location = New System.Drawing.Point(0, 0)
-        Me.ucrDataFrameMeta.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.ucrDataFrameMeta.Name = "ucrDataFrameMeta"
-        Me.ucrDataFrameMeta.Size = New System.Drawing.Size(179, 155)
-        Me.ucrDataFrameMeta.TabIndex = 0
-        '
-        'ucrScriptWindow
-        '
-        Me.ucrScriptWindow.AutoSize = True
-        Me.ucrScriptWindow.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-        Me.ucrScriptWindow.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.ucrScriptWindow.Location = New System.Drawing.Point(0, 0)
-        Me.ucrScriptWindow.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.ucrScriptWindow.Name = "ucrScriptWindow"
-        Me.ucrScriptWindow.Size = New System.Drawing.Size(577, 155)
-        Me.ucrScriptWindow.strActiveTabText = ""
-        Me.ucrScriptWindow.TabIndex = 2
-        Me.ucrScriptWindow.Tag = "Script_Window"
         '
         'splDataOutput
         '
@@ -5519,7 +5473,6 @@ Partial Class frmMain
         'splDataOutput.Panel1
         '
         Me.splDataOutput.Panel1.BackColor = System.Drawing.SystemColors.Control
-        Me.splDataOutput.Panel1.Controls.Add(Me.ucrDataViewer)
         '
         'splDataOutput.Panel2
         '
@@ -5529,19 +5482,6 @@ Partial Class frmMain
         Me.splDataOutput.SplitterDistance = 382
         Me.splDataOutput.SplitterWidth = 5
         Me.splDataOutput.TabIndex = 0
-        '
-        'ucrDataViewer
-        '
-        Me.ucrDataViewer.AutoSize = True
-        Me.ucrDataViewer.BackColor = System.Drawing.SystemColors.Control
-        Me.ucrDataViewer.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
-        Me.ucrDataViewer.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.ucrDataViewer.Location = New System.Drawing.Point(0, 0)
-        Me.ucrDataViewer.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.ucrDataViewer.Name = "ucrDataViewer"
-        Me.ucrDataViewer.Size = New System.Drawing.Size(382, 239)
-        Me.ucrDataViewer.TabIndex = 0
-        Me.ucrDataViewer.Tag = "Data_View"
         '
         'ucrOutput
         '
@@ -5615,18 +5555,10 @@ Partial Class frmMain
         CType(Me.splOverall, System.ComponentModel.ISupportInitialize).EndInit()
         Me.splOverall.ResumeLayout(False)
         Me.splExtraWindows.Panel1.ResumeLayout(False)
-        Me.splExtraWindows.Panel2.ResumeLayout(False)
-        Me.splExtraWindows.Panel2.PerformLayout()
         CType(Me.splExtraWindows, System.ComponentModel.ISupportInitialize).EndInit()
         Me.splExtraWindows.ResumeLayout(False)
-        Me.splMetadata.Panel1.ResumeLayout(False)
-        Me.splMetadata.Panel1.PerformLayout()
-        Me.splMetadata.Panel2.ResumeLayout(False)
-        Me.splMetadata.Panel2.PerformLayout()
         CType(Me.splMetadata, System.ComponentModel.ISupportInitialize).EndInit()
         Me.splMetadata.ResumeLayout(False)
-        Me.splDataOutput.Panel1.ResumeLayout(False)
-        Me.splDataOutput.Panel1.PerformLayout()
         Me.splDataOutput.Panel2.ResumeLayout(False)
         Me.splDataOutput.Panel2.PerformLayout()
         CType(Me.splDataOutput, System.ComponentModel.ISupportInitialize).EndInit()
@@ -5951,13 +5883,10 @@ Partial Class frmMain
     Friend WithEvents ToolStripSeparator35 As ToolStripSeparator
     Friend WithEvents splOverall As SplitContainer
     Friend WithEvents splDataOutput As SplitContainer
-    Friend WithEvents ucrDataViewer As ucrDataView
     Friend WithEvents ucrOutput As ucrOutputWindow
     Friend WithEvents splExtraWindows As SplitContainer
     Friend WithEvents splMetadata As SplitContainer
-    Friend WithEvents ucrColumnMeta As ucrColumnMetadata
     Friend WithEvents mnuViewResetToDefaultLayout As ToolStripMenuItem
-    Friend WithEvents ucrDataFrameMeta As ucrDataFrameMetadata
     Friend WithEvents mnuClimaticFileImportfromIRIDataLibrary As ToolStripMenuItem
     Friend WithEvents mnuDescribeOneVariableRatingData As ToolStripMenuItem
     Friend WithEvents mnuDescribeViewGraph As ToolStripMenuItem
@@ -6218,7 +6147,6 @@ Partial Class frmMain
     Friend WithEvents mnuHelpGlossary As ToolStripMenuItem
     Friend WithEvents mnuHelpPackagesDocumentation As ToolStripMenuItem
     Friend WithEvents mnuDescribeUseTable As ToolStripMenuItem
-    Friend WithEvents ucrScriptWindow As ucrScript
     Friend WithEvents mnuViewOutput As ToolStripMenuItem
     Friend WithEvents mnuViewLogScript As ToolStripMenuItem
     Friend WithEvents mnuTbSave As ToolStripSplitButton
@@ -6351,7 +6279,6 @@ Partial Class frmMain
     Friend WithEvents OneVariableToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents DuplicatesKeyVariableCheckToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents TwoThreeVariableToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents GraphSummariseToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents OptionalMenuToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents StructuredToolStripMenuItem1 As ToolStripMenuItem
     Friend WithEvents ClimaticToolStripMenuItem1 As ToolStripMenuItem
@@ -6359,4 +6286,6 @@ Partial Class frmMain
     Friend WithEvents ExperimentsToolStripMenuItem1 As ToolStripMenuItem
     Friend WithEvents TricotMenuToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents TricotXPMenuToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents GraphTwoThreeVariablesToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents ToolStripSeparator83 As ToolStripSeparator
 End Class

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -719,12 +719,9 @@ Partial Class frmMain
         Me.mnuProcurementCTFVCalculateCRI = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuProcurementUseCRISummariseCRIbyCountry = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTools = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuToolsRunRCode = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuToolsRestartR = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuToolsCheckForUpdates = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuToolsClearOutputWindow = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator5 = New System.Windows.Forms.ToolStripSeparator()
-        Me.mnuToolsSaveCurrentOptions = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuToolsRestoreBackup = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuToolsInstallRPackage = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuToolsOptions = New System.Windows.Forms.ToolStripMenuItem()
@@ -743,6 +740,7 @@ Partial Class frmMain
         Me.mnuDataFrameMetadata = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuScriptFile = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuLogFile = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuToolsRestartR = New System.Windows.Forms.ToolStripMenuItem()
         Me.stsStrip.SuspendLayout()
         Me.Tool_strip.SuspendLayout()
         Me.mnuBar.SuspendLayout()
@@ -768,7 +766,7 @@ Partial Class frmMain
         '
         Me.mnuDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeOneVariable, Me.mnuDescribeTwoThreeVariables, Me.mnuDescribeSpecificTablesGraphs, Me.mnuDescribeSpecificTables, Me.ToolStripSeparator9, Me.mnuDescribeMultivariate, Me.ToolStripSeparator13, Me.mnuDescribeUseTable, Me.mnuDescribeUseGraph, Me.mnuDescribeCombineGraph, Me.mnuDescribeThemes, Me.mnuDescribeViewGraph})
         Me.mnuDescribe.Name = "mnuDescribe"
-        Me.mnuDescribe.Size = New System.Drawing.Size(96, 29)
+        Me.mnuDescribe.Size = New System.Drawing.Size(64, 22)
         Me.mnuDescribe.Tag = "Describe"
         Me.mnuDescribe.Text = "Describe"
         '
@@ -776,25 +774,25 @@ Partial Class frmMain
         '
         Me.mnuDescribeOneVariable.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeOneVariableVisualiseData, Me.ToolStripSeparator72, Me.mnuDescribeOneVariableSummarise, Me.mnuDescribeOneVariableGraph, Me.ToolStripSeparator33, Me.mnuDescribeOneVariableFrequencies, Me.mnuDescribeOneVariableRatingData})
         Me.mnuDescribeOneVariable.Name = "mnuDescribeOneVariable"
-        Me.mnuDescribeOneVariable.Size = New System.Drawing.Size(271, 34)
+        Me.mnuDescribeOneVariable.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeOneVariable.Tag = "One_Variable"
         Me.mnuDescribeOneVariable.Text = "One Variable"
         '
         'mnuDescribeOneVariableVisualiseData
         '
         Me.mnuDescribeOneVariableVisualiseData.Name = "mnuDescribeOneVariableVisualiseData"
-        Me.mnuDescribeOneVariableVisualiseData.Size = New System.Drawing.Size(235, 34)
+        Me.mnuDescribeOneVariableVisualiseData.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableVisualiseData.Text = "Visualise Data..."
         '
         'ToolStripSeparator72
         '
         Me.ToolStripSeparator72.Name = "ToolStripSeparator72"
-        Me.ToolStripSeparator72.Size = New System.Drawing.Size(232, 6)
+        Me.ToolStripSeparator72.Size = New System.Drawing.Size(152, 6)
         '
         'mnuDescribeOneVariableSummarise
         '
         Me.mnuDescribeOneVariableSummarise.Name = "mnuDescribeOneVariableSummarise"
-        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(235, 34)
+        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableSummarise.Tag = "Summarise..."
         Me.mnuDescribeOneVariableSummarise.Text = "Summarise..."
         Me.mnuDescribeOneVariableSummarise.ToolTipText = "One Variable Summarise, Skim and Customised"
@@ -802,26 +800,26 @@ Partial Class frmMain
         'mnuDescribeOneVariableGraph
         '
         Me.mnuDescribeOneVariableGraph.Name = "mnuDescribeOneVariableGraph"
-        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(235, 34)
+        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableGraph.Tag = "Graph..."
         Me.mnuDescribeOneVariableGraph.Text = "Graph..."
         '
         'ToolStripSeparator33
         '
         Me.ToolStripSeparator33.Name = "ToolStripSeparator33"
-        Me.ToolStripSeparator33.Size = New System.Drawing.Size(232, 6)
+        Me.ToolStripSeparator33.Size = New System.Drawing.Size(152, 6)
         '
         'mnuDescribeOneVariableFrequencies
         '
         Me.mnuDescribeOneVariableFrequencies.Name = "mnuDescribeOneVariableFrequencies"
-        Me.mnuDescribeOneVariableFrequencies.Size = New System.Drawing.Size(235, 34)
+        Me.mnuDescribeOneVariableFrequencies.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableFrequencies.Text = "Frequencies..."
         Me.mnuDescribeOneVariableFrequencies.ToolTipText = "Table or Graph. Also Stem and Leaf Plots"
         '
         'mnuDescribeOneVariableRatingData
         '
         Me.mnuDescribeOneVariableRatingData.Name = "mnuDescribeOneVariableRatingData"
-        Me.mnuDescribeOneVariableRatingData.Size = New System.Drawing.Size(235, 34)
+        Me.mnuDescribeOneVariableRatingData.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableRatingData.Text = "Rating Data..."
         Me.mnuDescribeOneVariableRatingData.ToolTipText = "Table, Stacked Graph or Likert Graph"
         '
@@ -829,26 +827,26 @@ Partial Class frmMain
         '
         Me.mnuDescribeTwoThreeVariables.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeTwoThreeVariablesPivotTable, Me.ToolStripSeparator36, Me.mnuDescribeTwoVariablesSummarise, Me.mnuDescribeTwoVariablesGraph, Me.ToolStripSeparator34, Me.mnuDescribeTwoThreeVariablesCorrelations, Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies, Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies})
         Me.mnuDescribeTwoThreeVariables.Name = "mnuDescribeTwoThreeVariables"
-        Me.mnuDescribeTwoThreeVariables.Size = New System.Drawing.Size(271, 34)
+        Me.mnuDescribeTwoThreeVariables.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeTwoThreeVariables.Tag = "Two_Variables"
         Me.mnuDescribeTwoThreeVariables.Text = "Two/Three Variables"
         '
         'mnuDescribeTwoThreeVariablesPivotTable
         '
         Me.mnuDescribeTwoThreeVariablesPivotTable.Name = "mnuDescribeTwoThreeVariablesPivotTable"
-        Me.mnuDescribeTwoThreeVariablesPivotTable.Size = New System.Drawing.Size(308, 34)
+        Me.mnuDescribeTwoThreeVariablesPivotTable.Size = New System.Drawing.Size(207, 22)
         Me.mnuDescribeTwoThreeVariablesPivotTable.Text = "Pivot Table..."
         '
         'ToolStripSeparator36
         '
         Me.ToolStripSeparator36.Name = "ToolStripSeparator36"
-        Me.ToolStripSeparator36.Size = New System.Drawing.Size(305, 6)
+        Me.ToolStripSeparator36.Size = New System.Drawing.Size(204, 6)
         '
         'mnuDescribeTwoVariablesSummarise
         '
         Me.mnuDescribeTwoVariablesSummarise.DoubleClickEnabled = True
         Me.mnuDescribeTwoVariablesSummarise.Name = "mnuDescribeTwoVariablesSummarise"
-        Me.mnuDescribeTwoVariablesSummarise.Size = New System.Drawing.Size(308, 34)
+        Me.mnuDescribeTwoVariablesSummarise.Size = New System.Drawing.Size(207, 22)
         Me.mnuDescribeTwoVariablesSummarise.Tag = "Summarise..."
         Me.mnuDescribeTwoVariablesSummarise.Text = "Summarise..."
         Me.mnuDescribeTwoVariablesSummarise.ToolTipText = "Skim or Two Variables"
@@ -856,19 +854,19 @@ Partial Class frmMain
         'mnuDescribeTwoVariablesGraph
         '
         Me.mnuDescribeTwoVariablesGraph.Name = "mnuDescribeTwoVariablesGraph"
-        Me.mnuDescribeTwoVariablesGraph.Size = New System.Drawing.Size(308, 34)
+        Me.mnuDescribeTwoVariablesGraph.Size = New System.Drawing.Size(207, 22)
         Me.mnuDescribeTwoVariablesGraph.Tag = "Graph..."
         Me.mnuDescribeTwoVariablesGraph.Text = "Graph..."
         '
         'ToolStripSeparator34
         '
         Me.ToolStripSeparator34.Name = "ToolStripSeparator34"
-        Me.ToolStripSeparator34.Size = New System.Drawing.Size(305, 6)
+        Me.ToolStripSeparator34.Size = New System.Drawing.Size(204, 6)
         '
         'mnuDescribeTwoThreeVariablesCorrelations
         '
         Me.mnuDescribeTwoThreeVariablesCorrelations.Name = "mnuDescribeTwoThreeVariablesCorrelations"
-        Me.mnuDescribeTwoThreeVariablesCorrelations.Size = New System.Drawing.Size(308, 34)
+        Me.mnuDescribeTwoThreeVariablesCorrelations.Size = New System.Drawing.Size(207, 22)
         Me.mnuDescribeTwoThreeVariablesCorrelations.Text = "Correlations..."
         Me.mnuDescribeTwoThreeVariablesCorrelations.ToolTipText = "Multiple Variables or Two Variables"
         '
@@ -876,14 +874,14 @@ Partial Class frmMain
         '
         Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.DoubleClickEnabled = True
         Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Name = "mnuDescribeTwoThreeVariablesTwoWayFrequencies"
-        Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Size = New System.Drawing.Size(308, 34)
+        Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Size = New System.Drawing.Size(207, 22)
         Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Text = "Two-Way Frequencies..."
         Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.ToolTipText = "Table or Graph"
         '
         'mnuDescribeTwoThreeVariablesThreeWayFrequencies
         '
         Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Name = "mnuDescribeTwoThreeVariablesThreeWayFrequencies"
-        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Size = New System.Drawing.Size(308, 34)
+        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Size = New System.Drawing.Size(207, 22)
         Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Text = "Three-Way Frequencies..."
         Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.ToolTipText = "Table or Graph"
         '
@@ -891,14 +889,14 @@ Partial Class frmMain
         '
         Me.mnuDescribeSpecificTablesGraphs.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeSpecificBarPieChart, Me.mnuDescribeSpecificBoxplotJitterViolinPlot, Me.mnuDescribeSpecificHistogramDensityFrequencyPlot, Me.mnuDescribeSpecificPointPlot, Me.mnuDescribeSpecificLineSmoothPlot, Me.ToolStripSeparator38, Me.mnuDescribeGeneral, Me.ToolStripSeparator26, Me.mnuDescribeSpecificMapPlot, Me.mnuDescribeSpecificDotPlot, Me.mnuDescribeSpecificMosaic, Me.mnuDescribeSpecificCummulativeDistribution, Me.mnuDescribeSpecificParallelCoordinatePlot})
         Me.mnuDescribeSpecificTablesGraphs.Name = "mnuDescribeSpecificTablesGraphs"
-        Me.mnuDescribeSpecificTablesGraphs.Size = New System.Drawing.Size(271, 34)
+        Me.mnuDescribeSpecificTablesGraphs.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeSpecificTablesGraphs.Tag = "Graph_Dialogs"
         Me.mnuDescribeSpecificTablesGraphs.Text = "Graphs"
         '
         'mnuDescribeSpecificBarPieChart
         '
         Me.mnuDescribeSpecificBarPieChart.Name = "mnuDescribeSpecificBarPieChart"
-        Me.mnuDescribeSpecificBarPieChart.Size = New System.Drawing.Size(312, 34)
+        Me.mnuDescribeSpecificBarPieChart.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificBarPieChart.Tag = "Bar_Chart"
         Me.mnuDescribeSpecificBarPieChart.Text = "Bar Chart..."
         Me.mnuDescribeSpecificBarPieChart.ToolTipText = "Bar, Column, Lollipop, Pie, and Donut Charts, plus Treemaps and Wordclouds"
@@ -906,7 +904,7 @@ Partial Class frmMain
         'mnuDescribeSpecificBoxplotJitterViolinPlot
         '
         Me.mnuDescribeSpecificBoxplotJitterViolinPlot.Name = "mnuDescribeSpecificBoxplotJitterViolinPlot"
-        Me.mnuDescribeSpecificBoxplotJitterViolinPlot.Size = New System.Drawing.Size(312, 34)
+        Me.mnuDescribeSpecificBoxplotJitterViolinPlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificBoxplotJitterViolinPlot.Tag = "Boxplot..."
         Me.mnuDescribeSpecificBoxplotJitterViolinPlot.Text = "Boxplot..."
         Me.mnuDescribeSpecificBoxplotJitterViolinPlot.ToolTipText = "Boxplot (including Tufte), Jitter and Violin Plots"
@@ -914,7 +912,7 @@ Partial Class frmMain
         'mnuDescribeSpecificHistogramDensityFrequencyPlot
         '
         Me.mnuDescribeSpecificHistogramDensityFrequencyPlot.Name = "mnuDescribeSpecificHistogramDensityFrequencyPlot"
-        Me.mnuDescribeSpecificHistogramDensityFrequencyPlot.Size = New System.Drawing.Size(312, 34)
+        Me.mnuDescribeSpecificHistogramDensityFrequencyPlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificHistogramDensityFrequencyPlot.Tag = "Histogram..."
         Me.mnuDescribeSpecificHistogramDensityFrequencyPlot.Text = "Histogram..."
         Me.mnuDescribeSpecificHistogramDensityFrequencyPlot.ToolTipText = "Histograms, Dotplots, Density and Ridge Plots and Frequency Polygons"
@@ -922,7 +920,7 @@ Partial Class frmMain
         'mnuDescribeSpecificPointPlot
         '
         Me.mnuDescribeSpecificPointPlot.Name = "mnuDescribeSpecificPointPlot"
-        Me.mnuDescribeSpecificPointPlot.Size = New System.Drawing.Size(312, 34)
+        Me.mnuDescribeSpecificPointPlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificPointPlot.Tag = "Point_Plot..."
         Me.mnuDescribeSpecificPointPlot.Text = "Scatter Plot..."
         Me.mnuDescribeSpecificPointPlot.ToolTipText = "Point Plot"
@@ -930,7 +928,7 @@ Partial Class frmMain
         'mnuDescribeSpecificLineSmoothPlot
         '
         Me.mnuDescribeSpecificLineSmoothPlot.Name = "mnuDescribeSpecificLineSmoothPlot"
-        Me.mnuDescribeSpecificLineSmoothPlot.Size = New System.Drawing.Size(312, 34)
+        Me.mnuDescribeSpecificLineSmoothPlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificLineSmoothPlot.Tag = "Line_Plot..."
         Me.mnuDescribeSpecificLineSmoothPlot.Text = "Line Plot..."
         Me.mnuDescribeSpecificLineSmoothPlot.ToolTipText = "Line Plots, Smoothed Plots, Dumbbell and Slope Plots"
@@ -938,23 +936,23 @@ Partial Class frmMain
         'ToolStripSeparator38
         '
         Me.ToolStripSeparator38.Name = "ToolStripSeparator38"
-        Me.ToolStripSeparator38.Size = New System.Drawing.Size(309, 6)
+        Me.ToolStripSeparator38.Size = New System.Drawing.Size(206, 6)
         '
         'mnuDescribeGeneral
         '
         Me.mnuDescribeGeneral.Name = "mnuDescribeGeneral"
-        Me.mnuDescribeGeneral.Size = New System.Drawing.Size(312, 34)
+        Me.mnuDescribeGeneral.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeGeneral.Text = "General..."
         '
         'ToolStripSeparator26
         '
         Me.ToolStripSeparator26.Name = "ToolStripSeparator26"
-        Me.ToolStripSeparator26.Size = New System.Drawing.Size(309, 6)
+        Me.ToolStripSeparator26.Size = New System.Drawing.Size(206, 6)
         '
         'mnuDescribeSpecificMapPlot
         '
         Me.mnuDescribeSpecificMapPlot.Name = "mnuDescribeSpecificMapPlot"
-        Me.mnuDescribeSpecificMapPlot.Size = New System.Drawing.Size(312, 34)
+        Me.mnuDescribeSpecificMapPlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificMapPlot.Text = "Heatmap..."
         Me.mnuDescribeSpecificMapPlot.ToolTipText = "Heat Map and Chorolopleth Map"
         '
@@ -962,7 +960,7 @@ Partial Class frmMain
         '
         Me.mnuDescribeSpecificDotPlot.Enabled = False
         Me.mnuDescribeSpecificDotPlot.Name = "mnuDescribeSpecificDotPlot"
-        Me.mnuDescribeSpecificDotPlot.Size = New System.Drawing.Size(312, 34)
+        Me.mnuDescribeSpecificDotPlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificDotPlot.Tag = "Dotplot..."
         Me.mnuDescribeSpecificDotPlot.Text = "Dot Plot..."
         Me.mnuDescribeSpecificDotPlot.Visible = False
@@ -970,28 +968,28 @@ Partial Class frmMain
         'mnuDescribeSpecificMosaic
         '
         Me.mnuDescribeSpecificMosaic.Name = "mnuDescribeSpecificMosaic"
-        Me.mnuDescribeSpecificMosaic.Size = New System.Drawing.Size(312, 34)
+        Me.mnuDescribeSpecificMosaic.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificMosaic.Text = "Mosaic Plot..."
         Me.mnuDescribeSpecificMosaic.ToolTipText = "Mosaic Plot"
         '
         'mnuDescribeSpecificCummulativeDistribution
         '
         Me.mnuDescribeSpecificCummulativeDistribution.Name = "mnuDescribeSpecificCummulativeDistribution"
-        Me.mnuDescribeSpecificCummulativeDistribution.Size = New System.Drawing.Size(312, 34)
+        Me.mnuDescribeSpecificCummulativeDistribution.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificCummulativeDistribution.Text = "Cumulative Distribution..."
         Me.mnuDescribeSpecificCummulativeDistribution.ToolTipText = "Cumulative Graph and Exceedance Graph"
         '
         'mnuDescribeSpecificParallelCoordinatePlot
         '
         Me.mnuDescribeSpecificParallelCoordinatePlot.Name = "mnuDescribeSpecificParallelCoordinatePlot"
-        Me.mnuDescribeSpecificParallelCoordinatePlot.Size = New System.Drawing.Size(312, 34)
+        Me.mnuDescribeSpecificParallelCoordinatePlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificParallelCoordinatePlot.Text = "Parallel Coordinate Plot..."
         '
         'mnuDescribeSpecificTables
         '
         Me.mnuDescribeSpecificTables.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeSummaries, Me.mnuDescribePresentation})
         Me.mnuDescribeSpecificTables.Name = "mnuDescribeSpecificTables"
-        Me.mnuDescribeSpecificTables.Size = New System.Drawing.Size(271, 34)
+        Me.mnuDescribeSpecificTables.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeSpecificTables.Tag = "Table_Dialogs"
         Me.mnuDescribeSpecificTables.Text = "Tables..."
         Me.mnuDescribeSpecificTables.ToolTipText = "Frequency tables and Summary tables"
@@ -999,95 +997,95 @@ Partial Class frmMain
         'mnuDescribeSummaries
         '
         Me.mnuDescribeSummaries.Name = "mnuDescribeSummaries"
-        Me.mnuDescribeSummaries.Size = New System.Drawing.Size(224, 34)
+        Me.mnuDescribeSummaries.Size = New System.Drawing.Size(149, 22)
         Me.mnuDescribeSummaries.Text = "Summaries..."
         '
         'mnuDescribePresentation
         '
         Me.mnuDescribePresentation.Name = "mnuDescribePresentation"
-        Me.mnuDescribePresentation.Size = New System.Drawing.Size(224, 34)
+        Me.mnuDescribePresentation.Size = New System.Drawing.Size(149, 22)
         Me.mnuDescribePresentation.Text = "Presentation..."
         '
         'ToolStripSeparator9
         '
         Me.ToolStripSeparator9.Name = "ToolStripSeparator9"
-        Me.ToolStripSeparator9.Size = New System.Drawing.Size(268, 6)
+        Me.ToolStripSeparator9.Size = New System.Drawing.Size(177, 6)
         '
         'mnuDescribeMultivariate
         '
         Me.mnuDescribeMultivariate.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeMultivariateCorrelations, Me.mnuDescribeMultivariateprincipalComponents, Me.mnuDescribeMultivariateCanonicalCorrelations, Me.mnuDescribeMultivariateClusterAnalysis})
         Me.mnuDescribeMultivariate.Name = "mnuDescribeMultivariate"
-        Me.mnuDescribeMultivariate.Size = New System.Drawing.Size(271, 34)
+        Me.mnuDescribeMultivariate.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeMultivariate.Text = "Multivariate"
         '
         'mnuDescribeMultivariateCorrelations
         '
         Me.mnuDescribeMultivariateCorrelations.Name = "mnuDescribeMultivariateCorrelations"
-        Me.mnuDescribeMultivariateCorrelations.Size = New System.Drawing.Size(302, 34)
+        Me.mnuDescribeMultivariateCorrelations.Size = New System.Drawing.Size(203, 22)
         Me.mnuDescribeMultivariateCorrelations.Text = "Correlations..."
         Me.mnuDescribeMultivariateCorrelations.ToolTipText = "Multiple Variables or Two Variables"
         '
         'mnuDescribeMultivariateprincipalComponents
         '
         Me.mnuDescribeMultivariateprincipalComponents.Name = "mnuDescribeMultivariateprincipalComponents"
-        Me.mnuDescribeMultivariateprincipalComponents.Size = New System.Drawing.Size(302, 34)
+        Me.mnuDescribeMultivariateprincipalComponents.Size = New System.Drawing.Size(203, 22)
         Me.mnuDescribeMultivariateprincipalComponents.Text = "Principal Components..."
         '
         'mnuDescribeMultivariateCanonicalCorrelations
         '
         Me.mnuDescribeMultivariateCanonicalCorrelations.Name = "mnuDescribeMultivariateCanonicalCorrelations"
-        Me.mnuDescribeMultivariateCanonicalCorrelations.Size = New System.Drawing.Size(302, 34)
+        Me.mnuDescribeMultivariateCanonicalCorrelations.Size = New System.Drawing.Size(203, 22)
         Me.mnuDescribeMultivariateCanonicalCorrelations.Text = "Canonical Correlations..."
         '
         'mnuDescribeMultivariateClusterAnalysis
         '
         Me.mnuDescribeMultivariateClusterAnalysis.Name = "mnuDescribeMultivariateClusterAnalysis"
-        Me.mnuDescribeMultivariateClusterAnalysis.Size = New System.Drawing.Size(302, 34)
+        Me.mnuDescribeMultivariateClusterAnalysis.Size = New System.Drawing.Size(203, 22)
         Me.mnuDescribeMultivariateClusterAnalysis.Text = "Cluster Analysis..."
         Me.mnuDescribeMultivariateClusterAnalysis.ToolTipText = "Partitioning or Hierarchical"
         '
         'ToolStripSeparator13
         '
         Me.ToolStripSeparator13.Name = "ToolStripSeparator13"
-        Me.ToolStripSeparator13.Size = New System.Drawing.Size(268, 6)
+        Me.ToolStripSeparator13.Size = New System.Drawing.Size(177, 6)
         '
         'mnuDescribeUseTable
         '
         Me.mnuDescribeUseTable.Name = "mnuDescribeUseTable"
-        Me.mnuDescribeUseTable.Size = New System.Drawing.Size(271, 34)
+        Me.mnuDescribeUseTable.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeUseTable.Text = "Use Table..."
         '
         'mnuDescribeUseGraph
         '
         Me.mnuDescribeUseGraph.Name = "mnuDescribeUseGraph"
-        Me.mnuDescribeUseGraph.Size = New System.Drawing.Size(271, 34)
+        Me.mnuDescribeUseGraph.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeUseGraph.Text = "Use Graph..."
         '
         'mnuDescribeCombineGraph
         '
         Me.mnuDescribeCombineGraph.Name = "mnuDescribeCombineGraph"
-        Me.mnuDescribeCombineGraph.Size = New System.Drawing.Size(271, 34)
+        Me.mnuDescribeCombineGraph.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeCombineGraph.Text = "Combine Graphs..."
         '
         'mnuDescribeThemes
         '
         Me.mnuDescribeThemes.Enabled = False
         Me.mnuDescribeThemes.Name = "mnuDescribeThemes"
-        Me.mnuDescribeThemes.Size = New System.Drawing.Size(271, 34)
+        Me.mnuDescribeThemes.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeThemes.Text = "Themes..."
         Me.mnuDescribeThemes.Visible = False
         '
         'mnuDescribeViewGraph
         '
         Me.mnuDescribeViewGraph.Name = "mnuDescribeViewGraph"
-        Me.mnuDescribeViewGraph.Size = New System.Drawing.Size(271, 34)
+        Me.mnuDescribeViewGraph.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeViewGraph.Text = "View Graph..."
         '
         'mnuModel
         '
         Me.mnuModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelProbabilityDistributions, Me.ToolStripSeparator3, Me.mnuModelFitModel, Me.mnuModelCompareModels, Me.mnuModelUseModel, Me.mnuModelOtherOneVariable, Me.mnuModelOtherTwoVariables, Me.mnuModelOtherThreeVariables, Me.mnuModelOtherGeneral})
         Me.mnuModel.Name = "mnuModel"
-        Me.mnuModel.Size = New System.Drawing.Size(79, 29)
+        Me.mnuModel.Size = New System.Drawing.Size(53, 22)
         Me.mnuModel.Tag = "Model"
         Me.mnuModel.Text = "Model"
         '
@@ -1095,168 +1093,168 @@ Partial Class frmMain
         '
         Me.mnuModelProbabilityDistributions.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelProbabilityDistributionsShowModel, Me.mnuModelProbabilityDistributionsCompareModels, Me.mnuModelProbabilityDistributionsRandomSamplesUseModel})
         Me.mnuModelProbabilityDistributions.Name = "mnuModelProbabilityDistributions"
-        Me.mnuModelProbabilityDistributions.Size = New System.Drawing.Size(305, 34)
+        Me.mnuModelProbabilityDistributions.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelProbabilityDistributions.Tag = "Probability_Distributions"
         Me.mnuModelProbabilityDistributions.Text = "Probability Distributions"
         '
         'mnuModelProbabilityDistributionsShowModel
         '
         Me.mnuModelProbabilityDistributionsShowModel.Name = "mnuModelProbabilityDistributionsShowModel"
-        Me.mnuModelProbabilityDistributionsShowModel.Size = New System.Drawing.Size(271, 34)
+        Me.mnuModelProbabilityDistributionsShowModel.Size = New System.Drawing.Size(178, 22)
         Me.mnuModelProbabilityDistributionsShowModel.Text = "Show Model..."
         '
         'mnuModelProbabilityDistributionsCompareModels
         '
         Me.mnuModelProbabilityDistributionsCompareModels.Enabled = False
         Me.mnuModelProbabilityDistributionsCompareModels.Name = "mnuModelProbabilityDistributionsCompareModels"
-        Me.mnuModelProbabilityDistributionsCompareModels.Size = New System.Drawing.Size(271, 34)
+        Me.mnuModelProbabilityDistributionsCompareModels.Size = New System.Drawing.Size(178, 22)
         Me.mnuModelProbabilityDistributionsCompareModels.Tag = "Show_Models..."
         Me.mnuModelProbabilityDistributionsCompareModels.Text = "Compare Models..."
         '
         'mnuModelProbabilityDistributionsRandomSamplesUseModel
         '
         Me.mnuModelProbabilityDistributionsRandomSamplesUseModel.Name = "mnuModelProbabilityDistributionsRandomSamplesUseModel"
-        Me.mnuModelProbabilityDistributionsRandomSamplesUseModel.Size = New System.Drawing.Size(271, 34)
+        Me.mnuModelProbabilityDistributionsRandomSamplesUseModel.Size = New System.Drawing.Size(178, 22)
         Me.mnuModelProbabilityDistributionsRandomSamplesUseModel.Tag = "RandomSamples_(Use_Model)..."
         Me.mnuModelProbabilityDistributionsRandomSamplesUseModel.Text = "Random Samples ..."
         '
         'ToolStripSeparator3
         '
         Me.ToolStripSeparator3.Name = "ToolStripSeparator3"
-        Me.ToolStripSeparator3.Size = New System.Drawing.Size(302, 6)
+        Me.ToolStripSeparator3.Size = New System.Drawing.Size(198, 6)
         '
         'mnuModelFitModel
         '
         Me.mnuModelFitModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelFitModelOneVariable, Me.mnuModelFitModelTwoVariables, Me.mnuModelFitModelThreeVariables, Me.mnuModelFitModelFourVariables, Me.ToolStripSeparator24, Me.mnuModelFitModelGeneral, Me.mnuModelFitModelMachineLearning, Me.ToolStripSeparator57, Me.mnuModelFitModelHypothesisTestsKeyboard, Me.mnuModelFitModelModelKeyboard})
         Me.mnuModelFitModel.Name = "mnuModelFitModel"
-        Me.mnuModelFitModel.Size = New System.Drawing.Size(305, 34)
+        Me.mnuModelFitModel.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelFitModel.Tag = "Fit_Model..."
         Me.mnuModelFitModel.Text = "Fit Model"
         '
         'mnuModelFitModelOneVariable
         '
         Me.mnuModelFitModelOneVariable.Name = "mnuModelFitModelOneVariable"
-        Me.mnuModelFitModelOneVariable.Size = New System.Drawing.Size(347, 34)
+        Me.mnuModelFitModelOneVariable.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelOneVariable.Text = "One Variable..."
         '
         'mnuModelFitModelTwoVariables
         '
         Me.mnuModelFitModelTwoVariables.Name = "mnuModelFitModelTwoVariables"
-        Me.mnuModelFitModelTwoVariables.Size = New System.Drawing.Size(347, 34)
+        Me.mnuModelFitModelTwoVariables.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelTwoVariables.Text = "Two Variables..."
         '
         'mnuModelFitModelThreeVariables
         '
         Me.mnuModelFitModelThreeVariables.Name = "mnuModelFitModelThreeVariables"
-        Me.mnuModelFitModelThreeVariables.Size = New System.Drawing.Size(347, 34)
+        Me.mnuModelFitModelThreeVariables.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelThreeVariables.Text = "Three Variables..."
         '
         'mnuModelFitModelFourVariables
         '
         Me.mnuModelFitModelFourVariables.Name = "mnuModelFitModelFourVariables"
-        Me.mnuModelFitModelFourVariables.Size = New System.Drawing.Size(347, 34)
+        Me.mnuModelFitModelFourVariables.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelFourVariables.Text = "Four Variables..."
         '
         'ToolStripSeparator24
         '
         Me.ToolStripSeparator24.Name = "ToolStripSeparator24"
-        Me.ToolStripSeparator24.Size = New System.Drawing.Size(344, 6)
+        Me.ToolStripSeparator24.Size = New System.Drawing.Size(226, 6)
         '
         'mnuModelFitModelGeneral
         '
         Me.mnuModelFitModelGeneral.Name = "mnuModelFitModelGeneral"
-        Me.mnuModelFitModelGeneral.Size = New System.Drawing.Size(347, 34)
+        Me.mnuModelFitModelGeneral.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelGeneral.Text = "General..."
         '
         'mnuModelFitModelMachineLearning
         '
         Me.mnuModelFitModelMachineLearning.Enabled = False
         Me.mnuModelFitModelMachineLearning.Name = "mnuModelFitModelMachineLearning"
-        Me.mnuModelFitModelMachineLearning.Size = New System.Drawing.Size(347, 34)
+        Me.mnuModelFitModelMachineLearning.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelMachineLearning.Text = "Machine Learning (Caret)..."
         Me.mnuModelFitModelMachineLearning.Visible = False
         '
         'ToolStripSeparator57
         '
         Me.ToolStripSeparator57.Name = "ToolStripSeparator57"
-        Me.ToolStripSeparator57.Size = New System.Drawing.Size(344, 6)
+        Me.ToolStripSeparator57.Size = New System.Drawing.Size(226, 6)
         '
         'mnuModelFitModelHypothesisTestsKeyboard
         '
         Me.mnuModelFitModelHypothesisTestsKeyboard.Name = "mnuModelFitModelHypothesisTestsKeyboard"
-        Me.mnuModelFitModelHypothesisTestsKeyboard.Size = New System.Drawing.Size(347, 34)
+        Me.mnuModelFitModelHypothesisTestsKeyboard.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelHypothesisTestsKeyboard.Text = "Hypothesis Tests Keyboards..."
         '
         'mnuModelFitModelModelKeyboard
         '
         Me.mnuModelFitModelModelKeyboard.Name = "mnuModelFitModelModelKeyboard"
-        Me.mnuModelFitModelModelKeyboard.Size = New System.Drawing.Size(347, 34)
+        Me.mnuModelFitModelModelKeyboard.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelModelKeyboard.Text = "Fit Model Keyboards..."
         '
         'mnuModelCompareModels
         '
         Me.mnuModelCompareModels.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelCompareModelsOneVariable})
         Me.mnuModelCompareModels.Name = "mnuModelCompareModels"
-        Me.mnuModelCompareModels.Size = New System.Drawing.Size(305, 34)
+        Me.mnuModelCompareModels.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelCompareModels.Text = "Compare Models"
         '
         'mnuModelCompareModelsOneVariable
         '
         Me.mnuModelCompareModelsOneVariable.Name = "mnuModelCompareModelsOneVariable"
-        Me.mnuModelCompareModelsOneVariable.Size = New System.Drawing.Size(226, 34)
+        Me.mnuModelCompareModelsOneVariable.Size = New System.Drawing.Size(149, 22)
         Me.mnuModelCompareModelsOneVariable.Text = "One Variable..."
         '
         'mnuModelUseModel
         '
         Me.mnuModelUseModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelUseModelOneVariable, Me.mnuModelUseModelTwoVariables, Me.ToolStripSeparator59, Me.mnuModelUseModelGlance, Me.mnuModelUseModelTidy, Me.mnuModelUseModelAugment, Me.ToolStripSeparator58, Me.mnuModelUseModelUseModelKeyboard})
         Me.mnuModelUseModel.Name = "mnuModelUseModel"
-        Me.mnuModelUseModel.Size = New System.Drawing.Size(305, 34)
+        Me.mnuModelUseModel.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelUseModel.Text = "Use Model"
         '
         'mnuModelUseModelOneVariable
         '
         Me.mnuModelUseModelOneVariable.Name = "mnuModelUseModelOneVariable"
-        Me.mnuModelUseModelOneVariable.Size = New System.Drawing.Size(300, 34)
+        Me.mnuModelUseModelOneVariable.Size = New System.Drawing.Size(197, 22)
         Me.mnuModelUseModelOneVariable.Text = "One Variable..."
         '
         'mnuModelUseModelTwoVariables
         '
         Me.mnuModelUseModelTwoVariables.Name = "mnuModelUseModelTwoVariables"
-        Me.mnuModelUseModelTwoVariables.Size = New System.Drawing.Size(300, 34)
+        Me.mnuModelUseModelTwoVariables.Size = New System.Drawing.Size(197, 22)
         Me.mnuModelUseModelTwoVariables.Text = "Two Variables..."
         '
         'ToolStripSeparator59
         '
         Me.ToolStripSeparator59.Name = "ToolStripSeparator59"
-        Me.ToolStripSeparator59.Size = New System.Drawing.Size(297, 6)
+        Me.ToolStripSeparator59.Size = New System.Drawing.Size(194, 6)
         '
         'mnuModelUseModelGlance
         '
         Me.mnuModelUseModelGlance.Name = "mnuModelUseModelGlance"
-        Me.mnuModelUseModelGlance.Size = New System.Drawing.Size(300, 34)
+        Me.mnuModelUseModelGlance.Size = New System.Drawing.Size(197, 22)
         Me.mnuModelUseModelGlance.Text = "Glance..."
         '
         'mnuModelUseModelTidy
         '
         Me.mnuModelUseModelTidy.Name = "mnuModelUseModelTidy"
-        Me.mnuModelUseModelTidy.Size = New System.Drawing.Size(300, 34)
+        Me.mnuModelUseModelTidy.Size = New System.Drawing.Size(197, 22)
         Me.mnuModelUseModelTidy.Text = "Tidy..."
         '
         'mnuModelUseModelAugment
         '
         Me.mnuModelUseModelAugment.Name = "mnuModelUseModelAugment"
-        Me.mnuModelUseModelAugment.Size = New System.Drawing.Size(300, 34)
+        Me.mnuModelUseModelAugment.Size = New System.Drawing.Size(197, 22)
         Me.mnuModelUseModelAugment.Text = "Augment..."
         '
         'ToolStripSeparator58
         '
         Me.ToolStripSeparator58.Name = "ToolStripSeparator58"
-        Me.ToolStripSeparator58.Size = New System.Drawing.Size(297, 6)
+        Me.ToolStripSeparator58.Size = New System.Drawing.Size(194, 6)
         '
         'mnuModelUseModelUseModelKeyboard
         '
         Me.mnuModelUseModelUseModelKeyboard.Name = "mnuModelUseModelUseModelKeyboard"
-        Me.mnuModelUseModelUseModelKeyboard.Size = New System.Drawing.Size(300, 34)
+        Me.mnuModelUseModelUseModelKeyboard.Size = New System.Drawing.Size(197, 22)
         Me.mnuModelUseModelUseModelKeyboard.Text = "Use Model Keyboards..."
         '
         'mnuModelOtherOneVariable
@@ -1264,7 +1262,7 @@ Partial Class frmMain
         Me.mnuModelOtherOneVariable.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelOtherOneVariableExactResults, Me.mnuModelOtherOneVariableSampleSummaryData, Me.mnuModelOtherOneVariableNonParametric, Me.mnuModelOtherOneVariableGoodnessofFit})
         Me.mnuModelOtherOneVariable.Enabled = False
         Me.mnuModelOtherOneVariable.Name = "mnuModelOtherOneVariable"
-        Me.mnuModelOtherOneVariable.Size = New System.Drawing.Size(305, 34)
+        Me.mnuModelOtherOneVariable.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelOtherOneVariable.Tag = "Other_(One_Variable)"
         Me.mnuModelOtherOneVariable.Text = "Other (One Variable)"
         Me.mnuModelOtherOneVariable.Visible = False
@@ -1272,7 +1270,7 @@ Partial Class frmMain
         'mnuModelOtherOneVariableExactResults
         '
         Me.mnuModelOtherOneVariableExactResults.Name = "mnuModelOtherOneVariableExactResults"
-        Me.mnuModelOtherOneVariableExactResults.Size = New System.Drawing.Size(252, 34)
+        Me.mnuModelOtherOneVariableExactResults.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherOneVariableExactResults.Tag = "Exact_Results..."
         Me.mnuModelOtherOneVariableExactResults.Text = "Exact Results..."
         '
@@ -1280,7 +1278,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherOneVariableSampleSummaryData.Enabled = False
         Me.mnuModelOtherOneVariableSampleSummaryData.Name = "mnuModelOtherOneVariableSampleSummaryData"
-        Me.mnuModelOtherOneVariableSampleSummaryData.Size = New System.Drawing.Size(252, 34)
+        Me.mnuModelOtherOneVariableSampleSummaryData.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherOneVariableSampleSummaryData.Tag = "Summary_Data..."
         Me.mnuModelOtherOneVariableSampleSummaryData.Text = "Summary Data..."
         '
@@ -1288,7 +1286,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherOneVariableNonParametric.Enabled = False
         Me.mnuModelOtherOneVariableNonParametric.Name = "mnuModelOtherOneVariableNonParametric"
-        Me.mnuModelOtherOneVariableNonParametric.Size = New System.Drawing.Size(252, 34)
+        Me.mnuModelOtherOneVariableNonParametric.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherOneVariableNonParametric.Tag = "Non_Parametric..."
         Me.mnuModelOtherOneVariableNonParametric.Text = "Non Parametric..."
         '
@@ -1296,7 +1294,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherOneVariableGoodnessofFit.Enabled = False
         Me.mnuModelOtherOneVariableGoodnessofFit.Name = "mnuModelOtherOneVariableGoodnessofFit"
-        Me.mnuModelOtherOneVariableGoodnessofFit.Size = New System.Drawing.Size(252, 34)
+        Me.mnuModelOtherOneVariableGoodnessofFit.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherOneVariableGoodnessofFit.Tag = "Goodness_of_Fit"
         Me.mnuModelOtherOneVariableGoodnessofFit.Text = "Goodness of Fit..."
         '
@@ -1305,7 +1303,7 @@ Partial Class frmMain
         Me.mnuModelOtherTwoVariables.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelOtherTwoVariablesTwoSamples, Me.mnuModelOtherTwoVariablesSummaryData, Me.mnuModelOtherTwoVariablesSimpleRegression, Me.mnuModelOtherTwoVariablesOneWayANOVA, Me.mnuModelOtherTwoVariablesNonParametricTwoSamples, Me.mnuModelOtherTwoVariablesNonParametricOneWayANOVA})
         Me.mnuModelOtherTwoVariables.Enabled = False
         Me.mnuModelOtherTwoVariables.Name = "mnuModelOtherTwoVariables"
-        Me.mnuModelOtherTwoVariables.Size = New System.Drawing.Size(305, 34)
+        Me.mnuModelOtherTwoVariables.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelOtherTwoVariables.Tag = "Other_(Two_Variables)"
         Me.mnuModelOtherTwoVariables.Text = "Other (Two Variables)"
         Me.mnuModelOtherTwoVariables.Visible = False
@@ -1314,7 +1312,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherTwoVariablesTwoSamples.Enabled = False
         Me.mnuModelOtherTwoVariablesTwoSamples.Name = "mnuModelOtherTwoVariablesTwoSamples"
-        Me.mnuModelOtherTwoVariablesTwoSamples.Size = New System.Drawing.Size(399, 34)
+        Me.mnuModelOtherTwoVariablesTwoSamples.Size = New System.Drawing.Size(266, 22)
         Me.mnuModelOtherTwoVariablesTwoSamples.Tag = "Two_Samples..."
         Me.mnuModelOtherTwoVariablesTwoSamples.Text = "Two Samples..."
         '
@@ -1322,21 +1320,21 @@ Partial Class frmMain
         '
         Me.mnuModelOtherTwoVariablesSummaryData.Enabled = False
         Me.mnuModelOtherTwoVariablesSummaryData.Name = "mnuModelOtherTwoVariablesSummaryData"
-        Me.mnuModelOtherTwoVariablesSummaryData.Size = New System.Drawing.Size(399, 34)
+        Me.mnuModelOtherTwoVariablesSummaryData.Size = New System.Drawing.Size(266, 22)
         Me.mnuModelOtherTwoVariablesSummaryData.Tag = "Summary_Data..."
         Me.mnuModelOtherTwoVariablesSummaryData.Text = "Summary Data..."
         '
         'mnuModelOtherTwoVariablesSimpleRegression
         '
         Me.mnuModelOtherTwoVariablesSimpleRegression.Name = "mnuModelOtherTwoVariablesSimpleRegression"
-        Me.mnuModelOtherTwoVariablesSimpleRegression.Size = New System.Drawing.Size(399, 34)
+        Me.mnuModelOtherTwoVariablesSimpleRegression.Size = New System.Drawing.Size(266, 22)
         Me.mnuModelOtherTwoVariablesSimpleRegression.Tag = "Simple_Regression..."
         Me.mnuModelOtherTwoVariablesSimpleRegression.Text = "Simple Regression..."
         '
         'mnuModelOtherTwoVariablesOneWayANOVA
         '
         Me.mnuModelOtherTwoVariablesOneWayANOVA.Name = "mnuModelOtherTwoVariablesOneWayANOVA"
-        Me.mnuModelOtherTwoVariablesOneWayANOVA.Size = New System.Drawing.Size(399, 34)
+        Me.mnuModelOtherTwoVariablesOneWayANOVA.Size = New System.Drawing.Size(266, 22)
         Me.mnuModelOtherTwoVariablesOneWayANOVA.Tag = "One_Way_ANOVA..."
         Me.mnuModelOtherTwoVariablesOneWayANOVA.Text = "One Way ANOVA..."
         '
@@ -1344,14 +1342,14 @@ Partial Class frmMain
         '
         Me.mnuModelOtherTwoVariablesNonParametricTwoSamples.Enabled = False
         Me.mnuModelOtherTwoVariablesNonParametricTwoSamples.Name = "mnuModelOtherTwoVariablesNonParametricTwoSamples"
-        Me.mnuModelOtherTwoVariablesNonParametricTwoSamples.Size = New System.Drawing.Size(399, 34)
+        Me.mnuModelOtherTwoVariablesNonParametricTwoSamples.Size = New System.Drawing.Size(266, 22)
         Me.mnuModelOtherTwoVariablesNonParametricTwoSamples.Tag = "Non_Parameteric_Two_Samples..."
         Me.mnuModelOtherTwoVariablesNonParametricTwoSamples.Text = "Non Parametric Two Samples..."
         '
         'mnuModelOtherTwoVariablesNonParametricOneWayANOVA
         '
         Me.mnuModelOtherTwoVariablesNonParametricOneWayANOVA.Name = "mnuModelOtherTwoVariablesNonParametricOneWayANOVA"
-        Me.mnuModelOtherTwoVariablesNonParametricOneWayANOVA.Size = New System.Drawing.Size(399, 34)
+        Me.mnuModelOtherTwoVariablesNonParametricOneWayANOVA.Size = New System.Drawing.Size(266, 22)
         Me.mnuModelOtherTwoVariablesNonParametricOneWayANOVA.Tag = "Non_Parameteric_One_Way_ANOVA..."
         Me.mnuModelOtherTwoVariablesNonParametricOneWayANOVA.Text = "Non Parameteric One Way ANOVA..."
         '
@@ -1360,7 +1358,7 @@ Partial Class frmMain
         Me.mnuModelOtherThreeVariables.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelOtherThreeVariablesSimpleWithGroups, Me.mnuModelOtherThreeVariablesNonParametricTwoWayANOVA, Me.mnuModelOtherThreeVariablesChisquareTest})
         Me.mnuModelOtherThreeVariables.Enabled = False
         Me.mnuModelOtherThreeVariables.Name = "mnuModelOtherThreeVariables"
-        Me.mnuModelOtherThreeVariables.Size = New System.Drawing.Size(305, 34)
+        Me.mnuModelOtherThreeVariables.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelOtherThreeVariables.Tag = "Other_(Three_Variable)"
         Me.mnuModelOtherThreeVariables.Text = "Other (Three Variable)"
         Me.mnuModelOtherThreeVariables.Visible = False
@@ -1369,21 +1367,21 @@ Partial Class frmMain
         '
         Me.mnuModelOtherThreeVariablesSimpleWithGroups.Enabled = False
         Me.mnuModelOtherThreeVariablesSimpleWithGroups.Name = "mnuModelOtherThreeVariablesSimpleWithGroups"
-        Me.mnuModelOtherThreeVariablesSimpleWithGroups.Size = New System.Drawing.Size(389, 34)
+        Me.mnuModelOtherThreeVariablesSimpleWithGroups.Size = New System.Drawing.Size(260, 22)
         Me.mnuModelOtherThreeVariablesSimpleWithGroups.Tag = "Simple_with_groups..."
         Me.mnuModelOtherThreeVariablesSimpleWithGroups.Text = "Simple With Groups..."
         '
         'mnuModelOtherThreeVariablesNonParametricTwoWayANOVA
         '
         Me.mnuModelOtherThreeVariablesNonParametricTwoWayANOVA.Name = "mnuModelOtherThreeVariablesNonParametricTwoWayANOVA"
-        Me.mnuModelOtherThreeVariablesNonParametricTwoWayANOVA.Size = New System.Drawing.Size(389, 34)
+        Me.mnuModelOtherThreeVariablesNonParametricTwoWayANOVA.Size = New System.Drawing.Size(260, 22)
         Me.mnuModelOtherThreeVariablesNonParametricTwoWayANOVA.Tag = "Non_Parametric_Two_Way_ANOVA..."
         Me.mnuModelOtherThreeVariablesNonParametricTwoWayANOVA.Text = "Non Parametric Two Way ANOVA..."
         '
         'mnuModelOtherThreeVariablesChisquareTest
         '
         Me.mnuModelOtherThreeVariablesChisquareTest.Name = "mnuModelOtherThreeVariablesChisquareTest"
-        Me.mnuModelOtherThreeVariablesChisquareTest.Size = New System.Drawing.Size(389, 34)
+        Me.mnuModelOtherThreeVariablesChisquareTest.Size = New System.Drawing.Size(260, 22)
         Me.mnuModelOtherThreeVariablesChisquareTest.Tag = "Chi-square_Test"
         Me.mnuModelOtherThreeVariablesChisquareTest.Text = "Chi-square Test..."
         '
@@ -1392,7 +1390,7 @@ Partial Class frmMain
         Me.mnuModelOtherGeneral.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelOtherGeneralANOVAGeneral, Me.mnuModelOtherGeneralRegression, Me.mnuModelOtherGeneralLogLinear})
         Me.mnuModelOtherGeneral.Enabled = False
         Me.mnuModelOtherGeneral.Name = "mnuModelOtherGeneral"
-        Me.mnuModelOtherGeneral.Size = New System.Drawing.Size(305, 34)
+        Me.mnuModelOtherGeneral.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelOtherGeneral.Tag = "Other_(General)"
         Me.mnuModelOtherGeneral.Text = "Other (General)"
         Me.mnuModelOtherGeneral.Visible = False
@@ -1401,7 +1399,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherGeneralANOVAGeneral.Enabled = False
         Me.mnuModelOtherGeneralANOVAGeneral.Name = "mnuModelOtherGeneralANOVAGeneral"
-        Me.mnuModelOtherGeneralANOVAGeneral.Size = New System.Drawing.Size(251, 34)
+        Me.mnuModelOtherGeneralANOVAGeneral.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherGeneralANOVAGeneral.Tag = "ANOVA_General..."
         Me.mnuModelOtherGeneralANOVAGeneral.Text = "ANOVA General..."
         '
@@ -1409,7 +1407,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherGeneralRegression.Enabled = False
         Me.mnuModelOtherGeneralRegression.Name = "mnuModelOtherGeneralRegression"
-        Me.mnuModelOtherGeneralRegression.Size = New System.Drawing.Size(251, 34)
+        Me.mnuModelOtherGeneralRegression.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherGeneralRegression.Tag = "Regression..."
         Me.mnuModelOtherGeneralRegression.Text = "Regression..."
         '
@@ -1417,7 +1415,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherGeneralLogLinear.Enabled = False
         Me.mnuModelOtherGeneralLogLinear.Name = "mnuModelOtherGeneralLogLinear"
-        Me.mnuModelOtherGeneralLogLinear.Size = New System.Drawing.Size(251, 34)
+        Me.mnuModelOtherGeneralLogLinear.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherGeneralLogLinear.Tag = "Log_Linear"
         Me.mnuModelOtherGeneralLogLinear.Text = "Log Linear..."
         '
@@ -1425,7 +1423,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticExamine.Enabled = False
         Me.mnuClimaticExamine.Name = "mnuClimaticExamine"
-        Me.mnuClimaticExamine.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticExamine.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticExamine.Tag = "Examine"
         Me.mnuClimaticExamine.Text = "Examine..."
         Me.mnuClimaticExamine.Visible = False
@@ -1434,7 +1432,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticProcess.Enabled = False
         Me.mnuClimaticProcess.Name = "mnuClimaticProcess"
-        Me.mnuClimaticProcess.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticProcess.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticProcess.Tag = "Process"
         Me.mnuClimaticProcess.Text = "Process..."
         Me.mnuClimaticProcess.Visible = False
@@ -1443,7 +1441,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticEvaporation.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticEvaporationSite, Me.mnuClimaticEvaporationPenman})
         Me.mnuClimaticEvaporation.Name = "mnuClimaticEvaporation"
-        Me.mnuClimaticEvaporation.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticEvaporation.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticEvaporation.Tag = "Evaporation"
         Me.mnuClimaticEvaporation.Text = "Evaporation"
         Me.mnuClimaticEvaporation.Visible = False
@@ -1452,7 +1450,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticEvaporationSite.Enabled = False
         Me.mnuClimaticEvaporationSite.Name = "mnuClimaticEvaporationSite"
-        Me.mnuClimaticEvaporationSite.Size = New System.Drawing.Size(189, 34)
+        Me.mnuClimaticEvaporationSite.Size = New System.Drawing.Size(127, 22)
         Me.mnuClimaticEvaporationSite.Tag = "Site"
         Me.mnuClimaticEvaporationSite.Text = "Site..."
         '
@@ -1460,7 +1458,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticEvaporationPenman.Enabled = False
         Me.mnuClimaticEvaporationPenman.Name = "mnuClimaticEvaporationPenman"
-        Me.mnuClimaticEvaporationPenman.Size = New System.Drawing.Size(189, 34)
+        Me.mnuClimaticEvaporationPenman.Size = New System.Drawing.Size(127, 22)
         Me.mnuClimaticEvaporationPenman.Tag = "Penman"
         Me.mnuClimaticEvaporationPenman.Text = "Penman..."
         '
@@ -1468,7 +1466,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticCrop.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticCropCropCoefficients, Me.mnuClimaticCropWaterSatisfactionIndex})
         Me.mnuClimaticCrop.Name = "mnuClimaticCrop"
-        Me.mnuClimaticCrop.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticCrop.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticCrop.Tag = "Crop"
         Me.mnuClimaticCrop.Text = "Crop"
         Me.mnuClimaticCrop.Visible = False
@@ -1477,21 +1475,21 @@ Partial Class frmMain
         '
         Me.mnuClimaticCropCropCoefficients.Enabled = False
         Me.mnuClimaticCropCropCoefficients.Name = "mnuClimaticCropCropCoefficients"
-        Me.mnuClimaticCropCropCoefficients.Size = New System.Drawing.Size(316, 34)
+        Me.mnuClimaticCropCropCoefficients.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticCropCropCoefficients.Text = "Crop Coefficients..."
         '
         'mnuClimaticCropWaterSatisfactionIndex
         '
         Me.mnuClimaticCropWaterSatisfactionIndex.Enabled = False
         Me.mnuClimaticCropWaterSatisfactionIndex.Name = "mnuClimaticCropWaterSatisfactionIndex"
-        Me.mnuClimaticCropWaterSatisfactionIndex.Size = New System.Drawing.Size(316, 34)
+        Me.mnuClimaticCropWaterSatisfactionIndex.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticCropWaterSatisfactionIndex.Text = "Water Satisfaction Index..."
         '
         'mnuClimaticHeatSum
         '
         Me.mnuClimaticHeatSum.Enabled = False
         Me.mnuClimaticHeatSum.Name = "mnuClimaticHeatSum"
-        Me.mnuClimaticHeatSum.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticHeatSum.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticHeatSum.Tag = "Heat_Sum"
         Me.mnuClimaticHeatSum.Text = "Heat Sum..."
         Me.mnuClimaticHeatSum.Visible = False
@@ -1500,7 +1498,7 @@ Partial Class frmMain
         '
         Me.mnuView.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuViewDataView, Me.mnuViewOutput, Me.mnuViewLogScript, Me.mnuViewColumnMetadata, Me.mnuViewDataFrameMetadata, Me.ToolStripSeparator22, Me.mnuViewStructuredMenu, Me.mnuViewClimaticMenu, Me.mnuViewTricotMenu, Me.mnuViewTricotXpMenu, Me.mnuViewOptionsByContextMenu, Me.mnuViewProcurementMenu, Me.ToolStripSeparator39, Me.mnuViewResetToDefaultLayout, Me.mnuViewSwapDataAndMetadata, Me.mnuViewSwapDataAndDataframeMetadata, Me.mnuViewSwapDataAndScript})
         Me.mnuView.Name = "mnuView"
-        Me.mnuView.Size = New System.Drawing.Size(65, 29)
+        Me.mnuView.Size = New System.Drawing.Size(44, 22)
         Me.mnuView.Tag = "View"
         Me.mnuView.Text = "View"
         '
@@ -1508,7 +1506,7 @@ Partial Class frmMain
         '
         Me.mnuViewDataView.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewDataView.Name = "mnuViewDataView"
-        Me.mnuViewDataView.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewDataView.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewDataView.Tag = "Data_View"
         Me.mnuViewDataView.Text = "Data View"
         '
@@ -1516,21 +1514,21 @@ Partial Class frmMain
         '
         Me.mnuViewOutput.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewOutput.Name = "mnuViewOutput"
-        Me.mnuViewOutput.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewOutput.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewOutput.Text = "Output"
         '
         'mnuViewLogScript
         '
         Me.mnuViewLogScript.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewLogScript.Name = "mnuViewLogScript"
-        Me.mnuViewLogScript.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewLogScript.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewLogScript.Text = "Log/Script"
         '
         'mnuViewColumnMetadata
         '
         Me.mnuViewColumnMetadata.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewColumnMetadata.Name = "mnuViewColumnMetadata"
-        Me.mnuViewColumnMetadata.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewColumnMetadata.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewColumnMetadata.Tag = "Column_Metadata"
         Me.mnuViewColumnMetadata.Text = "Column Metadata"
         '
@@ -1538,27 +1536,27 @@ Partial Class frmMain
         '
         Me.mnuViewDataFrameMetadata.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewDataFrameMetadata.Name = "mnuViewDataFrameMetadata"
-        Me.mnuViewDataFrameMetadata.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewDataFrameMetadata.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewDataFrameMetadata.Tag = "Data_Frame_Metadata"
         Me.mnuViewDataFrameMetadata.Text = "Data Frame Metadata"
         '
         'ToolStripSeparator22
         '
         Me.ToolStripSeparator22.Name = "ToolStripSeparator22"
-        Me.ToolStripSeparator22.Size = New System.Drawing.Size(407, 6)
+        Me.ToolStripSeparator22.Size = New System.Drawing.Size(265, 6)
         '
         'mnuViewStructuredMenu
         '
         Me.mnuViewStructuredMenu.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewStructuredMenu.Name = "mnuViewStructuredMenu"
-        Me.mnuViewStructuredMenu.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewStructuredMenu.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewStructuredMenu.Text = "Structured Menu"
         '
         'mnuViewClimaticMenu
         '
         Me.mnuViewClimaticMenu.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewClimaticMenu.Name = "mnuViewClimaticMenu"
-        Me.mnuViewClimaticMenu.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewClimaticMenu.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewClimaticMenu.Tag = ""
         Me.mnuViewClimaticMenu.Text = "Climatic Menu"
         '
@@ -1566,261 +1564,261 @@ Partial Class frmMain
         '
         Me.mnuViewTricotMenu.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewTricotMenu.Name = "mnuViewTricotMenu"
-        Me.mnuViewTricotMenu.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewTricotMenu.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewTricotMenu.Text = "Tricot Menu"
         '
         'mnuViewTricotXpMenu
         '
         Me.mnuViewTricotXpMenu.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewTricotXpMenu.Name = "mnuViewTricotXpMenu"
-        Me.mnuViewTricotXpMenu.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewTricotXpMenu.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewTricotXpMenu.Text = "Tricot XP Menu"
         '
         'mnuViewOptionsByContextMenu
         '
         Me.mnuViewOptionsByContextMenu.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewOptionsByContextMenu.Name = "mnuViewOptionsByContextMenu"
-        Me.mnuViewOptionsByContextMenu.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewOptionsByContextMenu.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewOptionsByContextMenu.Text = "Experiments Menu"
         '
         'mnuViewProcurementMenu
         '
         Me.mnuViewProcurementMenu.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewProcurementMenu.Name = "mnuViewProcurementMenu"
-        Me.mnuViewProcurementMenu.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewProcurementMenu.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewProcurementMenu.Tag = ""
         Me.mnuViewProcurementMenu.Text = "Procurement Menu"
         '
         'ToolStripSeparator39
         '
         Me.ToolStripSeparator39.Name = "ToolStripSeparator39"
-        Me.ToolStripSeparator39.Size = New System.Drawing.Size(407, 6)
+        Me.ToolStripSeparator39.Size = New System.Drawing.Size(265, 6)
         '
         'mnuViewResetToDefaultLayout
         '
         Me.mnuViewResetToDefaultLayout.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewResetToDefaultLayout.Name = "mnuViewResetToDefaultLayout"
-        Me.mnuViewResetToDefaultLayout.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewResetToDefaultLayout.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewResetToDefaultLayout.Text = "Reset to Default Layout"
         '
         'mnuViewSwapDataAndMetadata
         '
         Me.mnuViewSwapDataAndMetadata.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewSwapDataAndMetadata.Name = "mnuViewSwapDataAndMetadata"
-        Me.mnuViewSwapDataAndMetadata.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewSwapDataAndMetadata.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewSwapDataAndMetadata.Text = "Swap Data and Metadata"
         '
         'mnuViewSwapDataAndDataframeMetadata
         '
         Me.mnuViewSwapDataAndDataframeMetadata.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewSwapDataAndDataframeMetadata.Name = "mnuViewSwapDataAndDataframeMetadata"
-        Me.mnuViewSwapDataAndDataframeMetadata.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewSwapDataAndDataframeMetadata.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewSwapDataAndDataframeMetadata.Text = "Swap Data and Data Frame Metadata"
         '
         'mnuViewSwapDataAndScript
         '
         Me.mnuViewSwapDataAndScript.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewSwapDataAndScript.Name = "mnuViewSwapDataAndScript"
-        Me.mnuViewSwapDataAndScript.Size = New System.Drawing.Size(410, 34)
+        Me.mnuViewSwapDataAndScript.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewSwapDataAndScript.Text = "Swap Data and  Log/Script"
         '
         'mnuHelp
         '
         Me.mnuHelp.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuHelpHelpIntroduction, Me.mnuHelpFAQ, Me.mnuHelpGetingStarted, Me.mnuHelpData, Me.ToolStripSeparator28, Me.mnuHelpWindows, Me.ToolStripSeparator81, Me.mnuHelpMenus, Me.mnuHelpAboutR, Me.mnuHelpLearningStatistics, Me.mnuHelpRPackages, Me.mnuHelpGlossary, Me.mnuHelpLicence, Me.ToolStripSeparator29, Me.mnuHelpResourcesSite, Me.mnuHelpPackagesDocumentation})
         Me.mnuHelp.Name = "mnuHelp"
-        Me.mnuHelp.Size = New System.Drawing.Size(65, 29)
+        Me.mnuHelp.Size = New System.Drawing.Size(44, 22)
         Me.mnuHelp.Tag = "Help"
         Me.mnuHelp.Text = "Help"
         '
         'mnuHelpHelpIntroduction
         '
         Me.mnuHelpHelpIntroduction.Name = "mnuHelpHelpIntroduction"
-        Me.mnuHelpHelpIntroduction.Size = New System.Drawing.Size(360, 34)
+        Me.mnuHelpHelpIntroduction.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpHelpIntroduction.Text = "Introduction..."
         '
         'mnuHelpFAQ
         '
         Me.mnuHelpFAQ.Name = "mnuHelpFAQ"
-        Me.mnuHelpFAQ.Size = New System.Drawing.Size(360, 34)
+        Me.mnuHelpFAQ.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpFAQ.Text = "FAQ..."
         '
         'mnuHelpGetingStarted
         '
         Me.mnuHelpGetingStarted.Name = "mnuHelpGetingStarted"
-        Me.mnuHelpGetingStarted.Size = New System.Drawing.Size(360, 34)
+        Me.mnuHelpGetingStarted.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpGetingStarted.Text = "Getting Started..."
         '
         'mnuHelpData
         '
         Me.mnuHelpData.Name = "mnuHelpData"
-        Me.mnuHelpData.Size = New System.Drawing.Size(360, 34)
+        Me.mnuHelpData.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpData.Text = "Data..."
         '
         'ToolStripSeparator28
         '
         Me.ToolStripSeparator28.Name = "ToolStripSeparator28"
-        Me.ToolStripSeparator28.Size = New System.Drawing.Size(357, 6)
+        Me.ToolStripSeparator28.Size = New System.Drawing.Size(236, 6)
         '
         'mnuHelpWindows
         '
         Me.mnuHelpWindows.Name = "mnuHelpWindows"
-        Me.mnuHelpWindows.Size = New System.Drawing.Size(360, 34)
+        Me.mnuHelpWindows.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpWindows.Text = "Windows..."
         '
         'ToolStripSeparator81
         '
         Me.ToolStripSeparator81.Name = "ToolStripSeparator81"
-        Me.ToolStripSeparator81.Size = New System.Drawing.Size(357, 6)
+        Me.ToolStripSeparator81.Size = New System.Drawing.Size(236, 6)
         '
         'mnuHelpMenus
         '
         Me.mnuHelpMenus.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.MenusAndDialogsToolStripMenuItem, Me.ToolStripSeparator82, Me.FileToolStripMenuItem, Me.EditToolStripMenuItem, Me.PrepareToolStripMenuItem, Me.DescribeToolStripMenuItem, Me.ModelToolStripMenuItem, Me.ToolStripSeparator83, Me.StructuredToolStripMenuItem, Me.ClimaticToolStripMenuItem, Me.ProcurementToolStripMenuItem, Me.ExperimentsToolStripMenuItem, Me.ToolsToolStripMenuItem, Me.ViewToolStripMenuItem})
         Me.mnuHelpMenus.Name = "mnuHelpMenus"
-        Me.mnuHelpMenus.Size = New System.Drawing.Size(360, 34)
+        Me.mnuHelpMenus.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpMenus.Text = "Menus and Dialogs"
         '
         'MenusAndDialogsToolStripMenuItem
         '
         Me.MenusAndDialogsToolStripMenuItem.Name = "MenusAndDialogsToolStripMenuItem"
-        Me.MenusAndDialogsToolStripMenuItem.Size = New System.Drawing.Size(279, 34)
+        Me.MenusAndDialogsToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.MenusAndDialogsToolStripMenuItem.Text = "Menus and Dialogs..."
         '
         'ToolStripSeparator82
         '
         Me.ToolStripSeparator82.Name = "ToolStripSeparator82"
-        Me.ToolStripSeparator82.Size = New System.Drawing.Size(276, 6)
+        Me.ToolStripSeparator82.Size = New System.Drawing.Size(181, 6)
         '
         'FileToolStripMenuItem
         '
         Me.FileToolStripMenuItem.Name = "FileToolStripMenuItem"
-        Me.FileToolStripMenuItem.Size = New System.Drawing.Size(279, 34)
+        Me.FileToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.FileToolStripMenuItem.Text = "File..."
         '
         'EditToolStripMenuItem
         '
         Me.EditToolStripMenuItem.Name = "EditToolStripMenuItem"
-        Me.EditToolStripMenuItem.Size = New System.Drawing.Size(279, 34)
+        Me.EditToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.EditToolStripMenuItem.Text = "Edit..."
         '
         'PrepareToolStripMenuItem
         '
         Me.PrepareToolStripMenuItem.Name = "PrepareToolStripMenuItem"
-        Me.PrepareToolStripMenuItem.Size = New System.Drawing.Size(279, 34)
+        Me.PrepareToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.PrepareToolStripMenuItem.Text = "Prepare..."
         '
         'DescribeToolStripMenuItem
         '
         Me.DescribeToolStripMenuItem.Name = "DescribeToolStripMenuItem"
-        Me.DescribeToolStripMenuItem.Size = New System.Drawing.Size(279, 34)
+        Me.DescribeToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.DescribeToolStripMenuItem.Text = "Describe..."
         '
         'ModelToolStripMenuItem
         '
         Me.ModelToolStripMenuItem.Name = "ModelToolStripMenuItem"
-        Me.ModelToolStripMenuItem.Size = New System.Drawing.Size(279, 34)
+        Me.ModelToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.ModelToolStripMenuItem.Text = "Model..."
         '
         'ToolStripSeparator83
         '
         Me.ToolStripSeparator83.Name = "ToolStripSeparator83"
-        Me.ToolStripSeparator83.Size = New System.Drawing.Size(276, 6)
+        Me.ToolStripSeparator83.Size = New System.Drawing.Size(181, 6)
         '
         'StructuredToolStripMenuItem
         '
         Me.StructuredToolStripMenuItem.Name = "StructuredToolStripMenuItem"
-        Me.StructuredToolStripMenuItem.Size = New System.Drawing.Size(279, 34)
+        Me.StructuredToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.StructuredToolStripMenuItem.Text = "Structured..."
         '
         'ClimaticToolStripMenuItem
         '
         Me.ClimaticToolStripMenuItem.Name = "ClimaticToolStripMenuItem"
-        Me.ClimaticToolStripMenuItem.Size = New System.Drawing.Size(279, 34)
+        Me.ClimaticToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.ClimaticToolStripMenuItem.Text = "Climatic..."
         '
         'ProcurementToolStripMenuItem
         '
         Me.ProcurementToolStripMenuItem.Name = "ProcurementToolStripMenuItem"
-        Me.ProcurementToolStripMenuItem.Size = New System.Drawing.Size(279, 34)
+        Me.ProcurementToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.ProcurementToolStripMenuItem.Text = "Procurement..."
         '
         'ExperimentsToolStripMenuItem
         '
         Me.ExperimentsToolStripMenuItem.Name = "ExperimentsToolStripMenuItem"
-        Me.ExperimentsToolStripMenuItem.Size = New System.Drawing.Size(279, 34)
+        Me.ExperimentsToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.ExperimentsToolStripMenuItem.Text = "Experiments..."
         '
         'ToolsToolStripMenuItem
         '
         Me.ToolsToolStripMenuItem.Name = "ToolsToolStripMenuItem"
-        Me.ToolsToolStripMenuItem.Size = New System.Drawing.Size(279, 34)
+        Me.ToolsToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.ToolsToolStripMenuItem.Text = "Tools..."
         '
         'ViewToolStripMenuItem
         '
         Me.ViewToolStripMenuItem.Name = "ViewToolStripMenuItem"
-        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(279, 34)
+        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.ViewToolStripMenuItem.Text = "View..."
         '
         'mnuHelpAboutR
         '
         Me.mnuHelpAboutR.Name = "mnuHelpAboutR"
-        Me.mnuHelpAboutR.Size = New System.Drawing.Size(360, 34)
+        Me.mnuHelpAboutR.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpAboutR.Text = "About R..."
         Me.mnuHelpAboutR.Visible = False
         '
         'mnuHelpLearningStatistics
         '
         Me.mnuHelpLearningStatistics.Name = "mnuHelpLearningStatistics"
-        Me.mnuHelpLearningStatistics.Size = New System.Drawing.Size(360, 34)
+        Me.mnuHelpLearningStatistics.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpLearningStatistics.Text = "Learning Statistics..."
         Me.mnuHelpLearningStatistics.Visible = False
         '
         'mnuHelpRPackages
         '
         Me.mnuHelpRPackages.Name = "mnuHelpRPackages"
-        Me.mnuHelpRPackages.Size = New System.Drawing.Size(360, 34)
+        Me.mnuHelpRPackages.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpRPackages.Text = "R Packages..."
         '
         'mnuHelpGlossary
         '
         Me.mnuHelpGlossary.Name = "mnuHelpGlossary"
-        Me.mnuHelpGlossary.Size = New System.Drawing.Size(360, 34)
+        Me.mnuHelpGlossary.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpGlossary.Text = "Glossary..."
         '
         'mnuHelpLicence
         '
         Me.mnuHelpLicence.Name = "mnuHelpLicence"
-        Me.mnuHelpLicence.Size = New System.Drawing.Size(360, 34)
+        Me.mnuHelpLicence.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpLicence.Tag = "Licence..."
         Me.mnuHelpLicence.Text = "Licence..."
         '
         'ToolStripSeparator29
         '
         Me.ToolStripSeparator29.Name = "ToolStripSeparator29"
-        Me.ToolStripSeparator29.Size = New System.Drawing.Size(357, 6)
+        Me.ToolStripSeparator29.Size = New System.Drawing.Size(236, 6)
         '
         'mnuHelpResourcesSite
         '
         Me.mnuHelpResourcesSite.Name = "mnuHelpResourcesSite"
-        Me.mnuHelpResourcesSite.Size = New System.Drawing.Size(360, 34)
+        Me.mnuHelpResourcesSite.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpResourcesSite.Text = "R-Instat Resources Site (Online)"
         '
         'mnuHelpPackagesDocumentation
         '
         Me.mnuHelpPackagesDocumentation.Name = "mnuHelpPackagesDocumentation"
-        Me.mnuHelpPackagesDocumentation.Size = New System.Drawing.Size(360, 34)
+        Me.mnuHelpPackagesDocumentation.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpPackagesDocumentation.Text = "R-Packages Documentation..."
         '
         'ToolStripSeparator16
         '
         Me.ToolStripSeparator16.Name = "ToolStripSeparator16"
-        Me.ToolStripSeparator16.Size = New System.Drawing.Size(322, 6)
+        Me.ToolStripSeparator16.Size = New System.Drawing.Size(209, 6)
         '
         'mnuClimatic
         '
         Me.mnuClimatic.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticFile, Me.ToolStripSeparator18, Me.mnuExamineEditData, Me.mnuClimaticTidyandExamine, Me.mnuClimaticDates, Me.mnuClimaticDefineClimaticData, Me.mnuClimaticCheckData, Me.mnuClimaticPrepare, Me.ToolStripSeparator30, Me.mnuClimaticDescribe, Me.mnuClimaticNCMP, Me.mnuClimaticPICSA, Me.mnuCMSAF, Me.mnuClimaticCompare, Me.mnuClimaticMapping, Me.ToolStripSeparator16, Me.mnuClimaticModel, Me.mnuClimaticExamine, Me.mnuClimaticProcess, Me.ToolStripSeparator23, Me.mnuClimaticSCF, Me.mnuClimaticEvaporation, Me.mnuClimaticCrop, Me.mnuClimaticHeatSum, Me.mnuClimaticClimateMethods})
         Me.mnuClimatic.Name = "mnuClimatic"
-        Me.mnuClimatic.Size = New System.Drawing.Size(90, 29)
+        Me.mnuClimatic.Size = New System.Drawing.Size(63, 22)
         Me.mnuClimatic.Tag = "Climatic"
         Me.mnuClimatic.Text = "Climatic"
         '
@@ -1828,288 +1826,288 @@ Partial Class frmMain
         '
         Me.mnuClimaticFile.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticFileImportSST, Me.mnuClimaticFileImportfromIRIDataLibrary, Me.mnuClimaticFileImportfromClimateDataStore, Me.mnuClimaticFileImportandTidyNetCDF, Me.mnuClimaticFileImportandTidyShapefile, Me.mnuClimateFileImportfromClimSoft, Me.mnuClimaticFileImportfromCliData, Me.ToolStripSeparator15, Me.mnuClimaticFileExportToClimsoft, Me.mnuClimaticFileExportToCPT, Me.mnuExportToWWRToolStrip, Me.mnuClimaticFileExportToClimpact, Me.mnuClimaticFileExportToGoogleBucketsToolStrip})
         Me.mnuClimaticFile.Name = "mnuClimaticFile"
-        Me.mnuClimaticFile.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticFile.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticFile.Text = "File"
         '
         'mnuClimaticFileImportSST
         '
         Me.mnuClimaticFileImportSST.Name = "mnuClimaticFileImportSST"
-        Me.mnuClimaticFileImportSST.Size = New System.Drawing.Size(426, 34)
+        Me.mnuClimaticFileImportSST.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileImportSST.Text = "Import SST..."
         '
         'mnuClimaticFileImportfromIRIDataLibrary
         '
         Me.mnuClimaticFileImportfromIRIDataLibrary.Name = "mnuClimaticFileImportfromIRIDataLibrary"
-        Me.mnuClimaticFileImportfromIRIDataLibrary.Size = New System.Drawing.Size(426, 34)
+        Me.mnuClimaticFileImportfromIRIDataLibrary.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileImportfromIRIDataLibrary.Text = "Import from IRI Data Library..."
         '
         'mnuClimaticFileImportfromClimateDataStore
         '
         Me.mnuClimaticFileImportfromClimateDataStore.Name = "mnuClimaticFileImportfromClimateDataStore"
-        Me.mnuClimaticFileImportfromClimateDataStore.Size = New System.Drawing.Size(426, 34)
+        Me.mnuClimaticFileImportfromClimateDataStore.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileImportfromClimateDataStore.Text = "Import from CDS (Climate Data Store)..."
         '
         'mnuClimaticFileImportandTidyNetCDF
         '
         Me.mnuClimaticFileImportandTidyNetCDF.Name = "mnuClimaticFileImportandTidyNetCDF"
-        Me.mnuClimaticFileImportandTidyNetCDF.Size = New System.Drawing.Size(426, 34)
+        Me.mnuClimaticFileImportandTidyNetCDF.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileImportandTidyNetCDF.Text = "Import and Tidy NetCDF..."
         '
         'mnuClimaticFileImportandTidyShapefile
         '
         Me.mnuClimaticFileImportandTidyShapefile.Name = "mnuClimaticFileImportandTidyShapefile"
-        Me.mnuClimaticFileImportandTidyShapefile.Size = New System.Drawing.Size(426, 34)
+        Me.mnuClimaticFileImportandTidyShapefile.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileImportandTidyShapefile.Text = "Import and Tidy Shapefile..."
         '
         'mnuClimateFileImportfromClimSoft
         '
         Me.mnuClimateFileImportfromClimSoft.Name = "mnuClimateFileImportfromClimSoft"
-        Me.mnuClimateFileImportfromClimSoft.Size = New System.Drawing.Size(426, 34)
+        Me.mnuClimateFileImportfromClimSoft.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimateFileImportfromClimSoft.Text = "Import from Climsoft..."
         '
         'mnuClimaticFileImportfromCliData
         '
         Me.mnuClimaticFileImportfromCliData.Enabled = False
         Me.mnuClimaticFileImportfromCliData.Name = "mnuClimaticFileImportfromCliData"
-        Me.mnuClimaticFileImportfromCliData.Size = New System.Drawing.Size(426, 34)
+        Me.mnuClimaticFileImportfromCliData.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileImportfromCliData.Text = "Import from CLIDATA..."
         Me.mnuClimaticFileImportfromCliData.Visible = False
         '
         'ToolStripSeparator15
         '
         Me.ToolStripSeparator15.Name = "ToolStripSeparator15"
-        Me.ToolStripSeparator15.Size = New System.Drawing.Size(423, 6)
+        Me.ToolStripSeparator15.Size = New System.Drawing.Size(279, 6)
         '
         'mnuClimaticFileExportToClimsoft
         '
         Me.mnuClimaticFileExportToClimsoft.Name = "mnuClimaticFileExportToClimsoft"
-        Me.mnuClimaticFileExportToClimsoft.Size = New System.Drawing.Size(426, 34)
+        Me.mnuClimaticFileExportToClimsoft.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileExportToClimsoft.Text = "Export to Climsoft..."
         '
         'mnuClimaticFileExportToCPT
         '
         Me.mnuClimaticFileExportToCPT.Name = "mnuClimaticFileExportToCPT"
-        Me.mnuClimaticFileExportToCPT.Size = New System.Drawing.Size(426, 34)
+        Me.mnuClimaticFileExportToCPT.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileExportToCPT.Tag = "Export_to_CPT"
         Me.mnuClimaticFileExportToCPT.Text = "Export to CPT..."
         '
         'mnuExportToWWRToolStrip
         '
         Me.mnuExportToWWRToolStrip.Name = "mnuExportToWWRToolStrip"
-        Me.mnuExportToWWRToolStrip.Size = New System.Drawing.Size(426, 34)
+        Me.mnuExportToWWRToolStrip.Size = New System.Drawing.Size(282, 22)
         Me.mnuExportToWWRToolStrip.Text = "Export to World Weather Records..."
         '
         'mnuClimaticFileExportToClimpact
         '
         Me.mnuClimaticFileExportToClimpact.Name = "mnuClimaticFileExportToClimpact"
-        Me.mnuClimaticFileExportToClimpact.Size = New System.Drawing.Size(426, 34)
+        Me.mnuClimaticFileExportToClimpact.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileExportToClimpact.Text = "Export to Climpact..."
         '
         'mnuClimaticFileExportToGoogleBucketsToolStrip
         '
         Me.mnuClimaticFileExportToGoogleBucketsToolStrip.Name = "mnuClimaticFileExportToGoogleBucketsToolStrip"
-        Me.mnuClimaticFileExportToGoogleBucketsToolStrip.Size = New System.Drawing.Size(426, 34)
+        Me.mnuClimaticFileExportToGoogleBucketsToolStrip.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileExportToGoogleBucketsToolStrip.Text = "Export to Google Buckets..."
         '
         'ToolStripSeparator18
         '
         Me.ToolStripSeparator18.Name = "ToolStripSeparator18"
-        Me.ToolStripSeparator18.Size = New System.Drawing.Size(322, 6)
+        Me.ToolStripSeparator18.Size = New System.Drawing.Size(209, 6)
         '
         'mnuExamineEditData
         '
         Me.mnuExamineEditData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticExamineEditDataVisualiseData, Me.mnuExamineEditDataPivotTable, Me.ToolStripSeparator27, Me.mnuExamineEditDataOneVariableSummarise, Me.mnuExamineEditDataOneVariableGraph, Me.mnuExamineEditDataOneVariableFrequencies, Me.ToolStripSeparator78, Me.mnuExamineEditDataSetupForDataEditing, Me.mnuExamineEditDataDailyDataEditing, Me.mnuExamineEditDataCompareColumns})
         Me.mnuExamineEditData.Name = "mnuExamineEditData"
-        Me.mnuExamineEditData.Size = New System.Drawing.Size(325, 34)
+        Me.mnuExamineEditData.Size = New System.Drawing.Size(212, 22)
         Me.mnuExamineEditData.Text = "Examine/Edit Data"
         '
         'mnuClimaticExamineEditDataVisualiseData
         '
         Me.mnuClimaticExamineEditDataVisualiseData.Name = "mnuClimaticExamineEditDataVisualiseData"
-        Me.mnuClimaticExamineEditDataVisualiseData.Size = New System.Drawing.Size(324, 34)
+        Me.mnuClimaticExamineEditDataVisualiseData.Size = New System.Drawing.Size(215, 22)
         Me.mnuClimaticExamineEditDataVisualiseData.Text = "Visualise Data..."
         '
         'mnuExamineEditDataPivotTable
         '
         Me.mnuExamineEditDataPivotTable.Name = "mnuExamineEditDataPivotTable"
-        Me.mnuExamineEditDataPivotTable.Size = New System.Drawing.Size(324, 34)
+        Me.mnuExamineEditDataPivotTable.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataPivotTable.Text = "Pivot Table..."
         '
         'ToolStripSeparator27
         '
         Me.ToolStripSeparator27.Name = "ToolStripSeparator27"
-        Me.ToolStripSeparator27.Size = New System.Drawing.Size(321, 6)
+        Me.ToolStripSeparator27.Size = New System.Drawing.Size(212, 6)
         '
         'mnuExamineEditDataOneVariableSummarise
         '
         Me.mnuExamineEditDataOneVariableSummarise.Name = "mnuExamineEditDataOneVariableSummarise"
-        Me.mnuExamineEditDataOneVariableSummarise.Size = New System.Drawing.Size(324, 34)
+        Me.mnuExamineEditDataOneVariableSummarise.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataOneVariableSummarise.Text = "One Variable Summarise..."
         '
         'mnuExamineEditDataOneVariableGraph
         '
         Me.mnuExamineEditDataOneVariableGraph.Name = "mnuExamineEditDataOneVariableGraph"
-        Me.mnuExamineEditDataOneVariableGraph.Size = New System.Drawing.Size(324, 34)
+        Me.mnuExamineEditDataOneVariableGraph.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataOneVariableGraph.Text = "One Variable Graph..."
         '
         'mnuExamineEditDataOneVariableFrequencies
         '
         Me.mnuExamineEditDataOneVariableFrequencies.Name = "mnuExamineEditDataOneVariableFrequencies"
-        Me.mnuExamineEditDataOneVariableFrequencies.Size = New System.Drawing.Size(324, 34)
+        Me.mnuExamineEditDataOneVariableFrequencies.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataOneVariableFrequencies.Text = "One Variable Frequencies..."
         '
         'ToolStripSeparator78
         '
         Me.ToolStripSeparator78.Name = "ToolStripSeparator78"
-        Me.ToolStripSeparator78.Size = New System.Drawing.Size(321, 6)
+        Me.ToolStripSeparator78.Size = New System.Drawing.Size(212, 6)
         '
         'mnuExamineEditDataSetupForDataEditing
         '
         Me.mnuExamineEditDataSetupForDataEditing.Name = "mnuExamineEditDataSetupForDataEditing"
-        Me.mnuExamineEditDataSetupForDataEditing.Size = New System.Drawing.Size(324, 34)
+        Me.mnuExamineEditDataSetupForDataEditing.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataSetupForDataEditing.Text = "Setup for Data Editing..."
         '
         'mnuExamineEditDataDailyDataEditing
         '
         Me.mnuExamineEditDataDailyDataEditing.Name = "mnuExamineEditDataDailyDataEditing"
-        Me.mnuExamineEditDataDailyDataEditing.Size = New System.Drawing.Size(324, 34)
+        Me.mnuExamineEditDataDailyDataEditing.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataDailyDataEditing.Text = "Daily Data Editing..."
         '
         'mnuExamineEditDataCompareColumns
         '
         Me.mnuExamineEditDataCompareColumns.Name = "mnuExamineEditDataCompareColumns"
-        Me.mnuExamineEditDataCompareColumns.Size = New System.Drawing.Size(324, 34)
+        Me.mnuExamineEditDataCompareColumns.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataCompareColumns.Text = "Compare Columns..."
         '
         'mnuClimaticTidyandExamine
         '
         Me.mnuClimaticTidyandExamine.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticTidyandExamineTidyDailyData, Me.ToolStripSeparator71, Me.mnuClimaticTidyandExamineReplaceValues, Me.mnuClimaticTidyandExamineDuplicateRows, Me.mnuClimaticTidyandExamineNonNumericCases, Me.ToolStripSeparator54, Me.mnuClimaticTidyandExamineTransformText, Me.mnuClimaticTidyandExamineSplitText, Me.ToolStripSeparator80, Me.mnuClimaticTidyandExamineStack, Me.mnuClimaticTidyandExamineUnstack, Me.mnuClimaticTidyandExamineMerge, Me.mnuClimaticTidyandExamineAppend, Me.ToolStripSeparator69, Me.mnuClimaticTidyDataKey})
         Me.mnuClimaticTidyandExamine.Name = "mnuClimaticTidyandExamine"
-        Me.mnuClimaticTidyandExamine.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticTidyandExamine.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticTidyandExamine.Text = "Tidy Data"
         '
         'mnuClimaticTidyandExamineTidyDailyData
         '
         Me.mnuClimaticTidyandExamineTidyDailyData.Name = "mnuClimaticTidyandExamineTidyDailyData"
-        Me.mnuClimaticTidyandExamineTidyDailyData.Size = New System.Drawing.Size(301, 34)
+        Me.mnuClimaticTidyandExamineTidyDailyData.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineTidyDailyData.Text = "Tidy Daily Data..."
         '
         'ToolStripSeparator71
         '
         Me.ToolStripSeparator71.Name = "ToolStripSeparator71"
-        Me.ToolStripSeparator71.Size = New System.Drawing.Size(298, 6)
+        Me.ToolStripSeparator71.Size = New System.Drawing.Size(198, 6)
         '
         'mnuClimaticTidyandExamineReplaceValues
         '
         Me.mnuClimaticTidyandExamineReplaceValues.Name = "mnuClimaticTidyandExamineReplaceValues"
-        Me.mnuClimaticTidyandExamineReplaceValues.Size = New System.Drawing.Size(301, 34)
+        Me.mnuClimaticTidyandExamineReplaceValues.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineReplaceValues.Text = "Replace Values..."
         '
         'mnuClimaticTidyandExamineDuplicateRows
         '
         Me.mnuClimaticTidyandExamineDuplicateRows.Name = "mnuClimaticTidyandExamineDuplicateRows"
-        Me.mnuClimaticTidyandExamineDuplicateRows.Size = New System.Drawing.Size(301, 34)
+        Me.mnuClimaticTidyandExamineDuplicateRows.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineDuplicateRows.Text = "Duplicate Rows..."
         '
         'mnuClimaticTidyandExamineNonNumericCases
         '
         Me.mnuClimaticTidyandExamineNonNumericCases.Name = "mnuClimaticTidyandExamineNonNumericCases"
-        Me.mnuClimaticTidyandExamineNonNumericCases.Size = New System.Drawing.Size(301, 34)
+        Me.mnuClimaticTidyandExamineNonNumericCases.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineNonNumericCases.Text = "Non-Numeric Values..."
         '
         'ToolStripSeparator54
         '
         Me.ToolStripSeparator54.Name = "ToolStripSeparator54"
-        Me.ToolStripSeparator54.Size = New System.Drawing.Size(298, 6)
+        Me.ToolStripSeparator54.Size = New System.Drawing.Size(198, 6)
         '
         'mnuClimaticTidyandExamineTransformText
         '
         Me.mnuClimaticTidyandExamineTransformText.Name = "mnuClimaticTidyandExamineTransformText"
-        Me.mnuClimaticTidyandExamineTransformText.Size = New System.Drawing.Size(301, 34)
+        Me.mnuClimaticTidyandExamineTransformText.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineTransformText.Text = "Transform Text..."
         '
         'mnuClimaticTidyandExamineSplitText
         '
         Me.mnuClimaticTidyandExamineSplitText.Name = "mnuClimaticTidyandExamineSplitText"
-        Me.mnuClimaticTidyandExamineSplitText.Size = New System.Drawing.Size(301, 34)
+        Me.mnuClimaticTidyandExamineSplitText.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineSplitText.Text = "Split Text..."
         '
         'ToolStripSeparator80
         '
         Me.ToolStripSeparator80.Name = "ToolStripSeparator80"
-        Me.ToolStripSeparator80.Size = New System.Drawing.Size(298, 6)
+        Me.ToolStripSeparator80.Size = New System.Drawing.Size(198, 6)
         '
         'mnuClimaticTidyandExamineStack
         '
         Me.mnuClimaticTidyandExamineStack.Name = "mnuClimaticTidyandExamineStack"
-        Me.mnuClimaticTidyandExamineStack.Size = New System.Drawing.Size(301, 34)
+        Me.mnuClimaticTidyandExamineStack.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineStack.Text = "Stack (Pivot Longer)..."
         '
         'mnuClimaticTidyandExamineUnstack
         '
         Me.mnuClimaticTidyandExamineUnstack.Name = "mnuClimaticTidyandExamineUnstack"
-        Me.mnuClimaticTidyandExamineUnstack.Size = New System.Drawing.Size(301, 34)
+        Me.mnuClimaticTidyandExamineUnstack.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineUnstack.Text = "Unstack (Pivot Wider)..."
         '
         'mnuClimaticTidyandExamineMerge
         '
         Me.mnuClimaticTidyandExamineMerge.Name = "mnuClimaticTidyandExamineMerge"
-        Me.mnuClimaticTidyandExamineMerge.Size = New System.Drawing.Size(301, 34)
+        Me.mnuClimaticTidyandExamineMerge.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineMerge.Text = "Add (Merge) Columns..."
         '
         'mnuClimaticTidyandExamineAppend
         '
         Me.mnuClimaticTidyandExamineAppend.Name = "mnuClimaticTidyandExamineAppend"
-        Me.mnuClimaticTidyandExamineAppend.Size = New System.Drawing.Size(301, 34)
+        Me.mnuClimaticTidyandExamineAppend.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineAppend.Text = "Append (Bind Rows)..."
         '
         'ToolStripSeparator69
         '
         Me.ToolStripSeparator69.Name = "ToolStripSeparator69"
-        Me.ToolStripSeparator69.Size = New System.Drawing.Size(298, 6)
+        Me.ToolStripSeparator69.Size = New System.Drawing.Size(198, 6)
         '
         'mnuClimaticTidyDataKey
         '
         Me.mnuClimaticTidyDataKey.Name = "mnuClimaticTidyDataKey"
-        Me.mnuClimaticTidyDataKey.Size = New System.Drawing.Size(301, 34)
+        Me.mnuClimaticTidyDataKey.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyDataKey.Text = "Add Key..."
         '
         'mnuClimaticDates
         '
         Me.mnuClimaticDates.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticDatesGenerateDates, Me.mnuClimaticDatesMakeDate, Me.mnuClimaticDatesInfillMissingDates, Me.mnuClimaticDatesUseDate, Me.mnuClimaticDatesMakeTime, Me.mnuClimaticDatesUseTime})
         Me.mnuClimaticDates.Name = "mnuClimaticDates"
-        Me.mnuClimaticDates.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticDates.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticDates.Text = "Dates"
         '
         'mnuClimaticDatesGenerateDates
         '
         Me.mnuClimaticDatesGenerateDates.Name = "mnuClimaticDatesGenerateDates"
-        Me.mnuClimaticDatesGenerateDates.Size = New System.Drawing.Size(246, 34)
+        Me.mnuClimaticDatesGenerateDates.Size = New System.Drawing.Size(162, 22)
         Me.mnuClimaticDatesGenerateDates.Text = "Generate Dates..."
         '
         'mnuClimaticDatesMakeDate
         '
         Me.mnuClimaticDatesMakeDate.Name = "mnuClimaticDatesMakeDate"
-        Me.mnuClimaticDatesMakeDate.Size = New System.Drawing.Size(246, 34)
+        Me.mnuClimaticDatesMakeDate.Size = New System.Drawing.Size(162, 22)
         Me.mnuClimaticDatesMakeDate.Text = "Make Date..."
         '
         'mnuClimaticDatesInfillMissingDates
         '
         Me.mnuClimaticDatesInfillMissingDates.Name = "mnuClimaticDatesInfillMissingDates"
-        Me.mnuClimaticDatesInfillMissingDates.Size = New System.Drawing.Size(246, 34)
+        Me.mnuClimaticDatesInfillMissingDates.Size = New System.Drawing.Size(162, 22)
         Me.mnuClimaticDatesInfillMissingDates.Text = "Fill Date Gaps..."
         '
         'mnuClimaticDatesUseDate
         '
         Me.mnuClimaticDatesUseDate.Name = "mnuClimaticDatesUseDate"
-        Me.mnuClimaticDatesUseDate.Size = New System.Drawing.Size(246, 34)
+        Me.mnuClimaticDatesUseDate.Size = New System.Drawing.Size(162, 22)
         Me.mnuClimaticDatesUseDate.Text = "Use Date..."
         '
         'mnuClimaticDatesMakeTime
         '
         Me.mnuClimaticDatesMakeTime.Enabled = False
         Me.mnuClimaticDatesMakeTime.Name = "mnuClimaticDatesMakeTime"
-        Me.mnuClimaticDatesMakeTime.Size = New System.Drawing.Size(246, 34)
+        Me.mnuClimaticDatesMakeTime.Size = New System.Drawing.Size(162, 22)
         Me.mnuClimaticDatesMakeTime.Text = "Make Time..."
         Me.mnuClimaticDatesMakeTime.Visible = False
         '
@@ -2117,175 +2115,175 @@ Partial Class frmMain
         '
         Me.mnuClimaticDatesUseTime.Enabled = False
         Me.mnuClimaticDatesUseTime.Name = "mnuClimaticDatesUseTime"
-        Me.mnuClimaticDatesUseTime.Size = New System.Drawing.Size(246, 34)
+        Me.mnuClimaticDatesUseTime.Size = New System.Drawing.Size(162, 22)
         Me.mnuClimaticDatesUseTime.Text = "Use Time..."
         Me.mnuClimaticDatesUseTime.Visible = False
         '
         'mnuClimaticDefineClimaticData
         '
         Me.mnuClimaticDefineClimaticData.Name = "mnuClimaticDefineClimaticData"
-        Me.mnuClimaticDefineClimaticData.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticDefineClimaticData.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticDefineClimaticData.Text = "Define Climatic Data..."
         '
         'mnuClimaticCheckData
         '
         Me.mnuClimaticCheckData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticCheckDataInventory, Me.mnuClimaticCheckDataDisplayDaily, Me.ToolStripSeparator65, Me.mnuClimaticCheckDataFillMissingValues, Me.mnuClimaticCheckDataBoxplot, Me.mnuClimaticCheckDataQCTemperatures, Me.mnuClimaticCheckDataQCRainfall, Me.ToolStripSeparator70, Me.mnuClimaticCheckDataHomogenization, Me.mnuClimaticCheckDataCheckStationLocations, Me.mnuClimaticCheckDataDistances})
         Me.mnuClimaticCheckData.Name = "mnuClimaticCheckData"
-        Me.mnuClimaticCheckData.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticCheckData.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticCheckData.Text = "Check Data"
         '
         'mnuClimaticCheckDataInventory
         '
         Me.mnuClimaticCheckDataInventory.Name = "mnuClimaticCheckDataInventory"
-        Me.mnuClimaticCheckDataInventory.Size = New System.Drawing.Size(313, 34)
+        Me.mnuClimaticCheckDataInventory.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataInventory.Text = "Inventory..."
         '
         'mnuClimaticCheckDataDisplayDaily
         '
         Me.mnuClimaticCheckDataDisplayDaily.Name = "mnuClimaticCheckDataDisplayDaily"
-        Me.mnuClimaticCheckDataDisplayDaily.Size = New System.Drawing.Size(313, 34)
+        Me.mnuClimaticCheckDataDisplayDaily.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataDisplayDaily.Text = "Display Daily..."
         '
         'ToolStripSeparator65
         '
         Me.ToolStripSeparator65.Name = "ToolStripSeparator65"
-        Me.ToolStripSeparator65.Size = New System.Drawing.Size(310, 6)
+        Me.ToolStripSeparator65.Size = New System.Drawing.Size(207, 6)
         '
         'mnuClimaticCheckDataFillMissingValues
         '
         Me.mnuClimaticCheckDataFillMissingValues.Name = "mnuClimaticCheckDataFillMissingValues"
-        Me.mnuClimaticCheckDataFillMissingValues.Size = New System.Drawing.Size(313, 34)
+        Me.mnuClimaticCheckDataFillMissingValues.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataFillMissingValues.Text = "Fill Missing Values..."
         '
         'mnuClimaticCheckDataBoxplot
         '
         Me.mnuClimaticCheckDataBoxplot.Name = "mnuClimaticCheckDataBoxplot"
-        Me.mnuClimaticCheckDataBoxplot.Size = New System.Drawing.Size(313, 34)
+        Me.mnuClimaticCheckDataBoxplot.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataBoxplot.Text = "Boxplot..."
         '
         'mnuClimaticCheckDataQCTemperatures
         '
         Me.mnuClimaticCheckDataQCTemperatures.Name = "mnuClimaticCheckDataQCTemperatures"
-        Me.mnuClimaticCheckDataQCTemperatures.Size = New System.Drawing.Size(313, 34)
+        Me.mnuClimaticCheckDataQCTemperatures.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataQCTemperatures.Text = "QC Temperatures..."
         '
         'mnuClimaticCheckDataQCRainfall
         '
         Me.mnuClimaticCheckDataQCRainfall.Name = "mnuClimaticCheckDataQCRainfall"
-        Me.mnuClimaticCheckDataQCRainfall.Size = New System.Drawing.Size(313, 34)
+        Me.mnuClimaticCheckDataQCRainfall.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataQCRainfall.Text = "QC Rainfall..."
         '
         'ToolStripSeparator70
         '
         Me.ToolStripSeparator70.Name = "ToolStripSeparator70"
-        Me.ToolStripSeparator70.Size = New System.Drawing.Size(310, 6)
+        Me.ToolStripSeparator70.Size = New System.Drawing.Size(207, 6)
         '
         'mnuClimaticCheckDataHomogenization
         '
         Me.mnuClimaticCheckDataHomogenization.Name = "mnuClimaticCheckDataHomogenization"
-        Me.mnuClimaticCheckDataHomogenization.Size = New System.Drawing.Size(313, 34)
+        Me.mnuClimaticCheckDataHomogenization.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataHomogenization.Text = "Homogenization..."
         '
         'mnuClimaticCheckDataCheckStationLocations
         '
         Me.mnuClimaticCheckDataCheckStationLocations.Name = "mnuClimaticCheckDataCheckStationLocations"
-        Me.mnuClimaticCheckDataCheckStationLocations.Size = New System.Drawing.Size(313, 34)
+        Me.mnuClimaticCheckDataCheckStationLocations.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataCheckStationLocations.Text = "Check Station Locations..."
         '
         'mnuClimaticCheckDataDistances
         '
         Me.mnuClimaticCheckDataDistances.Name = "mnuClimaticCheckDataDistances"
-        Me.mnuClimaticCheckDataDistances.Size = New System.Drawing.Size(313, 34)
+        Me.mnuClimaticCheckDataDistances.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataDistances.Text = "Distances..."
         '
         'mnuClimaticPrepare
         '
         Me.mnuClimaticPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuCimaticPrepareTransform, Me.mnuClimaticPrepareConversions, Me.ToolStripSeparator37, Me.mnuClimaticPrepareClimaticSummaries, Me.mnuClimaticPrepareStartoftheRains, Me.mnuClimaticPrepareEndOfRains, Me.mnuClimaticPrepareLengthOfSeason, Me.mnuClimaticPrepareSpells, Me.mnuClimaticPrepareExtremes, Me.ToolStripSeparator64, Me.mnuClimaticPrepareClimdex, Me.ToolStripSeparator51, Me.mnuClimaticPrepareEvapotranspiration, Me.mnuClimaticPrepareSummary, Me.mnuClimaticPrepareNewWorksheet, Me.mnuClimaticPrepareImportDailyData, Me.mnuClimaticPrepareMakeFactor, Me.mnuClimaticPrepareShiftDailyData, Me.mnuClimaticPrepareUnstackDailyData, Me.mnuClimaticPrepareStackDailyData})
         Me.mnuClimaticPrepare.Name = "mnuClimaticPrepare"
-        Me.mnuClimaticPrepare.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticPrepare.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticPrepare.Tag = "Prepare"
         Me.mnuClimaticPrepare.Text = "Prepare"
         '
         'mnuCimaticPrepareTransform
         '
         Me.mnuCimaticPrepareTransform.Name = "mnuCimaticPrepareTransform"
-        Me.mnuCimaticPrepareTransform.Size = New System.Drawing.Size(281, 34)
+        Me.mnuCimaticPrepareTransform.Size = New System.Drawing.Size(189, 22)
         Me.mnuCimaticPrepareTransform.Text = "Transform..."
         '
         'mnuClimaticPrepareConversions
         '
         Me.mnuClimaticPrepareConversions.Name = "mnuClimaticPrepareConversions"
-        Me.mnuClimaticPrepareConversions.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareConversions.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareConversions.Text = "Conversions..."
         '
         'ToolStripSeparator37
         '
         Me.ToolStripSeparator37.Name = "ToolStripSeparator37"
-        Me.ToolStripSeparator37.Size = New System.Drawing.Size(278, 6)
+        Me.ToolStripSeparator37.Size = New System.Drawing.Size(186, 6)
         '
         'mnuClimaticPrepareClimaticSummaries
         '
         Me.mnuClimaticPrepareClimaticSummaries.Name = "mnuClimaticPrepareClimaticSummaries"
-        Me.mnuClimaticPrepareClimaticSummaries.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareClimaticSummaries.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareClimaticSummaries.Text = "Climatic Summaries..."
         '
         'mnuClimaticPrepareStartoftheRains
         '
         Me.mnuClimaticPrepareStartoftheRains.Name = "mnuClimaticPrepareStartoftheRains"
-        Me.mnuClimaticPrepareStartoftheRains.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareStartoftheRains.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareStartoftheRains.Text = "Start of the Rains..."
         '
         'mnuClimaticPrepareEndOfRains
         '
         Me.mnuClimaticPrepareEndOfRains.Name = "mnuClimaticPrepareEndOfRains"
-        Me.mnuClimaticPrepareEndOfRains.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareEndOfRains.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareEndOfRains.Text = "End of Rains..."
         '
         'mnuClimaticPrepareLengthOfSeason
         '
         Me.mnuClimaticPrepareLengthOfSeason.Name = "mnuClimaticPrepareLengthOfSeason"
-        Me.mnuClimaticPrepareLengthOfSeason.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareLengthOfSeason.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareLengthOfSeason.Text = "Length of Season..."
         '
         'mnuClimaticPrepareSpells
         '
         Me.mnuClimaticPrepareSpells.Name = "mnuClimaticPrepareSpells"
-        Me.mnuClimaticPrepareSpells.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareSpells.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareSpells.Text = "Spells..."
         '
         'mnuClimaticPrepareExtremes
         '
         Me.mnuClimaticPrepareExtremes.Name = "mnuClimaticPrepareExtremes"
-        Me.mnuClimaticPrepareExtremes.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareExtremes.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareExtremes.Text = "Extremes..."
         '
         'ToolStripSeparator64
         '
         Me.ToolStripSeparator64.Name = "ToolStripSeparator64"
-        Me.ToolStripSeparator64.Size = New System.Drawing.Size(278, 6)
+        Me.ToolStripSeparator64.Size = New System.Drawing.Size(186, 6)
         '
         'mnuClimaticPrepareClimdex
         '
         Me.mnuClimaticPrepareClimdex.Name = "mnuClimaticPrepareClimdex"
-        Me.mnuClimaticPrepareClimdex.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareClimdex.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareClimdex.Text = "Climdex..."
         '
         'ToolStripSeparator51
         '
         Me.ToolStripSeparator51.Name = "ToolStripSeparator51"
-        Me.ToolStripSeparator51.Size = New System.Drawing.Size(278, 6)
+        Me.ToolStripSeparator51.Size = New System.Drawing.Size(186, 6)
         '
         'mnuClimaticPrepareEvapotranspiration
         '
         Me.mnuClimaticPrepareEvapotranspiration.Name = "mnuClimaticPrepareEvapotranspiration"
-        Me.mnuClimaticPrepareEvapotranspiration.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareEvapotranspiration.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareEvapotranspiration.Text = "Evapotranspiration..."
         '
         'mnuClimaticPrepareSummary
         '
         Me.mnuClimaticPrepareSummary.Enabled = False
         Me.mnuClimaticPrepareSummary.Name = "mnuClimaticPrepareSummary"
-        Me.mnuClimaticPrepareSummary.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareSummary.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareSummary.Text = "Summary..."
         Me.mnuClimaticPrepareSummary.Visible = False
         '
@@ -2293,7 +2291,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticPrepareNewWorksheet.Enabled = False
         Me.mnuClimaticPrepareNewWorksheet.Name = "mnuClimaticPrepareNewWorksheet"
-        Me.mnuClimaticPrepareNewWorksheet.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareNewWorksheet.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareNewWorksheet.Tag = "New_Worksheet"
         Me.mnuClimaticPrepareNewWorksheet.Text = "New Worksheet..."
         Me.mnuClimaticPrepareNewWorksheet.Visible = False
@@ -2302,7 +2300,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticPrepareImportDailyData.Enabled = False
         Me.mnuClimaticPrepareImportDailyData.Name = "mnuClimaticPrepareImportDailyData"
-        Me.mnuClimaticPrepareImportDailyData.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareImportDailyData.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareImportDailyData.Tag = "Import_daily_data"
         Me.mnuClimaticPrepareImportDailyData.Text = "Import daily Data..."
         Me.mnuClimaticPrepareImportDailyData.Visible = False
@@ -2311,7 +2309,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticPrepareMakeFactor.Enabled = False
         Me.mnuClimaticPrepareMakeFactor.Name = "mnuClimaticPrepareMakeFactor"
-        Me.mnuClimaticPrepareMakeFactor.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareMakeFactor.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareMakeFactor.Tag = "Make_Factor"
         Me.mnuClimaticPrepareMakeFactor.Text = "Make Factor..."
         Me.mnuClimaticPrepareMakeFactor.Visible = False
@@ -2320,7 +2318,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticPrepareShiftDailyData.Enabled = False
         Me.mnuClimaticPrepareShiftDailyData.Name = "mnuClimaticPrepareShiftDailyData"
-        Me.mnuClimaticPrepareShiftDailyData.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareShiftDailyData.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareShiftDailyData.Tag = "Shift_Daily_data"
         Me.mnuClimaticPrepareShiftDailyData.Text = "Shift Daily Data..."
         Me.mnuClimaticPrepareShiftDailyData.Visible = False
@@ -2329,7 +2327,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticPrepareUnstackDailyData.Enabled = False
         Me.mnuClimaticPrepareUnstackDailyData.Name = "mnuClimaticPrepareUnstackDailyData"
-        Me.mnuClimaticPrepareUnstackDailyData.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareUnstackDailyData.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareUnstackDailyData.Tag = "Unstack_Daily_data"
         Me.mnuClimaticPrepareUnstackDailyData.Text = "Unstack Daily Data..."
         Me.mnuClimaticPrepareUnstackDailyData.Visible = False
@@ -2338,7 +2336,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticPrepareStackDailyData.Enabled = False
         Me.mnuClimaticPrepareStackDailyData.Name = "mnuClimaticPrepareStackDailyData"
-        Me.mnuClimaticPrepareStackDailyData.Size = New System.Drawing.Size(281, 34)
+        Me.mnuClimaticPrepareStackDailyData.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareStackDailyData.Tag = "Stack_Daily_data"
         Me.mnuClimaticPrepareStackDailyData.Text = "Stack Daily data..."
         Me.mnuClimaticPrepareStackDailyData.Visible = False
@@ -2346,367 +2344,367 @@ Partial Class frmMain
         'ToolStripSeparator30
         '
         Me.ToolStripSeparator30.Name = "ToolStripSeparator30"
-        Me.ToolStripSeparator30.Size = New System.Drawing.Size(322, 6)
+        Me.ToolStripSeparator30.Size = New System.Drawing.Size(209, 6)
         '
         'mnuClimaticDescribe
         '
         Me.mnuClimaticDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticDescribeSummarise23Variables, Me.mnuClimaticDescribeGraph23Variables, Me.ToolStripSeparator31, Me.mnuClimaticDescribeSPISPEI, Me.mnuClimaticDescribeClimograph, Me.mnuClimaticDescribeTrendGraph, Me.mnuClimaticDescribeSeasonalGraph, Me.mnuClimaticDescribeIDF, Me.ToolStripSeparator17, Me.mnuClimaticDescribeWindRose, Me.mnuClimaticDescribeWindPollutionRose, Me.mnuClimaticDescribeOtherRosePlots})
         Me.mnuClimaticDescribe.Name = "mnuClimaticDescribe"
-        Me.mnuClimaticDescribe.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticDescribe.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticDescribe.Text = "Describe"
         '
         'mnuClimaticDescribeSummarise23Variables
         '
         Me.mnuClimaticDescribeSummarise23Variables.Name = "mnuClimaticDescribeSummarise23Variables"
-        Me.mnuClimaticDescribeSummarise23Variables.Size = New System.Drawing.Size(321, 34)
+        Me.mnuClimaticDescribeSummarise23Variables.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeSummarise23Variables.Text = "Summarise 2/3 Variables..."
         '
         'mnuClimaticDescribeGraph23Variables
         '
         Me.mnuClimaticDescribeGraph23Variables.Name = "mnuClimaticDescribeGraph23Variables"
-        Me.mnuClimaticDescribeGraph23Variables.Size = New System.Drawing.Size(321, 34)
+        Me.mnuClimaticDescribeGraph23Variables.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeGraph23Variables.Text = "Graph 2/3 Variables..."
         '
         'ToolStripSeparator31
         '
         Me.ToolStripSeparator31.Name = "ToolStripSeparator31"
-        Me.ToolStripSeparator31.Size = New System.Drawing.Size(318, 6)
+        Me.ToolStripSeparator31.Size = New System.Drawing.Size(208, 6)
         '
         'mnuClimaticDescribeSPISPEI
         '
         Me.mnuClimaticDescribeSPISPEI.Name = "mnuClimaticDescribeSPISPEI"
-        Me.mnuClimaticDescribeSPISPEI.Size = New System.Drawing.Size(321, 34)
+        Me.mnuClimaticDescribeSPISPEI.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeSPISPEI.Text = "SPI/SPEI..."
         '
         'mnuClimaticDescribeClimograph
         '
         Me.mnuClimaticDescribeClimograph.Name = "mnuClimaticDescribeClimograph"
-        Me.mnuClimaticDescribeClimograph.Size = New System.Drawing.Size(321, 34)
+        Me.mnuClimaticDescribeClimograph.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeClimograph.Text = "Climograph..."
         '
         'mnuClimaticDescribeTrendGraph
         '
         Me.mnuClimaticDescribeTrendGraph.Name = "mnuClimaticDescribeTrendGraph"
-        Me.mnuClimaticDescribeTrendGraph.Size = New System.Drawing.Size(321, 34)
+        Me.mnuClimaticDescribeTrendGraph.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeTrendGraph.Text = "Trend Graph..."
         '
         'mnuClimaticDescribeSeasonalGraph
         '
         Me.mnuClimaticDescribeSeasonalGraph.Name = "mnuClimaticDescribeSeasonalGraph"
-        Me.mnuClimaticDescribeSeasonalGraph.Size = New System.Drawing.Size(321, 34)
+        Me.mnuClimaticDescribeSeasonalGraph.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeSeasonalGraph.Text = "Seasonal Graph..."
         '
         'mnuClimaticDescribeIDF
         '
         Me.mnuClimaticDescribeIDF.Name = "mnuClimaticDescribeIDF"
-        Me.mnuClimaticDescribeIDF.Size = New System.Drawing.Size(321, 34)
+        Me.mnuClimaticDescribeIDF.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeIDF.Text = "IDF..."
         '
         'ToolStripSeparator17
         '
         Me.ToolStripSeparator17.Name = "ToolStripSeparator17"
-        Me.ToolStripSeparator17.Size = New System.Drawing.Size(318, 6)
+        Me.ToolStripSeparator17.Size = New System.Drawing.Size(208, 6)
         '
         'mnuClimaticDescribeWindRose
         '
         Me.mnuClimaticDescribeWindRose.Name = "mnuClimaticDescribeWindRose"
-        Me.mnuClimaticDescribeWindRose.Size = New System.Drawing.Size(321, 34)
+        Me.mnuClimaticDescribeWindRose.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeWindRose.Text = "Wind Rose..."
         '
         'mnuClimaticDescribeWindPollutionRose
         '
         Me.mnuClimaticDescribeWindPollutionRose.Name = "mnuClimaticDescribeWindPollutionRose"
-        Me.mnuClimaticDescribeWindPollutionRose.Size = New System.Drawing.Size(321, 34)
+        Me.mnuClimaticDescribeWindPollutionRose.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeWindPollutionRose.Text = "Wind/Pollution Rose..."
         '
         'mnuClimaticDescribeOtherRosePlots
         '
         Me.mnuClimaticDescribeOtherRosePlots.Name = "mnuClimaticDescribeOtherRosePlots"
-        Me.mnuClimaticDescribeOtherRosePlots.Size = New System.Drawing.Size(321, 34)
+        Me.mnuClimaticDescribeOtherRosePlots.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeOtherRosePlots.Text = "Other Rose Plots..."
         '
         'mnuClimaticNCMP
         '
         Me.mnuClimaticNCMP.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticNCMPIndices, Me.mnuClimaticNCMPVariogram, Me.mnuClimaticNCMPRegionAverage, Me.mnuClimaticNCMPTrendGraphs, Me.mnuClimaticNCMPCountRecords, Me.mnuClimaticNCMPSummary})
         Me.mnuClimaticNCMP.Name = "mnuClimaticNCMP"
-        Me.mnuClimaticNCMP.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticNCMP.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticNCMP.Text = "NCMP"
         '
         'mnuClimaticNCMPIndices
         '
         Me.mnuClimaticNCMPIndices.Name = "mnuClimaticNCMPIndices"
-        Me.mnuClimaticNCMPIndices.Size = New System.Drawing.Size(251, 34)
+        Me.mnuClimaticNCMPIndices.Size = New System.Drawing.Size(166, 22)
         Me.mnuClimaticNCMPIndices.Text = "Indices..."
         '
         'mnuClimaticNCMPVariogram
         '
         Me.mnuClimaticNCMPVariogram.Name = "mnuClimaticNCMPVariogram"
-        Me.mnuClimaticNCMPVariogram.Size = New System.Drawing.Size(251, 34)
+        Me.mnuClimaticNCMPVariogram.Size = New System.Drawing.Size(166, 22)
         Me.mnuClimaticNCMPVariogram.Text = "Variogram..."
         '
         'mnuClimaticNCMPRegionAverage
         '
         Me.mnuClimaticNCMPRegionAverage.Name = "mnuClimaticNCMPRegionAverage"
-        Me.mnuClimaticNCMPRegionAverage.Size = New System.Drawing.Size(251, 34)
+        Me.mnuClimaticNCMPRegionAverage.Size = New System.Drawing.Size(166, 22)
         Me.mnuClimaticNCMPRegionAverage.Text = "Region Average..."
         '
         'mnuClimaticNCMPTrendGraphs
         '
         Me.mnuClimaticNCMPTrendGraphs.Name = "mnuClimaticNCMPTrendGraphs"
-        Me.mnuClimaticNCMPTrendGraphs.Size = New System.Drawing.Size(251, 34)
+        Me.mnuClimaticNCMPTrendGraphs.Size = New System.Drawing.Size(166, 22)
         Me.mnuClimaticNCMPTrendGraphs.Text = "Trend Graphs..."
         '
         'mnuClimaticNCMPCountRecords
         '
         Me.mnuClimaticNCMPCountRecords.Name = "mnuClimaticNCMPCountRecords"
-        Me.mnuClimaticNCMPCountRecords.Size = New System.Drawing.Size(251, 34)
+        Me.mnuClimaticNCMPCountRecords.Size = New System.Drawing.Size(166, 22)
         Me.mnuClimaticNCMPCountRecords.Text = "Count Records..."
         '
         'mnuClimaticNCMPSummary
         '
         Me.mnuClimaticNCMPSummary.Name = "mnuClimaticNCMPSummary"
-        Me.mnuClimaticNCMPSummary.Size = New System.Drawing.Size(251, 34)
+        Me.mnuClimaticNCMPSummary.Size = New System.Drawing.Size(166, 22)
         Me.mnuClimaticNCMPSummary.Text = "Summary..."
         '
         'mnuClimaticPICSA
         '
         Me.mnuClimaticPICSA.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticPICSARainfallGraph, Me.mnuClimaticPICSATemperatureGraph, Me.mnuClimaticPICSAGeneralGrap, Me.ToolStripSeparator73, Me.mnuClimaticPICSACumExeedenceGraph, Me.mnuClimaticPICSACrops})
         Me.mnuClimaticPICSA.Name = "mnuClimaticPICSA"
-        Me.mnuClimaticPICSA.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticPICSA.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticPICSA.Text = "PICSA"
         '
         'mnuClimaticPICSARainfallGraph
         '
         Me.mnuClimaticPICSARainfallGraph.Name = "mnuClimaticPICSARainfallGraph"
-        Me.mnuClimaticPICSARainfallGraph.Size = New System.Drawing.Size(364, 34)
+        Me.mnuClimaticPICSARainfallGraph.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticPICSARainfallGraph.Text = "Rainfall Graph..."
         '
         'mnuClimaticPICSATemperatureGraph
         '
         Me.mnuClimaticPICSATemperatureGraph.Name = "mnuClimaticPICSATemperatureGraph"
-        Me.mnuClimaticPICSATemperatureGraph.Size = New System.Drawing.Size(364, 34)
+        Me.mnuClimaticPICSATemperatureGraph.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticPICSATemperatureGraph.Text = "Temperature Graph..."
         '
         'mnuClimaticPICSAGeneralGrap
         '
         Me.mnuClimaticPICSAGeneralGrap.Name = "mnuClimaticPICSAGeneralGrap"
-        Me.mnuClimaticPICSAGeneralGrap.Size = New System.Drawing.Size(364, 34)
+        Me.mnuClimaticPICSAGeneralGrap.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticPICSAGeneralGrap.Text = "General Graph..."
         '
         'ToolStripSeparator73
         '
         Me.ToolStripSeparator73.Name = "ToolStripSeparator73"
-        Me.ToolStripSeparator73.Size = New System.Drawing.Size(361, 6)
+        Me.ToolStripSeparator73.Size = New System.Drawing.Size(242, 6)
         '
         'mnuClimaticPICSACumExeedenceGraph
         '
         Me.mnuClimaticPICSACumExeedenceGraph.Name = "mnuClimaticPICSACumExeedenceGraph"
-        Me.mnuClimaticPICSACumExeedenceGraph.Size = New System.Drawing.Size(364, 34)
+        Me.mnuClimaticPICSACumExeedenceGraph.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticPICSACumExeedenceGraph.Text = "Cumulative/Exceedance Graph..."
         '
         'mnuClimaticPICSACrops
         '
         Me.mnuClimaticPICSACrops.Name = "mnuClimaticPICSACrops"
-        Me.mnuClimaticPICSACrops.Size = New System.Drawing.Size(364, 34)
+        Me.mnuClimaticPICSACrops.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticPICSACrops.Text = "Crops..."
         '
         'mnuCMSAF
         '
         Me.mnuCMSAF.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticCMSAFPlotRegion, Me.mnuClimaticCMSAFExporttoCMSAFRToolbox})
         Me.mnuCMSAF.Name = "mnuCMSAF"
-        Me.mnuCMSAF.Size = New System.Drawing.Size(325, 34)
+        Me.mnuCMSAF.Size = New System.Drawing.Size(212, 22)
         Me.mnuCMSAF.Text = "CM SAF"
         '
         'mnuClimaticCMSAFPlotRegion
         '
         Me.mnuClimaticCMSAFPlotRegion.Name = "mnuClimaticCMSAFPlotRegion"
-        Me.mnuClimaticCMSAFPlotRegion.Size = New System.Drawing.Size(351, 34)
+        Me.mnuClimaticCMSAFPlotRegion.Size = New System.Drawing.Size(230, 22)
         Me.mnuClimaticCMSAFPlotRegion.Text = "Plot Region..."
         '
         'mnuClimaticCMSAFExporttoCMSAFRToolbox
         '
         Me.mnuClimaticCMSAFExporttoCMSAFRToolbox.Name = "mnuClimaticCMSAFExporttoCMSAFRToolbox"
-        Me.mnuClimaticCMSAFExporttoCMSAFRToolbox.Size = New System.Drawing.Size(351, 34)
+        Me.mnuClimaticCMSAFExporttoCMSAFRToolbox.Size = New System.Drawing.Size(230, 22)
         Me.mnuClimaticCMSAFExporttoCMSAFRToolbox.Text = "Export to CM SAF R Toolbox..."
         '
         'mnuClimaticCompare
         '
         Me.mnuClimaticCompare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticCompareCalculation, Me.mnuClimaticCompareSummary, Me.ToolStripSeparator66, Me.mnuClimaticCompareCorrelations, Me.mnuClimaticCompareScatterplot, Me.mnuClimaticCompareTimeSeriesPlot, Me.mnuClimaticCompareSeasonalPlot, Me.mnuClimaticCompareDensityPlot, Me.mnuClimaticCompareConditionalQuantiles, Me.mnuClimaticCompareTaylorDiagram})
         Me.mnuClimaticCompare.Name = "mnuClimaticCompare"
-        Me.mnuClimaticCompare.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticCompare.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticCompare.Text = "Compare"
         '
         'mnuClimaticCompareCalculation
         '
         Me.mnuClimaticCompareCalculation.Name = "mnuClimaticCompareCalculation"
-        Me.mnuClimaticCompareCalculation.Size = New System.Drawing.Size(296, 34)
+        Me.mnuClimaticCompareCalculation.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareCalculation.Text = "Calculation..."
         '
         'mnuClimaticCompareSummary
         '
         Me.mnuClimaticCompareSummary.Name = "mnuClimaticCompareSummary"
-        Me.mnuClimaticCompareSummary.Size = New System.Drawing.Size(296, 34)
+        Me.mnuClimaticCompareSummary.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareSummary.Text = "Summary..."
         '
         'ToolStripSeparator66
         '
         Me.ToolStripSeparator66.Name = "ToolStripSeparator66"
-        Me.ToolStripSeparator66.Size = New System.Drawing.Size(293, 6)
+        Me.ToolStripSeparator66.Size = New System.Drawing.Size(195, 6)
         '
         'mnuClimaticCompareCorrelations
         '
         Me.mnuClimaticCompareCorrelations.Name = "mnuClimaticCompareCorrelations"
-        Me.mnuClimaticCompareCorrelations.Size = New System.Drawing.Size(296, 34)
+        Me.mnuClimaticCompareCorrelations.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareCorrelations.Text = "Correlations..."
         '
         'mnuClimaticCompareScatterplot
         '
         Me.mnuClimaticCompareScatterplot.Name = "mnuClimaticCompareScatterplot"
-        Me.mnuClimaticCompareScatterplot.Size = New System.Drawing.Size(296, 34)
+        Me.mnuClimaticCompareScatterplot.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareScatterplot.Text = "Scatterplot..."
         '
         'mnuClimaticCompareTimeSeriesPlot
         '
         Me.mnuClimaticCompareTimeSeriesPlot.Name = "mnuClimaticCompareTimeSeriesPlot"
-        Me.mnuClimaticCompareTimeSeriesPlot.Size = New System.Drawing.Size(296, 34)
+        Me.mnuClimaticCompareTimeSeriesPlot.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareTimeSeriesPlot.Text = "Time Series Plot..."
         '
         'mnuClimaticCompareSeasonalPlot
         '
         Me.mnuClimaticCompareSeasonalPlot.Name = "mnuClimaticCompareSeasonalPlot"
-        Me.mnuClimaticCompareSeasonalPlot.Size = New System.Drawing.Size(296, 34)
+        Me.mnuClimaticCompareSeasonalPlot.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareSeasonalPlot.Text = "Seasonal Plot..."
         '
         'mnuClimaticCompareDensityPlot
         '
         Me.mnuClimaticCompareDensityPlot.Name = "mnuClimaticCompareDensityPlot"
-        Me.mnuClimaticCompareDensityPlot.Size = New System.Drawing.Size(296, 34)
+        Me.mnuClimaticCompareDensityPlot.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareDensityPlot.Text = "Density Plot..."
         '
         'mnuClimaticCompareConditionalQuantiles
         '
         Me.mnuClimaticCompareConditionalQuantiles.Name = "mnuClimaticCompareConditionalQuantiles"
-        Me.mnuClimaticCompareConditionalQuantiles.Size = New System.Drawing.Size(296, 34)
+        Me.mnuClimaticCompareConditionalQuantiles.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareConditionalQuantiles.Text = "Conditional Quantiles..."
         '
         'mnuClimaticCompareTaylorDiagram
         '
         Me.mnuClimaticCompareTaylorDiagram.Name = "mnuClimaticCompareTaylorDiagram"
-        Me.mnuClimaticCompareTaylorDiagram.Size = New System.Drawing.Size(296, 34)
+        Me.mnuClimaticCompareTaylorDiagram.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareTaylorDiagram.Text = "Taylor Diagram..."
         '
         'mnuClimaticMapping
         '
         Me.mnuClimaticMapping.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticMappingMap, Me.mnuClimaticMappingCheckStationLocations})
         Me.mnuClimaticMapping.Name = "mnuClimaticMapping"
-        Me.mnuClimaticMapping.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticMapping.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticMapping.Text = "Mapping"
         '
         'mnuClimaticMappingMap
         '
         Me.mnuClimaticMappingMap.Name = "mnuClimaticMappingMap"
-        Me.mnuClimaticMappingMap.Size = New System.Drawing.Size(313, 34)
+        Me.mnuClimaticMappingMap.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticMappingMap.Text = "Map..."
         '
         'mnuClimaticMappingCheckStationLocations
         '
         Me.mnuClimaticMappingCheckStationLocations.Name = "mnuClimaticMappingCheckStationLocations"
-        Me.mnuClimaticMappingCheckStationLocations.Size = New System.Drawing.Size(313, 34)
+        Me.mnuClimaticMappingCheckStationLocations.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticMappingCheckStationLocations.Text = "Check Station Locations..."
         '
         'mnuClimaticModel
         '
         Me.mnuClimaticModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticModelOutfilling, Me.mnuClimaticModelsExtremes, Me.mnuClimaticModelCircular, Me.mnuClimaticModelMarkovModelling})
         Me.mnuClimaticModel.Name = "mnuClimaticModel"
-        Me.mnuClimaticModel.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticModel.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticModel.Text = "Model"
         '
         'mnuClimaticModelOutfilling
         '
         Me.mnuClimaticModelOutfilling.Name = "mnuClimaticModelOutfilling"
-        Me.mnuClimaticModelOutfilling.Size = New System.Drawing.Size(271, 34)
+        Me.mnuClimaticModelOutfilling.Size = New System.Drawing.Size(180, 22)
         Me.mnuClimaticModelOutfilling.Text = "Outfilling..."
         '
         'mnuClimaticModelsExtremes
         '
         Me.mnuClimaticModelsExtremes.Name = "mnuClimaticModelsExtremes"
-        Me.mnuClimaticModelsExtremes.Size = New System.Drawing.Size(271, 34)
+        Me.mnuClimaticModelsExtremes.Size = New System.Drawing.Size(180, 22)
         Me.mnuClimaticModelsExtremes.Text = "Extremes..."
         '
         'mnuClimaticModelCircular
         '
         Me.mnuClimaticModelCircular.Enabled = False
         Me.mnuClimaticModelCircular.Name = "mnuClimaticModelCircular"
-        Me.mnuClimaticModelCircular.Size = New System.Drawing.Size(271, 34)
+        Me.mnuClimaticModelCircular.Size = New System.Drawing.Size(180, 22)
         Me.mnuClimaticModelCircular.Text = "Circular..."
         Me.mnuClimaticModelCircular.Visible = False
         '
         'mnuClimaticModelMarkovModelling
         '
         Me.mnuClimaticModelMarkovModelling.Name = "mnuClimaticModelMarkovModelling"
-        Me.mnuClimaticModelMarkovModelling.Size = New System.Drawing.Size(271, 34)
+        Me.mnuClimaticModelMarkovModelling.Size = New System.Drawing.Size(180, 22)
         Me.mnuClimaticModelMarkovModelling.Tag = "Markov_Modelling"
         Me.mnuClimaticModelMarkovModelling.Text = "Markov Modelling..."
         '
         'ToolStripSeparator23
         '
         Me.ToolStripSeparator23.Name = "ToolStripSeparator23"
-        Me.ToolStripSeparator23.Size = New System.Drawing.Size(322, 6)
+        Me.ToolStripSeparator23.Size = New System.Drawing.Size(209, 6)
         '
         'mnuClimaticSCF
         '
         Me.mnuClimaticSCF.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticSCFSupportOpenSST, Me.mnuClimaticSCFSupportExporttoCPT, Me.ToolStripSeparator32, Me.mnuClimaticSCFSupportCorrelations, Me.mnuClimaticSCFSupportPrincipalComponents, Me.mnuClimaticSCFSupportCanonicalCorrelations, Me.mnuClimaticSCFSupportCumulativeExceedanceGraph})
         Me.mnuClimaticSCF.Name = "mnuClimaticSCF"
-        Me.mnuClimaticSCF.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticSCF.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticSCF.Text = "Seasonal Forecast Support"
         '
         'mnuClimaticSCFSupportOpenSST
         '
         Me.mnuClimaticSCFSupportOpenSST.Name = "mnuClimaticSCFSupportOpenSST"
-        Me.mnuClimaticSCFSupportOpenSST.Size = New System.Drawing.Size(364, 34)
+        Me.mnuClimaticSCFSupportOpenSST.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticSCFSupportOpenSST.Text = "Open SST..."
         '
         'mnuClimaticSCFSupportExporttoCPT
         '
         Me.mnuClimaticSCFSupportExporttoCPT.Name = "mnuClimaticSCFSupportExporttoCPT"
-        Me.mnuClimaticSCFSupportExporttoCPT.Size = New System.Drawing.Size(364, 34)
+        Me.mnuClimaticSCFSupportExporttoCPT.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticSCFSupportExporttoCPT.Tag = "Export_to_CPT"
         Me.mnuClimaticSCFSupportExporttoCPT.Text = "Export to CPT..."
         '
         'ToolStripSeparator32
         '
         Me.ToolStripSeparator32.Name = "ToolStripSeparator32"
-        Me.ToolStripSeparator32.Size = New System.Drawing.Size(361, 6)
+        Me.ToolStripSeparator32.Size = New System.Drawing.Size(242, 6)
         '
         'mnuClimaticSCFSupportCorrelations
         '
         Me.mnuClimaticSCFSupportCorrelations.Name = "mnuClimaticSCFSupportCorrelations"
-        Me.mnuClimaticSCFSupportCorrelations.Size = New System.Drawing.Size(364, 34)
+        Me.mnuClimaticSCFSupportCorrelations.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticSCFSupportCorrelations.Text = "Correlations..."
         '
         'mnuClimaticSCFSupportPrincipalComponents
         '
         Me.mnuClimaticSCFSupportPrincipalComponents.Name = "mnuClimaticSCFSupportPrincipalComponents"
-        Me.mnuClimaticSCFSupportPrincipalComponents.Size = New System.Drawing.Size(364, 34)
+        Me.mnuClimaticSCFSupportPrincipalComponents.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticSCFSupportPrincipalComponents.Text = "Principal Components..."
         '
         'mnuClimaticSCFSupportCanonicalCorrelations
         '
         Me.mnuClimaticSCFSupportCanonicalCorrelations.Name = "mnuClimaticSCFSupportCanonicalCorrelations"
-        Me.mnuClimaticSCFSupportCanonicalCorrelations.Size = New System.Drawing.Size(364, 34)
+        Me.mnuClimaticSCFSupportCanonicalCorrelations.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticSCFSupportCanonicalCorrelations.Text = "Canonical Correlations..."
         '
         'mnuClimaticSCFSupportCumulativeExceedanceGraph
         '
         Me.mnuClimaticSCFSupportCumulativeExceedanceGraph.Name = "mnuClimaticSCFSupportCumulativeExceedanceGraph"
-        Me.mnuClimaticSCFSupportCumulativeExceedanceGraph.Size = New System.Drawing.Size(364, 34)
+        Me.mnuClimaticSCFSupportCumulativeExceedanceGraph.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticSCFSupportCumulativeExceedanceGraph.Text = "Cumulative/Exceedance Graph..."
         '
         'mnuClimaticClimateMethods
         '
         Me.mnuClimaticClimateMethods.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticClimateMethodsDataManipulation, Me.mnuClimaticClimateMethodsGraphics, Me.mnuClimaticClimateMethodsModel, Me.mnuClimaticClimateMethodsAdditional, Me.mnuClimateMethodsCreateClimateObject})
         Me.mnuClimaticClimateMethods.Name = "mnuClimaticClimateMethods"
-        Me.mnuClimaticClimateMethods.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticClimateMethods.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticClimateMethods.Tag = "Climatic_Methods"
         Me.mnuClimaticClimateMethods.Text = "Climate Methods"
         Me.mnuClimaticClimateMethods.Visible = False
@@ -2715,7 +2713,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulation.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticClimateMethodsDataManipulationStartOfRain, Me.mnuClimaticClimateMethodsDataManipulationEndOfRain, Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth, Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular, Me.mnuClimaticClimateMethodsDataManipulationDayMonth, Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily, Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear, Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal, Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength, Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA, Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents, Me.mnuClimaticClimateMethodsDataManipulationMissingData, Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable, Me.mnuClimateMethodsDataManipulationMonthlySummaries, Me.mnuClimateMethodsDataManipulationOutputForCD})
         Me.mnuClimaticClimateMethodsDataManipulation.Name = "mnuClimaticClimateMethodsDataManipulation"
-        Me.mnuClimaticClimateMethodsDataManipulation.Size = New System.Drawing.Size(297, 34)
+        Me.mnuClimaticClimateMethodsDataManipulation.Size = New System.Drawing.Size(199, 22)
         Me.mnuClimaticClimateMethodsDataManipulation.Tag = "Data_Manipulation"
         Me.mnuClimaticClimateMethodsDataManipulation.Text = "Data Manipulation"
         '
@@ -2723,7 +2721,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationStartOfRain.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationStartOfRain.Name = "mnuClimaticClimateMethodsDataManipulationStartOfRain"
-        Me.mnuClimaticClimateMethodsDataManipulationStartOfRain.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimaticClimateMethodsDataManipulationStartOfRain.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationStartOfRain.Tag = "Start_of_Rain"
         Me.mnuClimaticClimateMethodsDataManipulationStartOfRain.Text = "Start of Rain..."
         '
@@ -2731,7 +2729,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationEndOfRain.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationEndOfRain.Name = "mnuClimaticClimateMethodsDataManipulationEndOfRain"
-        Me.mnuClimaticClimateMethodsDataManipulationEndOfRain.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimaticClimateMethodsDataManipulationEndOfRain.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationEndOfRain.Tag = "End_of_Rain"
         Me.mnuClimaticClimateMethodsDataManipulationEndOfRain.Text = "End of Rain..."
         '
@@ -2739,7 +2737,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth.Name = "mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth"
-        Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth.Tag = "Change_Format_Month"
         Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth.Text = "Change Format Day Month..."
         '
@@ -2747,7 +2745,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular.Name = "mnuClimaticClimateMethodsDataManipulationExportCPTToTabular"
-        Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular.Tag = "Expot_CPT_to_Tabular"
         Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular.Text = "Export CPT to Tabular..."
         '
@@ -2755,7 +2753,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationDayMonth.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationDayMonth.Name = "mnuClimaticClimateMethodsDataManipulationDayMonth"
-        Me.mnuClimaticClimateMethodsDataManipulationDayMonth.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimaticClimateMethodsDataManipulationDayMonth.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationDayMonth.Tag = "Day_Month"
         Me.mnuClimaticClimateMethodsDataManipulationDayMonth.Text = "Day Month..."
         '
@@ -2763,7 +2761,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily.Name = "mnuClimaticClimateMethodsDataManipulationDisplayDaily"
-        Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily.Tag = "Display_Daily"
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily.Text = "Display Daily..."
         '
@@ -2771,7 +2769,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear.Name = "mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear"
-        Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear.Tag = "Display_DOY_of_Year"
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear.Text = "Display DOY of Year..."
         '
@@ -2779,7 +2777,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal.Name = "mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal"
-        Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal.Tag = "Display_Rain_Running_Total"
         Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal.Text = "Display Rain Running Total..."
         '
@@ -2787,7 +2785,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength.Name = "mnuClimaticClimateMethodsDataManipulationDisplaySpellLength"
-        Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength.Tag = "Display_Spell_length"
         Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength.Text = "Display Spell Length..."
         '
@@ -2795,7 +2793,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA.Name = "mnuClimaticClimateMethodsDataManipulationExportForPICSA"
-        Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA.Tag = "Export_for_PICSA"
         Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA.Text = "Export for PICSA..."
         '
@@ -2803,7 +2801,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents.Name = "mnuClimaticClimateMethodsDataManipulationExtremeEvents"
-        Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents.Tag = "Extreme_Events"
         Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents.Text = "Extreme Events..."
         '
@@ -2811,7 +2809,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationMissingData.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationMissingData.Name = "mnuClimaticClimateMethodsDataManipulationMissingData"
-        Me.mnuClimaticClimateMethodsDataManipulationMissingData.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimaticClimateMethodsDataManipulationMissingData.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationMissingData.Tag = "Missing_Data"
         Me.mnuClimaticClimateMethodsDataManipulationMissingData.Text = "Missing Data..."
         '
@@ -2819,7 +2817,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable.Name = "mnuClimaticClimateMethodsDataManipulationMissingDataTable"
-        Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable.Tag = "Missing_Data_Table"
         Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable.Text = "Missing Data Table..."
         '
@@ -2827,7 +2825,7 @@ Partial Class frmMain
         '
         Me.mnuClimateMethodsDataManipulationMonthlySummaries.Enabled = False
         Me.mnuClimateMethodsDataManipulationMonthlySummaries.Name = "mnuClimateMethodsDataManipulationMonthlySummaries"
-        Me.mnuClimateMethodsDataManipulationMonthlySummaries.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimateMethodsDataManipulationMonthlySummaries.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimateMethodsDataManipulationMonthlySummaries.Tag = "Monthly_Summaries"
         Me.mnuClimateMethodsDataManipulationMonthlySummaries.Text = "Monthly Summaries..."
         '
@@ -2835,7 +2833,7 @@ Partial Class frmMain
         '
         Me.mnuClimateMethodsDataManipulationOutputForCD.Enabled = False
         Me.mnuClimateMethodsDataManipulationOutputForCD.Name = "mnuClimateMethodsDataManipulationOutputForCD"
-        Me.mnuClimateMethodsDataManipulationOutputForCD.Size = New System.Drawing.Size(342, 34)
+        Me.mnuClimateMethodsDataManipulationOutputForCD.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimateMethodsDataManipulationOutputForCD.Tag = "Output_for_CDT"
         Me.mnuClimateMethodsDataManipulationOutputForCD.Text = "Output for CDT..."
         '
@@ -2843,7 +2841,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphics.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot, Me.mnuClimaticClimateMethodsGraphicsCliplot, Me.mnuClimaticClimateMethodsGraphicsMissingValues, Me.mnuClimaticClimateMethodsGraphicsHistogram, Me.mnuClimaticClimateMethodsGraphicsCumExceedance, Me.mnuClimaticClimateMethodsGraphicsBoxplot, Me.mnuClimaticClimateMethodsGraphicsInventory, Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall, Me.mnuClimaticClimateMethodsGraphicsRainCount, Me.mnuClimaticClimateMethodsGraphicsTimeseries, Me.mnuClimaticClimateMethodsGraphicsWindrose, Me.mnuClimateMethodsGraphicsMultipleLines, Me.mnuClmateMethodThreeSummaries})
         Me.mnuClimaticClimateMethodsGraphics.Name = "mnuClimaticClimateMethodsGraphics"
-        Me.mnuClimaticClimateMethodsGraphics.Size = New System.Drawing.Size(297, 34)
+        Me.mnuClimaticClimateMethodsGraphics.Size = New System.Drawing.Size(199, 22)
         Me.mnuClimaticClimateMethodsGraphics.Tag = "Graphics"
         Me.mnuClimaticClimateMethodsGraphics.Text = "Graphics"
         '
@@ -2851,7 +2849,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot.Name = "mnuClimaticClimateMethodsGraphicsClipBoxPlot"
-        Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot.Tag = "Cliboxplot"
         Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot.Text = "Cliboxplot..."
         '
@@ -2859,7 +2857,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsCliplot.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsCliplot.Name = "mnuClimaticClimateMethodsGraphicsCliplot"
-        Me.mnuClimaticClimateMethodsGraphicsCliplot.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticClimateMethodsGraphicsCliplot.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsCliplot.Tag = "Cliplot"
         Me.mnuClimaticClimateMethodsGraphicsCliplot.Text = "Cliplot..."
         '
@@ -2867,7 +2865,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsMissingValues.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsMissingValues.Name = "mnuClimaticClimateMethodsGraphicsMissingValues"
-        Me.mnuClimaticClimateMethodsGraphicsMissingValues.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticClimateMethodsGraphicsMissingValues.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsMissingValues.Tag = "Missing_values"
         Me.mnuClimaticClimateMethodsGraphicsMissingValues.Text = "Missing Values..."
         '
@@ -2875,7 +2873,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsHistogram.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsHistogram.Name = "mnuClimaticClimateMethodsGraphicsHistogram"
-        Me.mnuClimaticClimateMethodsGraphicsHistogram.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticClimateMethodsGraphicsHistogram.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsHistogram.Tag = "Histogram"
         Me.mnuClimaticClimateMethodsGraphicsHistogram.Text = "Histogram..."
         '
@@ -2883,7 +2881,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsCumExceedance.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsCumExceedance.Name = "mnuClimaticClimateMethodsGraphicsCumExceedance"
-        Me.mnuClimaticClimateMethodsGraphicsCumExceedance.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticClimateMethodsGraphicsCumExceedance.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsCumExceedance.Tag = "Cumulative_Exceedence"
         Me.mnuClimaticClimateMethodsGraphicsCumExceedance.Text = "Cummulative Exceedance..."
         '
@@ -2891,7 +2889,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsBoxplot.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsBoxplot.Name = "mnuClimaticClimateMethodsGraphicsBoxplot"
-        Me.mnuClimaticClimateMethodsGraphicsBoxplot.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticClimateMethodsGraphicsBoxplot.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsBoxplot.Tag = "Boxplot"
         Me.mnuClimaticClimateMethodsGraphicsBoxplot.Text = "Boxplot..."
         '
@@ -2899,7 +2897,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsInventory.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsInventory.Name = "mnuClimaticClimateMethodsGraphicsInventory"
-        Me.mnuClimaticClimateMethodsGraphicsInventory.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticClimateMethodsGraphicsInventory.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsInventory.Tag = "Inventory"
         Me.mnuClimaticClimateMethodsGraphicsInventory.Text = "Inventory..."
         '
@@ -2907,7 +2905,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall.Name = "mnuClimaticClimateMethodsGraphicsAnnualRainfall"
-        Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall.Tag = "Annual_rainfall"
         Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall.Text = "Annual Rainfall..."
         '
@@ -2915,7 +2913,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsRainCount.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsRainCount.Name = "mnuClimaticClimateMethodsGraphicsRainCount"
-        Me.mnuClimaticClimateMethodsGraphicsRainCount.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticClimateMethodsGraphicsRainCount.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsRainCount.Tag = "Rain_count"
         Me.mnuClimaticClimateMethodsGraphicsRainCount.Text = "Rain Count..."
         '
@@ -2923,7 +2921,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsTimeseries.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsTimeseries.Name = "mnuClimaticClimateMethodsGraphicsTimeseries"
-        Me.mnuClimaticClimateMethodsGraphicsTimeseries.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticClimateMethodsGraphicsTimeseries.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsTimeseries.Tag = "Timeseries"
         Me.mnuClimaticClimateMethodsGraphicsTimeseries.Text = "Timeseries..."
         '
@@ -2931,7 +2929,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsWindrose.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsWindrose.Name = "mnuClimaticClimateMethodsGraphicsWindrose"
-        Me.mnuClimaticClimateMethodsGraphicsWindrose.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimaticClimateMethodsGraphicsWindrose.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsWindrose.Tag = "Windrose"
         Me.mnuClimaticClimateMethodsGraphicsWindrose.Text = "Windrose..."
         '
@@ -2939,7 +2937,7 @@ Partial Class frmMain
         '
         Me.mnuClimateMethodsGraphicsMultipleLines.Enabled = False
         Me.mnuClimateMethodsGraphicsMultipleLines.Name = "mnuClimateMethodsGraphicsMultipleLines"
-        Me.mnuClimateMethodsGraphicsMultipleLines.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClimateMethodsGraphicsMultipleLines.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimateMethodsGraphicsMultipleLines.Tag = "Multiple_lines"
         Me.mnuClimateMethodsGraphicsMultipleLines.Text = "Multple Lines..."
         '
@@ -2947,7 +2945,7 @@ Partial Class frmMain
         '
         Me.mnuClmateMethodThreeSummaries.Enabled = False
         Me.mnuClmateMethodThreeSummaries.Name = "mnuClmateMethodThreeSummaries"
-        Me.mnuClmateMethodThreeSummaries.Size = New System.Drawing.Size(325, 34)
+        Me.mnuClmateMethodThreeSummaries.Size = New System.Drawing.Size(219, 22)
         Me.mnuClmateMethodThreeSummaries.Tag = "Three_Summaries"
         Me.mnuClmateMethodThreeSummaries.Text = "Three Summaries..."
         '
@@ -2955,7 +2953,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsModel.Enabled = False
         Me.mnuClimaticClimateMethodsModel.Name = "mnuClimaticClimateMethodsModel"
-        Me.mnuClimaticClimateMethodsModel.Size = New System.Drawing.Size(297, 34)
+        Me.mnuClimaticClimateMethodsModel.Size = New System.Drawing.Size(199, 22)
         Me.mnuClimaticClimateMethodsModel.Tag = "Model"
         Me.mnuClimaticClimateMethodsModel.Text = "Model..."
         '
@@ -2963,7 +2961,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsAdditional.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticClimateMethodsAdditionalOutputForCPT, Me.mnuClimaticClimateMethodsAdditionalRainsStatistics, Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary, Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain, Me.mnuClimaticClimateMethodsAdditionalWaterBalance})
         Me.mnuClimaticClimateMethodsAdditional.Name = "mnuClimaticClimateMethodsAdditional"
-        Me.mnuClimaticClimateMethodsAdditional.Size = New System.Drawing.Size(297, 34)
+        Me.mnuClimaticClimateMethodsAdditional.Size = New System.Drawing.Size(199, 22)
         Me.mnuClimaticClimateMethodsAdditional.Tag = "Additional"
         Me.mnuClimaticClimateMethodsAdditional.Text = "Additional"
         '
@@ -2971,7 +2969,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsAdditionalOutputForCPT.Enabled = False
         Me.mnuClimaticClimateMethodsAdditionalOutputForCPT.Name = "mnuClimaticClimateMethodsAdditionalOutputForCPT"
-        Me.mnuClimaticClimateMethodsAdditionalOutputForCPT.Size = New System.Drawing.Size(316, 34)
+        Me.mnuClimaticClimateMethodsAdditionalOutputForCPT.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticClimateMethodsAdditionalOutputForCPT.Tag = "Output_for_CPT"
         Me.mnuClimaticClimateMethodsAdditionalOutputForCPT.Text = "Output for CPT..."
         '
@@ -2979,7 +2977,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsAdditionalRainsStatistics.Enabled = False
         Me.mnuClimaticClimateMethodsAdditionalRainsStatistics.Name = "mnuClimaticClimateMethodsAdditionalRainsStatistics"
-        Me.mnuClimaticClimateMethodsAdditionalRainsStatistics.Size = New System.Drawing.Size(316, 34)
+        Me.mnuClimaticClimateMethodsAdditionalRainsStatistics.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticClimateMethodsAdditionalRainsStatistics.Tag = "Rain_Statistics"
         Me.mnuClimaticClimateMethodsAdditionalRainsStatistics.Text = "Rains Statistics..."
         '
@@ -2987,7 +2985,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary.Enabled = False
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary.Name = "mnuClimaticClimateMethodsAdditionalSeasonalSummary"
-        Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary.Size = New System.Drawing.Size(316, 34)
+        Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary.Tag = "Seasonal_Summary"
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary.Text = "Seasonal Summary..."
         '
@@ -2995,7 +2993,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain.Enabled = False
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain.Name = "mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain"
-        Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain.Size = New System.Drawing.Size(316, 34)
+        Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain.Tag = "Seasonal_Summary_Rain"
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain.Text = "Seasonal Summary Rain..."
         '
@@ -3003,7 +3001,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsAdditionalWaterBalance.Enabled = False
         Me.mnuClimaticClimateMethodsAdditionalWaterBalance.Name = "mnuClimaticClimateMethodsAdditionalWaterBalance"
-        Me.mnuClimaticClimateMethodsAdditionalWaterBalance.Size = New System.Drawing.Size(316, 34)
+        Me.mnuClimaticClimateMethodsAdditionalWaterBalance.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticClimateMethodsAdditionalWaterBalance.Tag = "Water_Balance"
         Me.mnuClimaticClimateMethodsAdditionalWaterBalance.Text = "Water Balance..."
         '
@@ -3011,7 +3009,7 @@ Partial Class frmMain
         '
         Me.mnuClimateMethodsCreateClimateObject.Enabled = False
         Me.mnuClimateMethodsCreateClimateObject.Name = "mnuClimateMethodsCreateClimateObject"
-        Me.mnuClimateMethodsCreateClimateObject.Size = New System.Drawing.Size(297, 34)
+        Me.mnuClimateMethodsCreateClimateObject.Size = New System.Drawing.Size(199, 22)
         Me.mnuClimateMethodsCreateClimateObject.Tag = "Create_Climate_Object"
         Me.mnuClimateMethodsCreateClimateObject.Text = "Create Climate Object..."
         '
@@ -3019,7 +3017,7 @@ Partial Class frmMain
         '
         Me.mnuFileSave.Name = "mnuFileSave"
         Me.mnuFileSave.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.S), System.Windows.Forms.Keys)
-        Me.mnuFileSave.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileSave.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileSave.Tag = "Save"
         Me.mnuFileSave.Text = "Save..."
         '
@@ -3027,32 +3025,32 @@ Partial Class frmMain
         '
         Me.mnuFileSaveAs.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuFileSaveAsDataAs, Me.mnuFileSaveAsOutputAs, Me.mnuFileSaveAsLogAs, Me.mnuFileSaveAsScriptAs})
         Me.mnuFileSaveAs.Name = "mnuFileSaveAs"
-        Me.mnuFileSaveAs.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileSaveAs.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileSaveAs.Tag = "Save_As"
         Me.mnuFileSaveAs.Text = "Save As"
         '
         'mnuFileSaveAsDataAs
         '
         Me.mnuFileSaveAsDataAs.Name = "mnuFileSaveAsDataAs"
-        Me.mnuFileSaveAsDataAs.Size = New System.Drawing.Size(250, 34)
+        Me.mnuFileSaveAsDataAs.Size = New System.Drawing.Size(164, 22)
         Me.mnuFileSaveAsDataAs.Text = "Save Data As..."
         '
         'mnuFileSaveAsOutputAs
         '
         Me.mnuFileSaveAsOutputAs.Name = "mnuFileSaveAsOutputAs"
-        Me.mnuFileSaveAsOutputAs.Size = New System.Drawing.Size(250, 34)
+        Me.mnuFileSaveAsOutputAs.Size = New System.Drawing.Size(164, 22)
         Me.mnuFileSaveAsOutputAs.Text = "Save Output As..."
         '
         'mnuFileSaveAsLogAs
         '
         Me.mnuFileSaveAsLogAs.Name = "mnuFileSaveAsLogAs"
-        Me.mnuFileSaveAsLogAs.Size = New System.Drawing.Size(250, 34)
+        Me.mnuFileSaveAsLogAs.Size = New System.Drawing.Size(164, 22)
         Me.mnuFileSaveAsLogAs.Text = "Save Log As..."
         '
         'mnuFileSaveAsScriptAs
         '
         Me.mnuFileSaveAsScriptAs.Name = "mnuFileSaveAsScriptAs"
-        Me.mnuFileSaveAsScriptAs.Size = New System.Drawing.Size(250, 34)
+        Me.mnuFileSaveAsScriptAs.Size = New System.Drawing.Size(164, 22)
         Me.mnuFileSaveAsScriptAs.Text = "Save Script As..."
         '
         'mnuFilePrint
@@ -3060,7 +3058,7 @@ Partial Class frmMain
         Me.mnuFilePrint.Enabled = False
         Me.mnuFilePrint.Name = "mnuFilePrint"
         Me.mnuFilePrint.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.P), System.Windows.Forms.Keys)
-        Me.mnuFilePrint.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFilePrint.Size = New System.Drawing.Size(241, 22)
         Me.mnuFilePrint.Tag = "Print"
         Me.mnuFilePrint.Text = "Print..."
         Me.mnuFilePrint.Visible = False
@@ -3069,7 +3067,7 @@ Partial Class frmMain
         '
         Me.mnuFilePrintPreview.Enabled = False
         Me.mnuFilePrintPreview.Name = "mnuFilePrintPreview"
-        Me.mnuFilePrintPreview.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFilePrintPreview.Size = New System.Drawing.Size(241, 22)
         Me.mnuFilePrintPreview.Tag = "Print_Preview"
         Me.mnuFilePrintPreview.Text = "Print Preview..."
         Me.mnuFilePrintPreview.Visible = False
@@ -3077,12 +3075,12 @@ Partial Class frmMain
         'tlSeparatorFile3
         '
         Me.tlSeparatorFile3.Name = "tlSeparatorFile3"
-        Me.tlSeparatorFile3.Size = New System.Drawing.Size(362, 6)
+        Me.tlSeparatorFile3.Size = New System.Drawing.Size(238, 6)
         '
         'mnuFIleExit
         '
         Me.mnuFIleExit.Name = "mnuFIleExit"
-        Me.mnuFIleExit.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFIleExit.Size = New System.Drawing.Size(241, 22)
         Me.mnuFIleExit.Tag = "Exit"
         Me.mnuFIleExit.Text = "Exit"
         '
@@ -3090,7 +3088,7 @@ Partial Class frmMain
         '
         Me.mnuEdit.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuUndo, Me.mnuEditFind, Me.mnuEditCopy, Me.mnuEditPaste, Me.mnuEditPasteNew, Me.mnuEditWordwrap, Me.mnuEditSelectAll})
         Me.mnuEdit.Name = "mnuEdit"
-        Me.mnuEdit.Size = New System.Drawing.Size(58, 29)
+        Me.mnuEdit.Size = New System.Drawing.Size(39, 22)
         Me.mnuEdit.Tag = "Edit"
         Me.mnuEdit.Text = "Edit"
         '
@@ -3098,14 +3096,14 @@ Partial Class frmMain
         '
         Me.mnuUndo.Name = "mnuUndo"
         Me.mnuUndo.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.Z), System.Windows.Forms.Keys)
-        Me.mnuUndo.Size = New System.Drawing.Size(253, 34)
+        Me.mnuUndo.Size = New System.Drawing.Size(167, 22)
         Me.mnuUndo.Text = "Undo"
         '
         'mnuEditFind
         '
         Me.mnuEditFind.Name = "mnuEditFind"
         Me.mnuEditFind.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.F), System.Windows.Forms.Keys)
-        Me.mnuEditFind.Size = New System.Drawing.Size(253, 34)
+        Me.mnuEditFind.Size = New System.Drawing.Size(167, 22)
         Me.mnuEditFind.Tag = "Find"
         Me.mnuEditFind.Text = "Find"
         '
@@ -3113,7 +3111,7 @@ Partial Class frmMain
         '
         Me.mnuEditCopy.Name = "mnuEditCopy"
         Me.mnuEditCopy.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.C), System.Windows.Forms.Keys)
-        Me.mnuEditCopy.Size = New System.Drawing.Size(253, 34)
+        Me.mnuEditCopy.Size = New System.Drawing.Size(167, 22)
         Me.mnuEditCopy.Tag = "Copy"
         Me.mnuEditCopy.Text = "Copy"
         '
@@ -3121,27 +3119,27 @@ Partial Class frmMain
         '
         Me.mnuEditPaste.Name = "mnuEditPaste"
         Me.mnuEditPaste.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.V), System.Windows.Forms.Keys)
-        Me.mnuEditPaste.Size = New System.Drawing.Size(253, 34)
+        Me.mnuEditPaste.Size = New System.Drawing.Size(167, 22)
         Me.mnuEditPaste.Tag = "Paste"
         Me.mnuEditPaste.Text = "Paste"
         '
         'mnuEditPasteNew
         '
         Me.mnuEditPasteNew.Name = "mnuEditPasteNew"
-        Me.mnuEditPasteNew.Size = New System.Drawing.Size(253, 34)
+        Me.mnuEditPasteNew.Size = New System.Drawing.Size(167, 22)
         Me.mnuEditPasteNew.Text = "Paste New..."
         '
         'mnuEditWordwrap
         '
         Me.mnuEditWordwrap.Name = "mnuEditWordwrap"
-        Me.mnuEditWordwrap.Size = New System.Drawing.Size(253, 34)
+        Me.mnuEditWordwrap.Size = New System.Drawing.Size(167, 22)
         Me.mnuEditWordwrap.Text = "Wordwrap..."
         '
         'mnuEditSelectAll
         '
         Me.mnuEditSelectAll.Name = "mnuEditSelectAll"
         Me.mnuEditSelectAll.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.A), System.Windows.Forms.Keys)
-        Me.mnuEditSelectAll.Size = New System.Drawing.Size(253, 34)
+        Me.mnuEditSelectAll.Size = New System.Drawing.Size(167, 22)
         Me.mnuEditSelectAll.Tag = "Select_All"
         Me.mnuEditSelectAll.Text = "Select All "
         '
@@ -3149,18 +3147,17 @@ Partial Class frmMain
         '
         Me.stsStrip.ImageScalingSize = New System.Drawing.Size(24, 24)
         Me.stsStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.tstatus})
-        Me.stsStrip.Location = New System.Drawing.Point(0, 691)
+        Me.stsStrip.Location = New System.Drawing.Point(0, 460)
         Me.stsStrip.Name = "stsStrip"
-        Me.stsStrip.Padding = New System.Windows.Forms.Padding(2, 0, 21, 0)
         Me.stsStrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional
-        Me.stsStrip.Size = New System.Drawing.Size(1251, 32)
+        Me.stsStrip.Size = New System.Drawing.Size(834, 22)
         Me.stsStrip.TabIndex = 8
         Me.stsStrip.Text = "Status"
         '
         'tstatus
         '
         Me.tstatus.Name = "tstatus"
-        Me.tstatus.Size = New System.Drawing.Size(182, 25)
+        Me.tstatus.Size = New System.Drawing.Size(119, 17)
         Me.tstatus.Text = "No worksheet loaded"
         '
         'Tool_strip
@@ -3169,12 +3166,12 @@ Partial Class frmMain
         Me.Tool_strip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden
         Me.Tool_strip.ImageScalingSize = New System.Drawing.Size(30, 30)
         Me.Tool_strip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTbOpen, Me.mnuTbOpenFromLibrary, Me.mnuTbSave, Me.toolStripSeparator, Me.mnuTbLast10Dialogs, Me.separator2, Me.mnuTbDataView, Me.mnuTbOutput, Me.ToolStripSeparator74, Me.mnuLastGraph, Me.ToolStripSeparator75, Me.mnuTbLogScript, Me.mnuMetadata, Me.ToolStripSeparator76, Me.mnuTbResetLayout, Me.separator3, Me.mnuTbHelp, Me.ToolStripSeparator77, Me.mnuTbLan, Me.separator1})
-        Me.Tool_strip.Location = New System.Drawing.Point(0, 33)
+        Me.Tool_strip.Location = New System.Drawing.Point(0, 24)
         Me.Tool_strip.Name = "Tool_strip"
-        Me.Tool_strip.Padding = New System.Windows.Forms.Padding(0, 0, 3, 0)
+        Me.Tool_strip.Padding = New System.Windows.Forms.Padding(0, 0, 2, 0)
         Me.Tool_strip.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional
         Me.Tool_strip.RightToLeft = System.Windows.Forms.RightToLeft.No
-        Me.Tool_strip.Size = New System.Drawing.Size(1251, 39)
+        Me.Tool_strip.Size = New System.Drawing.Size(834, 37)
         Me.Tool_strip.TabIndex = 7
         Me.Tool_strip.Text = "Tool"
         '
@@ -3186,7 +3183,7 @@ Partial Class frmMain
         Me.mnuTbOpen.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.mnuTbOpen.Margin = New System.Windows.Forms.Padding(2, 1, 2, 2)
         Me.mnuTbOpen.Name = "mnuTbOpen"
-        Me.mnuTbOpen.Size = New System.Drawing.Size(53, 36)
+        Me.mnuTbOpen.Size = New System.Drawing.Size(53, 34)
         Me.mnuTbOpen.Text = "&Open"
         Me.mnuTbOpen.ToolTipText = "Import"
         '
@@ -3197,7 +3194,7 @@ Partial Class frmMain
         Me.mnuTbOpenFromLibrary.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.mnuTbOpenFromLibrary.Margin = New System.Windows.Forms.Padding(2, 1, 2, 2)
         Me.mnuTbOpenFromLibrary.Name = "mnuTbOpenFromLibrary"
-        Me.mnuTbOpenFromLibrary.Size = New System.Drawing.Size(34, 36)
+        Me.mnuTbOpenFromLibrary.Size = New System.Drawing.Size(34, 34)
         Me.mnuTbOpenFromLibrary.ToolTipText = "Import From Library"
         '
         'mnuTbSave
@@ -3209,40 +3206,40 @@ Partial Class frmMain
         Me.mnuTbSave.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.mnuTbSave.Margin = New System.Windows.Forms.Padding(2, 1, 2, 2)
         Me.mnuTbSave.Name = "mnuTbSave"
-        Me.mnuTbSave.Size = New System.Drawing.Size(53, 36)
+        Me.mnuTbSave.Size = New System.Drawing.Size(53, 34)
         Me.mnuTbSave.Text = "&Save"
         '
         'mnuSaveData
         '
         Me.mnuSaveData.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuSaveData.Name = "mnuSaveData"
-        Me.mnuSaveData.Size = New System.Drawing.Size(213, 34)
+        Me.mnuSaveData.Size = New System.Drawing.Size(139, 22)
         Me.mnuSaveData.Text = "Save Data"
         '
         'mnuSaveOutput
         '
         Me.mnuSaveOutput.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuSaveOutput.Name = "mnuSaveOutput"
-        Me.mnuSaveOutput.Size = New System.Drawing.Size(213, 34)
+        Me.mnuSaveOutput.Size = New System.Drawing.Size(139, 22)
         Me.mnuSaveOutput.Text = "Save Output"
         '
         'mnuSaveScript
         '
         Me.mnuSaveScript.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuSaveScript.Name = "mnuSaveScript"
-        Me.mnuSaveScript.Size = New System.Drawing.Size(213, 34)
+        Me.mnuSaveScript.Size = New System.Drawing.Size(139, 22)
         Me.mnuSaveScript.Text = "Save Script"
         '
         'mnuSaveLog
         '
         Me.mnuSaveLog.Name = "mnuSaveLog"
-        Me.mnuSaveLog.Size = New System.Drawing.Size(213, 34)
+        Me.mnuSaveLog.Size = New System.Drawing.Size(139, 22)
         Me.mnuSaveLog.Text = "Save Log"
         '
         'toolStripSeparator
         '
         Me.toolStripSeparator.Name = "toolStripSeparator"
-        Me.toolStripSeparator.Size = New System.Drawing.Size(6, 39)
+        Me.toolStripSeparator.Size = New System.Drawing.Size(6, 37)
         '
         'mnuTbLast10Dialogs
         '
@@ -3258,7 +3255,7 @@ Partial Class frmMain
         'separator2
         '
         Me.separator2.Name = "separator2"
-        Me.separator2.Size = New System.Drawing.Size(6, 39)
+        Me.separator2.Size = New System.Drawing.Size(6, 37)
         '
         'mnuTbDataView
         '
@@ -3269,35 +3266,35 @@ Partial Class frmMain
         Me.mnuTbDataView.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.mnuTbDataView.Margin = New System.Windows.Forms.Padding(2, 1, 2, 2)
         Me.mnuTbDataView.Name = "mnuTbDataView"
-        Me.mnuTbDataView.Size = New System.Drawing.Size(53, 36)
+        Me.mnuTbDataView.Size = New System.Drawing.Size(53, 34)
         Me.mnuTbDataView.ToolTipText = "Toggle Data view open and closed"
         '
         'mnuDataViewWindow
         '
         Me.mnuDataViewWindow.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuDataViewWindow.Name = "mnuDataViewWindow"
-        Me.mnuDataViewWindow.Size = New System.Drawing.Size(409, 34)
+        Me.mnuDataViewWindow.Size = New System.Drawing.Size(268, 22)
         Me.mnuDataViewWindow.Text = "Data View"
         '
         'mnuSwapDataMetadata
         '
         Me.mnuSwapDataMetadata.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuSwapDataMetadata.Name = "mnuSwapDataMetadata"
-        Me.mnuSwapDataMetadata.Size = New System.Drawing.Size(409, 34)
+        Me.mnuSwapDataMetadata.Size = New System.Drawing.Size(268, 22)
         Me.mnuSwapDataMetadata.Text = "Swap Data With Column Metadata"
         '
         'mnuSwapDataDataframeMetadata
         '
         Me.mnuSwapDataDataframeMetadata.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuSwapDataDataframeMetadata.Name = "mnuSwapDataDataframeMetadata"
-        Me.mnuSwapDataDataframeMetadata.Size = New System.Drawing.Size(409, 34)
+        Me.mnuSwapDataDataframeMetadata.Size = New System.Drawing.Size(268, 22)
         Me.mnuSwapDataDataframeMetadata.Text = "Swap Data With Dataframe Metadata"
         '
         'mnuRDataViewerWindow
         '
         Me.mnuRDataViewerWindow.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuRDataViewerWindow.Name = "mnuRDataViewerWindow"
-        Me.mnuRDataViewerWindow.Size = New System.Drawing.Size(409, 34)
+        Me.mnuRDataViewerWindow.Size = New System.Drawing.Size(268, 22)
         Me.mnuRDataViewerWindow.Text = "R-Data Viewer"
         '
         'mnuTbOutput
@@ -3309,34 +3306,34 @@ Partial Class frmMain
         Me.mnuTbOutput.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.mnuTbOutput.Margin = New System.Windows.Forms.Padding(2, 1, 2, 2)
         Me.mnuTbOutput.Name = "mnuTbOutput"
-        Me.mnuTbOutput.Size = New System.Drawing.Size(53, 36)
+        Me.mnuTbOutput.Size = New System.Drawing.Size(53, 34)
         Me.mnuTbOutput.ToolTipText = "Toggle Output window open and closed"
         '
         'mnuOutputWindow
         '
         Me.mnuOutputWindow.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuOutputWindow.Name = "mnuOutputWindow"
-        Me.mnuOutputWindow.Size = New System.Drawing.Size(271, 34)
+        Me.mnuOutputWindow.Size = New System.Drawing.Size(178, 22)
         Me.mnuOutputWindow.Text = "Show Output"
         '
         'mnuShowRCommand
         '
         Me.mnuShowRCommand.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuShowRCommand.Name = "mnuShowRCommand"
-        Me.mnuShowRCommand.Size = New System.Drawing.Size(271, 34)
+        Me.mnuShowRCommand.Size = New System.Drawing.Size(178, 22)
         Me.mnuShowRCommand.Text = "Show R Commands"
         '
         'mnuIncludeComments
         '
         Me.mnuIncludeComments.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuIncludeComments.Name = "mnuIncludeComments"
-        Me.mnuIncludeComments.Size = New System.Drawing.Size(271, 34)
+        Me.mnuIncludeComments.Size = New System.Drawing.Size(178, 22)
         Me.mnuIncludeComments.Text = "Show Comments"
         '
         'ToolStripSeparator74
         '
         Me.ToolStripSeparator74.Name = "ToolStripSeparator74"
-        Me.ToolStripSeparator74.Size = New System.Drawing.Size(6, 39)
+        Me.ToolStripSeparator74.Size = New System.Drawing.Size(6, 37)
         '
         'mnuLastGraph
         '
@@ -3353,25 +3350,25 @@ Partial Class frmMain
         'mnuNormalViewer
         '
         Me.mnuNormalViewer.Name = "mnuNormalViewer"
-        Me.mnuNormalViewer.Size = New System.Drawing.Size(194, 34)
+        Me.mnuNormalViewer.Size = New System.Drawing.Size(128, 22)
         Me.mnuNormalViewer.Text = "Viewer..."
         '
         'mnuploty
         '
         Me.mnuploty.Name = "mnuploty"
-        Me.mnuploty.Size = New System.Drawing.Size(194, 34)
+        Me.mnuploty.Size = New System.Drawing.Size(128, 22)
         Me.mnuploty.Text = "Plotly..."
         '
         'mnuRViewer
         '
         Me.mnuRViewer.Name = "mnuRViewer"
-        Me.mnuRViewer.Size = New System.Drawing.Size(194, 34)
+        Me.mnuRViewer.Size = New System.Drawing.Size(128, 22)
         Me.mnuRViewer.Text = "R Viewer..."
         '
         'ToolStripSeparator75
         '
         Me.ToolStripSeparator75.Name = "ToolStripSeparator75"
-        Me.ToolStripSeparator75.Size = New System.Drawing.Size(6, 39)
+        Me.ToolStripSeparator75.Size = New System.Drawing.Size(6, 37)
         '
         'mnuTbLogScript
         '
@@ -3389,14 +3386,14 @@ Partial Class frmMain
         '
         Me.mnuLogScript.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuLogScript.Name = "mnuLogScript"
-        Me.mnuLogScript.Size = New System.Drawing.Size(321, 34)
+        Me.mnuLogScript.Size = New System.Drawing.Size(210, 22)
         Me.mnuLogScript.Text = "Log/Script"
         '
         'mnuSwapDataLogScript
         '
         Me.mnuSwapDataLogScript.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuSwapDataLogScript.Name = "mnuSwapDataLogScript"
-        Me.mnuSwapDataLogScript.Size = New System.Drawing.Size(321, 34)
+        Me.mnuSwapDataLogScript.Size = New System.Drawing.Size(210, 22)
         Me.mnuSwapDataLogScript.Text = "Swap Data and Log/Script"
         '
         'mnuMetadata
@@ -3415,20 +3412,20 @@ Partial Class frmMain
         '
         Me.mnuColumnMetadat.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuColumnMetadat.Name = "mnuColumnMetadat"
-        Me.mnuColumnMetadat.Size = New System.Drawing.Size(307, 34)
+        Me.mnuColumnMetadat.Size = New System.Drawing.Size(202, 22)
         Me.mnuColumnMetadat.Text = "  Column Metadata..."
         '
         'mnuDataFrameMetadat
         '
         Me.mnuDataFrameMetadat.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuDataFrameMetadat.Name = "mnuDataFrameMetadat"
-        Me.mnuDataFrameMetadat.Size = New System.Drawing.Size(307, 34)
+        Me.mnuDataFrameMetadat.Size = New System.Drawing.Size(202, 22)
         Me.mnuDataFrameMetadat.Text = "  Data Frame Metadata..."
         '
         'ToolStripSeparator76
         '
         Me.ToolStripSeparator76.Name = "ToolStripSeparator76"
-        Me.ToolStripSeparator76.Size = New System.Drawing.Size(6, 39)
+        Me.ToolStripSeparator76.Size = New System.Drawing.Size(6, 37)
         '
         'mnuTbResetLayout
         '
@@ -3437,13 +3434,13 @@ Partial Class frmMain
         Me.mnuTbResetLayout.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.mnuTbResetLayout.Margin = New System.Windows.Forms.Padding(2, 1, 2, 2)
         Me.mnuTbResetLayout.Name = "mnuTbResetLayout"
-        Me.mnuTbResetLayout.Size = New System.Drawing.Size(34, 36)
+        Me.mnuTbResetLayout.Size = New System.Drawing.Size(34, 34)
         Me.mnuTbResetLayout.ToolTipText = "Reset to Default Layout"
         '
         'separator3
         '
         Me.separator3.Name = "separator3"
-        Me.separator3.Size = New System.Drawing.Size(6, 39)
+        Me.separator3.Size = New System.Drawing.Size(6, 37)
         '
         'mnuTbHelp
         '
@@ -3461,32 +3458,32 @@ Partial Class frmMain
         '
         Me.mnuToolBarHelp.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuToolBarHelp.Name = "mnuToolBarHelp"
-        Me.mnuToolBarHelp.Size = New System.Drawing.Size(264, 34)
+        Me.mnuToolBarHelp.Size = New System.Drawing.Size(173, 22)
         Me.mnuToolBarHelp.Text = "Toolbar Help"
         '
         'mnuDataWindowHelp
         '
         Me.mnuDataWindowHelp.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuDataWindowHelp.Name = "mnuDataWindowHelp"
-        Me.mnuDataWindowHelp.Size = New System.Drawing.Size(264, 34)
+        Me.mnuDataWindowHelp.Size = New System.Drawing.Size(173, 22)
         Me.mnuDataWindowHelp.Text = "Data Window Help"
         '
         'mnuOutputHelp
         '
         Me.mnuOutputHelp.Name = "mnuOutputHelp"
-        Me.mnuOutputHelp.Size = New System.Drawing.Size(264, 34)
+        Me.mnuOutputHelp.Size = New System.Drawing.Size(173, 22)
         Me.mnuOutputHelp.Text = "Output Help"
         '
         'mnuLogScriptHelp
         '
         Me.mnuLogScriptHelp.Name = "mnuLogScriptHelp"
-        Me.mnuLogScriptHelp.Size = New System.Drawing.Size(264, 34)
+        Me.mnuLogScriptHelp.Size = New System.Drawing.Size(173, 22)
         Me.mnuLogScriptHelp.Text = "Log Script Help"
         '
         'ToolStripSeparator77
         '
         Me.ToolStripSeparator77.Name = "ToolStripSeparator77"
-        Me.ToolStripSeparator77.Size = New System.Drawing.Size(6, 39)
+        Me.ToolStripSeparator77.Size = New System.Drawing.Size(6, 37)
         '
         'mnuTbLan
         '
@@ -3495,29 +3492,28 @@ Partial Class frmMain
         Me.mnuTbLan.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.mnuTbLan.Margin = New System.Windows.Forms.Padding(2, 1, 2, 2)
         Me.mnuTbLan.Name = "mnuTbLan"
-        Me.mnuTbLan.Size = New System.Drawing.Size(34, 36)
+        Me.mnuTbLan.Size = New System.Drawing.Size(34, 34)
         Me.mnuTbLan.ToolTipText = "Changes the menu language to English, and from English"
         '
         'separator1
         '
         Me.separator1.Name = "separator1"
-        Me.separator1.Size = New System.Drawing.Size(6, 39)
+        Me.separator1.Size = New System.Drawing.Size(6, 37)
         '
         'mnuBar
         '
         Me.mnuBar.AllowMerge = False
         Me.mnuBar.BackColor = System.Drawing.SystemColors.ControlLightLight
-        Me.mnuBar.GripMargin = New System.Windows.Forms.Padding(2, 2, 0, 2)
         Me.mnuBar.ImageScalingSize = New System.Drawing.Size(24, 24)
         Me.mnuBar.ImeMode = System.Windows.Forms.ImeMode.[On]
         Me.mnuBar.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuFile, Me.mnuEdit, Me.mnuPrepare, Me.mnuDescribe, Me.mnuModel, Me.mnuStructured, Me.mnuClimatic, Me.mnuTricot, Me.mnuTricotXp, Me.mnuOptionsByContext, Me.mnuProcurement, Me.mnuTools, Me.mnuView, Me.mnuHelp})
         Me.mnuBar.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow
         Me.mnuBar.Location = New System.Drawing.Point(0, 0)
         Me.mnuBar.Name = "mnuBar"
-        Me.mnuBar.Padding = New System.Windows.Forms.Padding(6, 2, 0, 2)
+        Me.mnuBar.Padding = New System.Windows.Forms.Padding(4, 1, 0, 1)
         Me.mnuBar.RenderMode = System.Windows.Forms.ToolStripRenderMode.System
         Me.mnuBar.ShowItemToolTips = True
-        Me.mnuBar.Size = New System.Drawing.Size(1251, 33)
+        Me.mnuBar.Size = New System.Drawing.Size(834, 24)
         Me.mnuBar.TabIndex = 6
         Me.mnuBar.Text = "Menu_strip"
         '
@@ -3525,7 +3521,7 @@ Partial Class frmMain
         '
         Me.mnuFile.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuFileNewDataFrame, Me.mnuFileImportFromFile, Me.mnuFileImportFromLibrary, Me.ToolStripSeparator35, Me.mnuFileImportFromODK, Me.mnuFileImportFromCSPRO, Me.mnuFileImportFromDatabases, Me.mnuFileImportFromPostgres, Me.mnuFileImportFromRapidPro, Me.mnuFileImportandTidyNetCDFFile, Me.mnuImportFromOpenAppBuilder, Me.mnuFileConvert, Me.tlSeparatorFile, Me.mnuFileSave, Me.mnuFileSaveAs, Me.mnuFileExport, Me.mnuFilePrint, Me.mnuFilePrintPreview, Me.tlSeparatorFile3, Me.mnuFileCloseData, Me.ToolStripSeparator8, Me.mnuFIleExit})
         Me.mnuFile.Name = "mnuFile"
-        Me.mnuFile.Size = New System.Drawing.Size(54, 29)
+        Me.mnuFile.Size = New System.Drawing.Size(37, 22)
         Me.mnuFile.Tag = "File"
         Me.mnuFile.Text = "File"
         '
@@ -3533,7 +3529,7 @@ Partial Class frmMain
         '
         Me.mnuFileNewDataFrame.Name = "mnuFileNewDataFrame"
         Me.mnuFileNewDataFrame.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.N), System.Windows.Forms.Keys)
-        Me.mnuFileNewDataFrame.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileNewDataFrame.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileNewDataFrame.Tag = "New_Data_Frame"
         Me.mnuFileNewDataFrame.Text = "New Data Frame..."
         '
@@ -3541,33 +3537,33 @@ Partial Class frmMain
         '
         Me.mnuFileImportFromFile.Name = "mnuFileImportFromFile"
         Me.mnuFileImportFromFile.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.O), System.Windows.Forms.Keys)
-        Me.mnuFileImportFromFile.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileImportFromFile.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromFile.Tag = "Import_From_File"
         Me.mnuFileImportFromFile.Text = "Import From File..."
         '
         'mnuFileImportFromLibrary
         '
         Me.mnuFileImportFromLibrary.Name = "mnuFileImportFromLibrary"
-        Me.mnuFileImportFromLibrary.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileImportFromLibrary.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromLibrary.Tag = "Open_From_Library"
         Me.mnuFileImportFromLibrary.Text = "Import From Library..."
         '
         'ToolStripSeparator35
         '
         Me.ToolStripSeparator35.Name = "ToolStripSeparator35"
-        Me.ToolStripSeparator35.Size = New System.Drawing.Size(362, 6)
+        Me.ToolStripSeparator35.Size = New System.Drawing.Size(238, 6)
         '
         'mnuFileImportFromODK
         '
         Me.mnuFileImportFromODK.Name = "mnuFileImportFromODK"
-        Me.mnuFileImportFromODK.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileImportFromODK.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromODK.Text = "Import From ODK..."
         '
         'mnuFileImportFromCSPRO
         '
         Me.mnuFileImportFromCSPRO.Enabled = False
         Me.mnuFileImportFromCSPRO.Name = "mnuFileImportFromCSPRO"
-        Me.mnuFileImportFromCSPRO.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileImportFromCSPRO.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromCSPRO.Text = "Import From CSPRO..."
         Me.mnuFileImportFromCSPRO.Visible = False
         '
@@ -3575,7 +3571,7 @@ Partial Class frmMain
         '
         Me.mnuFileImportFromDatabases.Enabled = False
         Me.mnuFileImportFromDatabases.Name = "mnuFileImportFromDatabases"
-        Me.mnuFileImportFromDatabases.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileImportFromDatabases.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromDatabases.Text = "Import From Databases..."
         Me.mnuFileImportFromDatabases.Visible = False
         '
@@ -3583,88 +3579,88 @@ Partial Class frmMain
         '
         Me.mnuFileImportFromPostgres.Enabled = False
         Me.mnuFileImportFromPostgres.Name = "mnuFileImportFromPostgres"
-        Me.mnuFileImportFromPostgres.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileImportFromPostgres.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromPostgres.Text = "Import From Postgres"
         Me.mnuFileImportFromPostgres.Visible = False
         '
         'mnuFileImportFromRapidPro
         '
         Me.mnuFileImportFromRapidPro.Name = "mnuFileImportFromRapidPro"
-        Me.mnuFileImportFromRapidPro.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileImportFromRapidPro.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromRapidPro.Text = "Import From RapidPro"
         '
         'mnuFileImportandTidyNetCDFFile
         '
         Me.mnuFileImportandTidyNetCDFFile.Name = "mnuFileImportandTidyNetCDFFile"
-        Me.mnuFileImportandTidyNetCDFFile.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileImportandTidyNetCDFFile.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportandTidyNetCDFFile.Text = "Import and Tidy NetCDF File..."
         '
         'mnuImportFromOpenAppBuilder
         '
         Me.mnuImportFromOpenAppBuilder.Name = "mnuImportFromOpenAppBuilder"
-        Me.mnuImportFromOpenAppBuilder.Size = New System.Drawing.Size(365, 34)
+        Me.mnuImportFromOpenAppBuilder.Size = New System.Drawing.Size(241, 22)
         Me.mnuImportFromOpenAppBuilder.Text = "Import From OpenAppBuilder..."
         '
         'mnuFileConvert
         '
         Me.mnuFileConvert.Enabled = False
         Me.mnuFileConvert.Name = "mnuFileConvert"
-        Me.mnuFileConvert.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileConvert.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileConvert.Text = "Convert..."
         Me.mnuFileConvert.Visible = False
         '
         'tlSeparatorFile
         '
         Me.tlSeparatorFile.Name = "tlSeparatorFile"
-        Me.tlSeparatorFile.Size = New System.Drawing.Size(362, 6)
+        Me.tlSeparatorFile.Size = New System.Drawing.Size(238, 6)
         '
         'mnuFileExport
         '
         Me.mnuFileExport.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuFileExportExportDataSet, Me.mnuFileExportExportRObjectsToolStripMenuItem, Me.mnuFileExportExportRWorkspace, Me.mnuFileExportExportGraphAsImage})
         Me.mnuFileExport.Name = "mnuFileExport"
-        Me.mnuFileExport.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileExport.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileExport.Text = "Export"
         '
         'mnuFileExportExportDataSet
         '
         Me.mnuFileExportExportDataSet.Name = "mnuFileExportExportDataSet"
-        Me.mnuFileExportExportDataSet.Size = New System.Drawing.Size(310, 34)
+        Me.mnuFileExportExportDataSet.Size = New System.Drawing.Size(203, 22)
         Me.mnuFileExportExportDataSet.Text = "Export Dataset..."
         '
         'mnuFileExportExportRObjectsToolStripMenuItem
         '
         Me.mnuFileExportExportRObjectsToolStripMenuItem.Name = "mnuFileExportExportRObjectsToolStripMenuItem"
-        Me.mnuFileExportExportRObjectsToolStripMenuItem.Size = New System.Drawing.Size(310, 34)
+        Me.mnuFileExportExportRObjectsToolStripMenuItem.Size = New System.Drawing.Size(203, 22)
         Me.mnuFileExportExportRObjectsToolStripMenuItem.Text = "Export R Objects..."
         '
         'mnuFileExportExportRWorkspace
         '
         Me.mnuFileExportExportRWorkspace.Name = "mnuFileExportExportRWorkspace"
-        Me.mnuFileExportExportRWorkspace.Size = New System.Drawing.Size(310, 34)
+        Me.mnuFileExportExportRWorkspace.Size = New System.Drawing.Size(203, 22)
         Me.mnuFileExportExportRWorkspace.Text = "Export R Workspace..."
         '
         'mnuFileExportExportGraphAsImage
         '
         Me.mnuFileExportExportGraphAsImage.Name = "mnuFileExportExportGraphAsImage"
-        Me.mnuFileExportExportGraphAsImage.Size = New System.Drawing.Size(310, 34)
+        Me.mnuFileExportExportGraphAsImage.Size = New System.Drawing.Size(203, 22)
         Me.mnuFileExportExportGraphAsImage.Text = "Export Graph As Image..."
         '
         'mnuFileCloseData
         '
         Me.mnuFileCloseData.Name = "mnuFileCloseData"
-        Me.mnuFileCloseData.Size = New System.Drawing.Size(365, 34)
+        Me.mnuFileCloseData.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileCloseData.Text = "Close Data Book"
         '
         'ToolStripSeparator8
         '
         Me.ToolStripSeparator8.Name = "ToolStripSeparator8"
-        Me.ToolStripSeparator8.Size = New System.Drawing.Size(362, 6)
+        Me.ToolStripSeparator8.Size = New System.Drawing.Size(238, 6)
         '
         'mnuPrepare
         '
         Me.mnuPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataFrame, Me.mnuPrepareCheckData, Me.ToolStripSeparator6, Me.mnuPrepareCalculator, Me.ToolStripSeparator79, Me.mnuPrepareColumnCalculate, Me.mnuPrepareColumnFactor, Me.mnuPrepareColumnText, Me.mnuPrepareColumnDate, Me.mnuPrepareColumnDefine, Me.ToolStripSeparator4, Me.mnuPrepareDataReshape, Me.ToolStripSeparator7, Me.mnuPrepareKeysAndLinks, Me.mnuPrepareDataBook, Me.mnuPrepareRObjects})
         Me.mnuPrepare.Name = "mnuPrepare"
-        Me.mnuPrepare.Size = New System.Drawing.Size(88, 29)
+        Me.mnuPrepare.Size = New System.Drawing.Size(59, 22)
         Me.mnuPrepare.Tag = "Prepare"
         Me.mnuPrepare.Text = "Prepare"
         '
@@ -3672,105 +3668,105 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataFrame.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataFrameViewData, Me.mnuPrepareDataFrameRenameColumn, Me.mnuPrepareDataFrameDuplicateColumn, Me.mnuPrepareDataFrameRowNumbersNames, Me.ToolStripSeparator1, Me.mnuPrepareDataFrameSort, Me.mnuPrepareDataFrameFilterRows, Me.mnuPrepareDataFrameSelectColumns, Me.mnuPrepareDataFrameReplaceValues, Me.mnuPrepareDataFrameConvertColumns, Me.ToolStripSeparator2, Me.mnuPrepareDataFrameReorderColumns, Me.mnuPrepareDataFrameAddMergeColumns, Me.mnuPrepareDataFrameInsertColumnsRows, Me.mnuPrepareDataFrameDeleteColumnsRows, Me.mnuPrepareDataFrameProtectColumn, Me.mnuPrepareDataFrameFreezeColumns, Me.mnuPrepareDataframeColourByProperty})
         Me.mnuPrepareDataFrame.Name = "mnuPrepareDataFrame"
-        Me.mnuPrepareDataFrame.Size = New System.Drawing.Size(251, 34)
+        Me.mnuPrepareDataFrame.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareDataFrame.Tag = "Data_Frame"
         Me.mnuPrepareDataFrame.Text = "Data Frame"
         '
         'mnuPrepareDataFrameViewData
         '
         Me.mnuPrepareDataFrameViewData.Name = "mnuPrepareDataFrameViewData"
-        Me.mnuPrepareDataFrameViewData.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameViewData.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameViewData.Tag = "View_Data..."
         Me.mnuPrepareDataFrameViewData.Text = "View Data..."
         '
         'mnuPrepareDataFrameRenameColumn
         '
         Me.mnuPrepareDataFrameRenameColumn.Name = "mnuPrepareDataFrameRenameColumn"
-        Me.mnuPrepareDataFrameRenameColumn.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameRenameColumn.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameRenameColumn.Tag = "Rename_Column..."
         Me.mnuPrepareDataFrameRenameColumn.Text = "Rename Columns..."
         '
         'mnuPrepareDataFrameDuplicateColumn
         '
         Me.mnuPrepareDataFrameDuplicateColumn.Name = "mnuPrepareDataFrameDuplicateColumn"
-        Me.mnuPrepareDataFrameDuplicateColumn.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameDuplicateColumn.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameDuplicateColumn.Text = "Duplicate Column..."
         '
         'mnuPrepareDataFrameRowNumbersNames
         '
         Me.mnuPrepareDataFrameRowNumbersNames.Name = "mnuPrepareDataFrameRowNumbersNames"
-        Me.mnuPrepareDataFrameRowNumbersNames.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameRowNumbersNames.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameRowNumbersNames.Tag = "Row_Numbers/Names..."
         Me.mnuPrepareDataFrameRowNumbersNames.Text = "Row Numbers/Names..."
         '
         'ToolStripSeparator1
         '
         Me.ToolStripSeparator1.Name = "ToolStripSeparator1"
-        Me.ToolStripSeparator1.Size = New System.Drawing.Size(298, 6)
+        Me.ToolStripSeparator1.Size = New System.Drawing.Size(198, 6)
         '
         'mnuPrepareDataFrameSort
         '
         Me.mnuPrepareDataFrameSort.Name = "mnuPrepareDataFrameSort"
-        Me.mnuPrepareDataFrameSort.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameSort.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameSort.Tag = "Sort..."
         Me.mnuPrepareDataFrameSort.Text = "Sort..."
         '
         'mnuPrepareDataFrameFilterRows
         '
         Me.mnuPrepareDataFrameFilterRows.Name = "mnuPrepareDataFrameFilterRows"
-        Me.mnuPrepareDataFrameFilterRows.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameFilterRows.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameFilterRows.Tag = "Filter..."
         Me.mnuPrepareDataFrameFilterRows.Text = "Filter Rows..."
         '
         'mnuPrepareDataFrameSelectColumns
         '
         Me.mnuPrepareDataFrameSelectColumns.Name = "mnuPrepareDataFrameSelectColumns"
-        Me.mnuPrepareDataFrameSelectColumns.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameSelectColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameSelectColumns.Text = "Select Columns..."
         '
         'mnuPrepareDataFrameReplaceValues
         '
         Me.mnuPrepareDataFrameReplaceValues.Name = "mnuPrepareDataFrameReplaceValues"
-        Me.mnuPrepareDataFrameReplaceValues.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameReplaceValues.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameReplaceValues.Tag = "Replace_Values..."
         Me.mnuPrepareDataFrameReplaceValues.Text = "Replace Values..."
         '
         'mnuPrepareDataFrameConvertColumns
         '
         Me.mnuPrepareDataFrameConvertColumns.Name = "mnuPrepareDataFrameConvertColumns"
-        Me.mnuPrepareDataFrameConvertColumns.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameConvertColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameConvertColumns.Tag = "Convert_Columns..."
         Me.mnuPrepareDataFrameConvertColumns.Text = "Convert Columns..."
         '
         'ToolStripSeparator2
         '
         Me.ToolStripSeparator2.Name = "ToolStripSeparator2"
-        Me.ToolStripSeparator2.Size = New System.Drawing.Size(298, 6)
+        Me.ToolStripSeparator2.Size = New System.Drawing.Size(198, 6)
         '
         'mnuPrepareDataFrameReorderColumns
         '
         Me.mnuPrepareDataFrameReorderColumns.Name = "mnuPrepareDataFrameReorderColumns"
-        Me.mnuPrepareDataFrameReorderColumns.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameReorderColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameReorderColumns.Tag = "Reorder_Columns..."
         Me.mnuPrepareDataFrameReorderColumns.Text = "Reorder Columns..."
         '
         'mnuPrepareDataFrameAddMergeColumns
         '
         Me.mnuPrepareDataFrameAddMergeColumns.Name = "mnuPrepareDataFrameAddMergeColumns"
-        Me.mnuPrepareDataFrameAddMergeColumns.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameAddMergeColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameAddMergeColumns.Text = "Add (Merge) Columns..."
         '
         'mnuPrepareDataFrameInsertColumnsRows
         '
         Me.mnuPrepareDataFrameInsertColumnsRows.Name = "mnuPrepareDataFrameInsertColumnsRows"
-        Me.mnuPrepareDataFrameInsertColumnsRows.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameInsertColumnsRows.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameInsertColumnsRows.Tag = "Insert_Columns/Rows..."
         Me.mnuPrepareDataFrameInsertColumnsRows.Text = "Insert Columns/Rows..."
         '
         'mnuPrepareDataFrameDeleteColumnsRows
         '
         Me.mnuPrepareDataFrameDeleteColumnsRows.Name = "mnuPrepareDataFrameDeleteColumnsRows"
-        Me.mnuPrepareDataFrameDeleteColumnsRows.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameDeleteColumnsRows.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameDeleteColumnsRows.Tag = "Delete_Columns/Rows..."
         Me.mnuPrepareDataFrameDeleteColumnsRows.Text = "Delete Columns/Rows..."
         '
@@ -3778,7 +3774,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataFrameProtectColumn.Enabled = False
         Me.mnuPrepareDataFrameProtectColumn.Name = "mnuPrepareDataFrameProtectColumn"
-        Me.mnuPrepareDataFrameProtectColumn.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameProtectColumn.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameProtectColumn.Tag = "..."
         Me.mnuPrepareDataFrameProtectColumn.Text = "Protect Column..."
         Me.mnuPrepareDataFrameProtectColumn.Visible = False
@@ -3787,7 +3783,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataFrameFreezeColumns.Enabled = False
         Me.mnuPrepareDataFrameFreezeColumns.Name = "mnuPrepareDataFrameFreezeColumns"
-        Me.mnuPrepareDataFrameFreezeColumns.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataFrameFreezeColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameFreezeColumns.Tag = "Freeze_Columns..."
         Me.mnuPrepareDataFrameFreezeColumns.Text = "Freeze Columns..."
         Me.mnuPrepareDataFrameFreezeColumns.Visible = False
@@ -3795,7 +3791,7 @@ Partial Class frmMain
         'mnuPrepareDataframeColourByProperty
         '
         Me.mnuPrepareDataframeColourByProperty.Name = "mnuPrepareDataframeColourByProperty"
-        Me.mnuPrepareDataframeColourByProperty.Size = New System.Drawing.Size(301, 34)
+        Me.mnuPrepareDataframeColourByProperty.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataframeColourByProperty.Text = "Colour by Property..."
         '
         'mnuPrepareCheckData
@@ -3803,109 +3799,109 @@ Partial Class frmMain
         Me.mnuPrepareCheckData.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right
         Me.mnuPrepareCheckData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareCheckDataVisualiseData, Me.mnuPrepareCheckDataPivotTable, Me.ToolStripSeparator50, Me.mnuPrepareCheckDataDuplicates, Me.mnuPrepareCheckDataCompareColumns, Me.mnuPrepareCheckDataNonNumericCases, Me.ToolStripSeparator49, Me.mnuPrepareCheckDataBoxplot, Me.mnuPrepareCheckDataOneVariableSummarise, Me.mnuPrepareCheckDataOneVariableGraph, Me.mnuPrepareCheckDataOneWayFrequencies, Me.mnuPrepareCheckDataViewDeleteLabels, Me.ToolStripSeparator41, Me.mnuPrepareCheckDataExportOpenRefine, Me.mnuPrepareCheckDataImportOpenRefine, Me.ToolStripSeparator40, Me.mnuPreparePrepareToShareJitter, Me.mnuPrepareCheckDataPrePareToShareSdcPackage, Me.mnuPrepareCheckDataAnonymiseIDColumn})
         Me.mnuPrepareCheckData.Name = "mnuPrepareCheckData"
-        Me.mnuPrepareCheckData.Size = New System.Drawing.Size(251, 34)
+        Me.mnuPrepareCheckData.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareCheckData.Text = "Check Data"
         '
         'mnuPrepareCheckDataVisualiseData
         '
         Me.mnuPrepareCheckDataVisualiseData.Name = "mnuPrepareCheckDataVisualiseData"
-        Me.mnuPrepareCheckDataVisualiseData.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataVisualiseData.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataVisualiseData.Text = "Visualise Data..."
         '
         'mnuPrepareCheckDataPivotTable
         '
         Me.mnuPrepareCheckDataPivotTable.Name = "mnuPrepareCheckDataPivotTable"
-        Me.mnuPrepareCheckDataPivotTable.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataPivotTable.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataPivotTable.Text = "Pivot Table..."
         '
         'ToolStripSeparator50
         '
         Me.ToolStripSeparator50.Name = "ToolStripSeparator50"
-        Me.ToolStripSeparator50.Size = New System.Drawing.Size(367, 6)
+        Me.ToolStripSeparator50.Size = New System.Drawing.Size(242, 6)
         '
         'mnuPrepareCheckDataDuplicates
         '
         Me.mnuPrepareCheckDataDuplicates.Name = "mnuPrepareCheckDataDuplicates"
-        Me.mnuPrepareCheckDataDuplicates.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataDuplicates.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataDuplicates.Text = "Duplicate Rows..."
         '
         'mnuPrepareCheckDataCompareColumns
         '
         Me.mnuPrepareCheckDataCompareColumns.Name = "mnuPrepareCheckDataCompareColumns"
-        Me.mnuPrepareCheckDataCompareColumns.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataCompareColumns.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataCompareColumns.Text = "Compare Columns..."
         '
         'mnuPrepareCheckDataNonNumericCases
         '
         Me.mnuPrepareCheckDataNonNumericCases.Name = "mnuPrepareCheckDataNonNumericCases"
-        Me.mnuPrepareCheckDataNonNumericCases.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataNonNumericCases.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataNonNumericCases.Text = "Non-Numeric Values..."
         '
         'ToolStripSeparator49
         '
         Me.ToolStripSeparator49.Name = "ToolStripSeparator49"
-        Me.ToolStripSeparator49.Size = New System.Drawing.Size(367, 6)
+        Me.ToolStripSeparator49.Size = New System.Drawing.Size(242, 6)
         '
         'mnuPrepareCheckDataBoxplot
         '
         Me.mnuPrepareCheckDataBoxplot.Name = "mnuPrepareCheckDataBoxplot"
-        Me.mnuPrepareCheckDataBoxplot.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataBoxplot.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataBoxplot.Text = "Boxplot..."
         '
         'mnuPrepareCheckDataOneVariableSummarise
         '
         Me.mnuPrepareCheckDataOneVariableSummarise.Name = "mnuPrepareCheckDataOneVariableSummarise"
-        Me.mnuPrepareCheckDataOneVariableSummarise.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataOneVariableSummarise.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataOneVariableSummarise.Text = "One Variable Summarise..."
         '
         'mnuPrepareCheckDataOneVariableGraph
         '
         Me.mnuPrepareCheckDataOneVariableGraph.Name = "mnuPrepareCheckDataOneVariableGraph"
-        Me.mnuPrepareCheckDataOneVariableGraph.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataOneVariableGraph.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataOneVariableGraph.Text = "One Variable Graph..."
         '
         'mnuPrepareCheckDataOneWayFrequencies
         '
         Me.mnuPrepareCheckDataOneWayFrequencies.Name = "mnuPrepareCheckDataOneWayFrequencies"
-        Me.mnuPrepareCheckDataOneWayFrequencies.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataOneWayFrequencies.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataOneWayFrequencies.Text = "One Variable Frequencies..."
         '
         'mnuPrepareCheckDataViewDeleteLabels
         '
         Me.mnuPrepareCheckDataViewDeleteLabels.Name = "mnuPrepareCheckDataViewDeleteLabels"
-        Me.mnuPrepareCheckDataViewDeleteLabels.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataViewDeleteLabels.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataViewDeleteLabels.Text = "View/Delete Labels..."
         '
         'ToolStripSeparator41
         '
         Me.ToolStripSeparator41.Name = "ToolStripSeparator41"
-        Me.ToolStripSeparator41.Size = New System.Drawing.Size(367, 6)
+        Me.ToolStripSeparator41.Size = New System.Drawing.Size(242, 6)
         Me.ToolStripSeparator41.Visible = False
         '
         'mnuPrepareCheckDataExportOpenRefine
         '
         Me.mnuPrepareCheckDataExportOpenRefine.Name = "mnuPrepareCheckDataExportOpenRefine"
-        Me.mnuPrepareCheckDataExportOpenRefine.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataExportOpenRefine.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataExportOpenRefine.Text = "Export To OpenRefine..."
         Me.mnuPrepareCheckDataExportOpenRefine.Visible = False
         '
         'mnuPrepareCheckDataImportOpenRefine
         '
         Me.mnuPrepareCheckDataImportOpenRefine.Name = "mnuPrepareCheckDataImportOpenRefine"
-        Me.mnuPrepareCheckDataImportOpenRefine.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataImportOpenRefine.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataImportOpenRefine.Text = "Import From OpenRefine..."
         Me.mnuPrepareCheckDataImportOpenRefine.Visible = False
         '
         'ToolStripSeparator40
         '
         Me.ToolStripSeparator40.Name = "ToolStripSeparator40"
-        Me.ToolStripSeparator40.Size = New System.Drawing.Size(367, 6)
+        Me.ToolStripSeparator40.Size = New System.Drawing.Size(242, 6)
         '
         'mnuPreparePrepareToShareJitter
         '
         Me.mnuPreparePrepareToShareJitter.Enabled = False
         Me.mnuPreparePrepareToShareJitter.Name = "mnuPreparePrepareToShareJitter"
-        Me.mnuPreparePrepareToShareJitter.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPreparePrepareToShareJitter.Size = New System.Drawing.Size(245, 22)
         Me.mnuPreparePrepareToShareJitter.Text = "Jitter..."
         Me.mnuPreparePrepareToShareJitter.Visible = False
         '
@@ -3913,95 +3909,95 @@ Partial Class frmMain
         '
         Me.mnuPrepareCheckDataPrePareToShareSdcPackage.Enabled = False
         Me.mnuPrepareCheckDataPrePareToShareSdcPackage.Name = "mnuPrepareCheckDataPrePareToShareSdcPackage"
-        Me.mnuPrepareCheckDataPrePareToShareSdcPackage.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataPrePareToShareSdcPackage.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataPrePareToShareSdcPackage.Text = "Prepare to Share (sdc package)..."
         Me.mnuPrepareCheckDataPrePareToShareSdcPackage.Visible = False
         '
         'mnuPrepareCheckDataAnonymiseIDColumn
         '
         Me.mnuPrepareCheckDataAnonymiseIDColumn.Name = "mnuPrepareCheckDataAnonymiseIDColumn"
-        Me.mnuPrepareCheckDataAnonymiseIDColumn.Size = New System.Drawing.Size(370, 34)
+        Me.mnuPrepareCheckDataAnonymiseIDColumn.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataAnonymiseIDColumn.Text = "Anonymise ID Column..."
         '
         'ToolStripSeparator6
         '
         Me.ToolStripSeparator6.Name = "ToolStripSeparator6"
-        Me.ToolStripSeparator6.Size = New System.Drawing.Size(248, 6)
+        Me.ToolStripSeparator6.Size = New System.Drawing.Size(166, 6)
         '
         'mnuPrepareCalculator
         '
         Me.mnuPrepareCalculator.Name = "mnuPrepareCalculator"
-        Me.mnuPrepareCalculator.Size = New System.Drawing.Size(251, 34)
+        Me.mnuPrepareCalculator.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareCalculator.Tag = "Calculator..."
         Me.mnuPrepareCalculator.Text = "Calculator..."
         '
         'ToolStripSeparator79
         '
         Me.ToolStripSeparator79.Name = "ToolStripSeparator79"
-        Me.ToolStripSeparator79.Size = New System.Drawing.Size(248, 6)
+        Me.ToolStripSeparator79.Size = New System.Drawing.Size(166, 6)
         '
         'mnuPrepareColumnCalculate
         '
         Me.mnuPrepareColumnCalculate.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnNumericRegularSequence, Me.mnuPrepareColumnNumericEnter, Me.ToolStripSeparator25, Me.mnuPrepareColumnNumericRowSummaries, Me.mnuPrepareColumnNumericTransform, Me.mnuPrepareColumnNumericPolynomials, Me.ToolStripSeparator56, Me.mnuPrepareColumnNumericRandomSamples, Me.mnuPrepareColumnNumericPermuteRows})
         Me.mnuPrepareColumnCalculate.Name = "mnuPrepareColumnCalculate"
-        Me.mnuPrepareColumnCalculate.Size = New System.Drawing.Size(251, 34)
+        Me.mnuPrepareColumnCalculate.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareColumnCalculate.Tag = "Column:_Calculate"
         Me.mnuPrepareColumnCalculate.Text = "Column: Numeric"
         '
         'mnuPrepareColumnNumericRegularSequence
         '
         Me.mnuPrepareColumnNumericRegularSequence.Name = "mnuPrepareColumnNumericRegularSequence"
-        Me.mnuPrepareColumnNumericRegularSequence.Size = New System.Drawing.Size(304, 34)
+        Me.mnuPrepareColumnNumericRegularSequence.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericRegularSequence.Tag = "Regular_Sequence..."
         Me.mnuPrepareColumnNumericRegularSequence.Text = "Regular Sequence..."
         '
         'mnuPrepareColumnNumericEnter
         '
         Me.mnuPrepareColumnNumericEnter.Name = "mnuPrepareColumnNumericEnter"
-        Me.mnuPrepareColumnNumericEnter.Size = New System.Drawing.Size(304, 34)
+        Me.mnuPrepareColumnNumericEnter.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericEnter.Text = "Enter..."
         '
         'ToolStripSeparator25
         '
         Me.ToolStripSeparator25.Name = "ToolStripSeparator25"
-        Me.ToolStripSeparator25.Size = New System.Drawing.Size(301, 6)
+        Me.ToolStripSeparator25.Size = New System.Drawing.Size(200, 6)
         '
         'mnuPrepareColumnNumericRowSummaries
         '
         Me.mnuPrepareColumnNumericRowSummaries.Name = "mnuPrepareColumnNumericRowSummaries"
-        Me.mnuPrepareColumnNumericRowSummaries.Size = New System.Drawing.Size(304, 34)
+        Me.mnuPrepareColumnNumericRowSummaries.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericRowSummaries.Text = "Row Summaries..."
         '
         'mnuPrepareColumnNumericTransform
         '
         Me.mnuPrepareColumnNumericTransform.Name = "mnuPrepareColumnNumericTransform"
-        Me.mnuPrepareColumnNumericTransform.Size = New System.Drawing.Size(304, 34)
+        Me.mnuPrepareColumnNumericTransform.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericTransform.Tag = "Rank..."
         Me.mnuPrepareColumnNumericTransform.Text = "Transform..."
         '
         'mnuPrepareColumnNumericPolynomials
         '
         Me.mnuPrepareColumnNumericPolynomials.Name = "mnuPrepareColumnNumericPolynomials"
-        Me.mnuPrepareColumnNumericPolynomials.Size = New System.Drawing.Size(304, 34)
+        Me.mnuPrepareColumnNumericPolynomials.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericPolynomials.Tag = "Polynomials..."
         Me.mnuPrepareColumnNumericPolynomials.Text = "Polynomials..."
         '
         'ToolStripSeparator56
         '
         Me.ToolStripSeparator56.Name = "ToolStripSeparator56"
-        Me.ToolStripSeparator56.Size = New System.Drawing.Size(301, 6)
+        Me.ToolStripSeparator56.Size = New System.Drawing.Size(200, 6)
         '
         'mnuPrepareColumnNumericRandomSamples
         '
         Me.mnuPrepareColumnNumericRandomSamples.Name = "mnuPrepareColumnNumericRandomSamples"
-        Me.mnuPrepareColumnNumericRandomSamples.Size = New System.Drawing.Size(304, 34)
+        Me.mnuPrepareColumnNumericRandomSamples.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericRandomSamples.Tag = "Random_Samples..."
         Me.mnuPrepareColumnNumericRandomSamples.Text = "Random Samples..."
         '
         'mnuPrepareColumnNumericPermuteRows
         '
         Me.mnuPrepareColumnNumericPermuteRows.Name = "mnuPrepareColumnNumericPermuteRows"
-        Me.mnuPrepareColumnNumericPermuteRows.Size = New System.Drawing.Size(304, 34)
+        Me.mnuPrepareColumnNumericPermuteRows.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericPermuteRows.Tag = "Permute_Rows..."
         Me.mnuPrepareColumnNumericPermuteRows.Text = "Permute/Sample Rows..."
         '
@@ -4009,105 +4005,105 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnFactor.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnFactorConvertToFactor, Me.mnuPrepareColumnFactorRecodeNumeric, Me.mnuPrepareColumnFactorCountInFactor, Me.ToolStripSeparator12, Me.mnuPrepareColumnFactorRecodeFactor, Me.mnuPrepareColumnFactorCombineFactors, Me.mnuPrepareColumnFactorDummyVariables, Me.ToolStripSeparator14, Me.mnuPrepareColumnFactorLevelsLabels, Me.mnuPrepareColumnFactorReorderLevels, Me.mnuPrepareColumnFactorReferenceLevel, Me.mnuPrepareColumnFactorUnusedLevels, Me.mnuPrepareColumnFactorContrasts, Me.ToolStripSeparator19, Me.mnuPrepareColumnFactorFactorDataFrame})
         Me.mnuPrepareColumnFactor.Name = "mnuPrepareColumnFactor"
-        Me.mnuPrepareColumnFactor.Size = New System.Drawing.Size(251, 34)
+        Me.mnuPrepareColumnFactor.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareColumnFactor.Tag = "Column:_Factor"
         Me.mnuPrepareColumnFactor.Text = "Column: Factor"
         '
         'mnuPrepareColumnFactorConvertToFactor
         '
         Me.mnuPrepareColumnFactorConvertToFactor.Name = "mnuPrepareColumnFactorConvertToFactor"
-        Me.mnuPrepareColumnFactorConvertToFactor.Size = New System.Drawing.Size(270, 34)
+        Me.mnuPrepareColumnFactorConvertToFactor.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorConvertToFactor.Tag = "Convert_To_Factor"
         Me.mnuPrepareColumnFactorConvertToFactor.Text = "Convert To Factor..."
         '
         'mnuPrepareColumnFactorRecodeNumeric
         '
         Me.mnuPrepareColumnFactorRecodeNumeric.Name = "mnuPrepareColumnFactorRecodeNumeric"
-        Me.mnuPrepareColumnFactorRecodeNumeric.Size = New System.Drawing.Size(270, 34)
+        Me.mnuPrepareColumnFactorRecodeNumeric.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorRecodeNumeric.Tag = "Recode_Numeric..."
         Me.mnuPrepareColumnFactorRecodeNumeric.Text = "Recode Numeric..."
         '
         'mnuPrepareColumnFactorCountInFactor
         '
         Me.mnuPrepareColumnFactorCountInFactor.Name = "mnuPrepareColumnFactorCountInFactor"
-        Me.mnuPrepareColumnFactorCountInFactor.Size = New System.Drawing.Size(270, 34)
+        Me.mnuPrepareColumnFactorCountInFactor.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorCountInFactor.Text = "Count in Factor..."
         '
         'ToolStripSeparator12
         '
         Me.ToolStripSeparator12.Name = "ToolStripSeparator12"
-        Me.ToolStripSeparator12.Size = New System.Drawing.Size(267, 6)
+        Me.ToolStripSeparator12.Size = New System.Drawing.Size(176, 6)
         '
         'mnuPrepareColumnFactorRecodeFactor
         '
         Me.mnuPrepareColumnFactorRecodeFactor.Name = "mnuPrepareColumnFactorRecodeFactor"
-        Me.mnuPrepareColumnFactorRecodeFactor.Size = New System.Drawing.Size(270, 34)
+        Me.mnuPrepareColumnFactorRecodeFactor.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorRecodeFactor.Tag = "Recode_Factor..."
         Me.mnuPrepareColumnFactorRecodeFactor.Text = "Recode Factor..."
         '
         'mnuPrepareColumnFactorCombineFactors
         '
         Me.mnuPrepareColumnFactorCombineFactors.Name = "mnuPrepareColumnFactorCombineFactors"
-        Me.mnuPrepareColumnFactorCombineFactors.Size = New System.Drawing.Size(270, 34)
+        Me.mnuPrepareColumnFactorCombineFactors.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorCombineFactors.Tag = "Combine_Factors..."
         Me.mnuPrepareColumnFactorCombineFactors.Text = "Combine Factors..."
         '
         'mnuPrepareColumnFactorDummyVariables
         '
         Me.mnuPrepareColumnFactorDummyVariables.Name = "mnuPrepareColumnFactorDummyVariables"
-        Me.mnuPrepareColumnFactorDummyVariables.Size = New System.Drawing.Size(270, 34)
+        Me.mnuPrepareColumnFactorDummyVariables.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorDummyVariables.Tag = "Dummy_Variables..."
         Me.mnuPrepareColumnFactorDummyVariables.Text = "Dummy Variables..."
         '
         'ToolStripSeparator14
         '
         Me.ToolStripSeparator14.Name = "ToolStripSeparator14"
-        Me.ToolStripSeparator14.Size = New System.Drawing.Size(267, 6)
+        Me.ToolStripSeparator14.Size = New System.Drawing.Size(176, 6)
         '
         'mnuPrepareColumnFactorLevelsLabels
         '
         Me.mnuPrepareColumnFactorLevelsLabels.Name = "mnuPrepareColumnFactorLevelsLabels"
-        Me.mnuPrepareColumnFactorLevelsLabels.Size = New System.Drawing.Size(270, 34)
+        Me.mnuPrepareColumnFactorLevelsLabels.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorLevelsLabels.Tag = "Levels/Labels..."
         Me.mnuPrepareColumnFactorLevelsLabels.Text = "Levels/Labels..."
         '
         'mnuPrepareColumnFactorReorderLevels
         '
         Me.mnuPrepareColumnFactorReorderLevels.Name = "mnuPrepareColumnFactorReorderLevels"
-        Me.mnuPrepareColumnFactorReorderLevels.Size = New System.Drawing.Size(270, 34)
+        Me.mnuPrepareColumnFactorReorderLevels.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorReorderLevels.Tag = "Reorder_Levels..."
         Me.mnuPrepareColumnFactorReorderLevels.Text = "Reorder Levels..."
         '
         'mnuPrepareColumnFactorReferenceLevel
         '
         Me.mnuPrepareColumnFactorReferenceLevel.Name = "mnuPrepareColumnFactorReferenceLevel"
-        Me.mnuPrepareColumnFactorReferenceLevel.Size = New System.Drawing.Size(270, 34)
+        Me.mnuPrepareColumnFactorReferenceLevel.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorReferenceLevel.Tag = "Reference_Level..."
         Me.mnuPrepareColumnFactorReferenceLevel.Text = "Reference Level..."
         '
         'mnuPrepareColumnFactorUnusedLevels
         '
         Me.mnuPrepareColumnFactorUnusedLevels.Name = "mnuPrepareColumnFactorUnusedLevels"
-        Me.mnuPrepareColumnFactorUnusedLevels.Size = New System.Drawing.Size(270, 34)
+        Me.mnuPrepareColumnFactorUnusedLevels.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorUnusedLevels.Tag = "Unused_Levels..."
         Me.mnuPrepareColumnFactorUnusedLevels.Text = "Unused Levels..."
         '
         'mnuPrepareColumnFactorContrasts
         '
         Me.mnuPrepareColumnFactorContrasts.Name = "mnuPrepareColumnFactorContrasts"
-        Me.mnuPrepareColumnFactorContrasts.Size = New System.Drawing.Size(270, 34)
+        Me.mnuPrepareColumnFactorContrasts.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorContrasts.Tag = "Contrasts..."
         Me.mnuPrepareColumnFactorContrasts.Text = "Contrasts..."
         '
         'ToolStripSeparator19
         '
         Me.ToolStripSeparator19.Name = "ToolStripSeparator19"
-        Me.ToolStripSeparator19.Size = New System.Drawing.Size(267, 6)
+        Me.ToolStripSeparator19.Size = New System.Drawing.Size(176, 6)
         '
         'mnuPrepareColumnFactorFactorDataFrame
         '
         Me.mnuPrepareColumnFactorFactorDataFrame.Name = "mnuPrepareColumnFactorFactorDataFrame"
-        Me.mnuPrepareColumnFactorFactorDataFrame.Size = New System.Drawing.Size(270, 34)
+        Me.mnuPrepareColumnFactorFactorDataFrame.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorFactorDataFrame.Tag = "Factor_Data_Frame"
         Me.mnuPrepareColumnFactorFactorDataFrame.Text = "Factor Data Frame..."
         '
@@ -4115,42 +4111,42 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnText.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnTextFindReplace, Me.mnuPrepareColumnTextSearch, Me.mnuPrepareColumnTextTransform, Me.mnuPrepareColumnTextSplit, Me.mnuPrepareColumnTextCombine, Me.mnuPrepareColumnTextMatch, Me.mnuPrepareColumnTextDistance})
         Me.mnuPrepareColumnText.Name = "mnuPrepareColumnText"
-        Me.mnuPrepareColumnText.Size = New System.Drawing.Size(251, 34)
+        Me.mnuPrepareColumnText.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareColumnText.Tag = "Column:_Text"
         Me.mnuPrepareColumnText.Text = "Column: Text"
         '
         'mnuPrepareColumnTextFindReplace
         '
         Me.mnuPrepareColumnTextFindReplace.Name = "mnuPrepareColumnTextFindReplace"
-        Me.mnuPrepareColumnTextFindReplace.Size = New System.Drawing.Size(227, 34)
+        Me.mnuPrepareColumnTextFindReplace.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextFindReplace.Tag = "Find/Replace..."
         Me.mnuPrepareColumnTextFindReplace.Text = "Find/Replace..."
         '
         'mnuPrepareColumnTextSearch
         '
         Me.mnuPrepareColumnTextSearch.Name = "mnuPrepareColumnTextSearch"
-        Me.mnuPrepareColumnTextSearch.Size = New System.Drawing.Size(227, 34)
+        Me.mnuPrepareColumnTextSearch.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextSearch.Text = "Search..."
         Me.mnuPrepareColumnTextSearch.Visible = False
         '
         'mnuPrepareColumnTextTransform
         '
         Me.mnuPrepareColumnTextTransform.Name = "mnuPrepareColumnTextTransform"
-        Me.mnuPrepareColumnTextTransform.Size = New System.Drawing.Size(227, 34)
+        Me.mnuPrepareColumnTextTransform.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextTransform.Tag = "Transform..."
         Me.mnuPrepareColumnTextTransform.Text = "Transform..."
         '
         'mnuPrepareColumnTextSplit
         '
         Me.mnuPrepareColumnTextSplit.Name = "mnuPrepareColumnTextSplit"
-        Me.mnuPrepareColumnTextSplit.Size = New System.Drawing.Size(227, 34)
+        Me.mnuPrepareColumnTextSplit.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextSplit.Tag = "Split..."
         Me.mnuPrepareColumnTextSplit.Text = "Split..."
         '
         'mnuPrepareColumnTextCombine
         '
         Me.mnuPrepareColumnTextCombine.Name = "mnuPrepareColumnTextCombine"
-        Me.mnuPrepareColumnTextCombine.Size = New System.Drawing.Size(227, 34)
+        Me.mnuPrepareColumnTextCombine.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextCombine.Tag = "Combine..."
         Me.mnuPrepareColumnTextCombine.Text = "Combine..."
         '
@@ -4158,7 +4154,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnTextMatch.Enabled = False
         Me.mnuPrepareColumnTextMatch.Name = "mnuPrepareColumnTextMatch"
-        Me.mnuPrepareColumnTextMatch.Size = New System.Drawing.Size(227, 34)
+        Me.mnuPrepareColumnTextMatch.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextMatch.Tag = "Match..."
         Me.mnuPrepareColumnTextMatch.Text = "Match..."
         Me.mnuPrepareColumnTextMatch.Visible = False
@@ -4166,7 +4162,7 @@ Partial Class frmMain
         'mnuPrepareColumnTextDistance
         '
         Me.mnuPrepareColumnTextDistance.Name = "mnuPrepareColumnTextDistance"
-        Me.mnuPrepareColumnTextDistance.Size = New System.Drawing.Size(227, 34)
+        Me.mnuPrepareColumnTextDistance.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextDistance.Tag = "Distance..."
         Me.mnuPrepareColumnTextDistance.Text = "Distance..."
         '
@@ -4174,38 +4170,38 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnDate.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnDateGenerateDate, Me.mnuPrepareColumnDateMakeDate, Me.mnuPrepareColumnDateInfillMissingDates, Me.mnuPrepareColumnDateUseDate, Me.mnuPrepareColumnDateMakeTime, Me.mnuPrepareColumnDateUseTime})
         Me.mnuPrepareColumnDate.Name = "mnuPrepareColumnDate"
-        Me.mnuPrepareColumnDate.Size = New System.Drawing.Size(251, 34)
+        Me.mnuPrepareColumnDate.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareColumnDate.Text = "Column: Date"
         '
         'mnuPrepareColumnDateGenerateDate
         '
         Me.mnuPrepareColumnDateGenerateDate.Name = "mnuPrepareColumnDateGenerateDate"
-        Me.mnuPrepareColumnDateGenerateDate.Size = New System.Drawing.Size(246, 34)
+        Me.mnuPrepareColumnDateGenerateDate.Size = New System.Drawing.Size(162, 22)
         Me.mnuPrepareColumnDateGenerateDate.Text = "Generate Dates..."
         '
         'mnuPrepareColumnDateMakeDate
         '
         Me.mnuPrepareColumnDateMakeDate.Name = "mnuPrepareColumnDateMakeDate"
-        Me.mnuPrepareColumnDateMakeDate.Size = New System.Drawing.Size(246, 34)
+        Me.mnuPrepareColumnDateMakeDate.Size = New System.Drawing.Size(162, 22)
         Me.mnuPrepareColumnDateMakeDate.Text = "Make Date..."
         '
         'mnuPrepareColumnDateInfillMissingDates
         '
         Me.mnuPrepareColumnDateInfillMissingDates.Name = "mnuPrepareColumnDateInfillMissingDates"
-        Me.mnuPrepareColumnDateInfillMissingDates.Size = New System.Drawing.Size(246, 34)
+        Me.mnuPrepareColumnDateInfillMissingDates.Size = New System.Drawing.Size(162, 22)
         Me.mnuPrepareColumnDateInfillMissingDates.Text = "Fill Date Gaps..."
         '
         'mnuPrepareColumnDateUseDate
         '
         Me.mnuPrepareColumnDateUseDate.Name = "mnuPrepareColumnDateUseDate"
-        Me.mnuPrepareColumnDateUseDate.Size = New System.Drawing.Size(246, 34)
+        Me.mnuPrepareColumnDateUseDate.Size = New System.Drawing.Size(162, 22)
         Me.mnuPrepareColumnDateUseDate.Text = "Use Date..."
         '
         'mnuPrepareColumnDateMakeTime
         '
         Me.mnuPrepareColumnDateMakeTime.Enabled = False
         Me.mnuPrepareColumnDateMakeTime.Name = "mnuPrepareColumnDateMakeTime"
-        Me.mnuPrepareColumnDateMakeTime.Size = New System.Drawing.Size(246, 34)
+        Me.mnuPrepareColumnDateMakeTime.Size = New System.Drawing.Size(162, 22)
         Me.mnuPrepareColumnDateMakeTime.Text = "Make Time..."
         Me.mnuPrepareColumnDateMakeTime.Visible = False
         '
@@ -4213,7 +4209,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnDateUseTime.Enabled = False
         Me.mnuPrepareColumnDateUseTime.Name = "mnuPrepareColumnDateUseTime"
-        Me.mnuPrepareColumnDateUseTime.Size = New System.Drawing.Size(246, 34)
+        Me.mnuPrepareColumnDateUseTime.Size = New System.Drawing.Size(162, 22)
         Me.mnuPrepareColumnDateUseTime.Text = "Use Time..."
         Me.mnuPrepareColumnDateUseTime.Visible = False
         '
@@ -4221,169 +4217,169 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnDefine.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnDefineConvertColumns, Me.ToolStripSeparator55, Me.mnuPrepareColumnDefineCircular})
         Me.mnuPrepareColumnDefine.Name = "mnuPrepareColumnDefine"
-        Me.mnuPrepareColumnDefine.Size = New System.Drawing.Size(251, 34)
+        Me.mnuPrepareColumnDefine.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareColumnDefine.Text = "Column: Define"
         '
         'mnuPrepareColumnDefineConvertColumns
         '
         Me.mnuPrepareColumnDefineConvertColumns.Name = "mnuPrepareColumnDefineConvertColumns"
-        Me.mnuPrepareColumnDefineConvertColumns.Size = New System.Drawing.Size(263, 34)
+        Me.mnuPrepareColumnDefineConvertColumns.Size = New System.Drawing.Size(176, 22)
         Me.mnuPrepareColumnDefineConvertColumns.Text = "Convert Columns..."
         '
         'ToolStripSeparator55
         '
         Me.ToolStripSeparator55.Name = "ToolStripSeparator55"
-        Me.ToolStripSeparator55.Size = New System.Drawing.Size(260, 6)
+        Me.ToolStripSeparator55.Size = New System.Drawing.Size(173, 6)
         '
         'mnuPrepareColumnDefineCircular
         '
         Me.mnuPrepareColumnDefineCircular.Name = "mnuPrepareColumnDefineCircular"
-        Me.mnuPrepareColumnDefineCircular.Size = New System.Drawing.Size(263, 34)
+        Me.mnuPrepareColumnDefineCircular.Size = New System.Drawing.Size(176, 22)
         Me.mnuPrepareColumnDefineCircular.Text = "Circular..."
         '
         'ToolStripSeparator4
         '
         Me.ToolStripSeparator4.Name = "ToolStripSeparator4"
-        Me.ToolStripSeparator4.Size = New System.Drawing.Size(248, 6)
+        Me.ToolStripSeparator4.Size = New System.Drawing.Size(166, 6)
         '
         'mnuPrepareDataReshape
         '
         Me.mnuPrepareDataReshape.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnReshapeColumnSummaries, Me.mnuPrepareColumnReshapeGeneralSummaries, Me.ToolStripSeparator10, Me.mnuPrepareColumnReshapeStack, Me.mnuPrepareColumnReshapeUnstack, Me.mnuPrepareColumnReshapeMerge, Me.ToolStripSeparator11, Me.mnuPrepareAppendDataFrame, Me.mnuPrepareColumnReshapeSubset, Me.mnuPrepareColumnReshapeRandomSubset, Me.mnuPrepareColumnReshapeTranspose, Me.mnuPrepareDataReshapeScaleOrDistance, Me.mnuPrepareDataReshapeRandomSplit})
         Me.mnuPrepareDataReshape.Name = "mnuPrepareDataReshape"
-        Me.mnuPrepareDataReshape.Size = New System.Drawing.Size(251, 34)
+        Me.mnuPrepareDataReshape.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareDataReshape.Tag = ""
         Me.mnuPrepareDataReshape.Text = "Data Reshape"
         '
         'mnuPrepareColumnReshapeColumnSummaries
         '
         Me.mnuPrepareColumnReshapeColumnSummaries.Name = "mnuPrepareColumnReshapeColumnSummaries"
-        Me.mnuPrepareColumnReshapeColumnSummaries.Size = New System.Drawing.Size(295, 34)
+        Me.mnuPrepareColumnReshapeColumnSummaries.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeColumnSummaries.Tag = "Column_Summaries..."
         Me.mnuPrepareColumnReshapeColumnSummaries.Text = "Column Summaries..."
         '
         'mnuPrepareColumnReshapeGeneralSummaries
         '
         Me.mnuPrepareColumnReshapeGeneralSummaries.Name = "mnuPrepareColumnReshapeGeneralSummaries"
-        Me.mnuPrepareColumnReshapeGeneralSummaries.Size = New System.Drawing.Size(295, 34)
+        Me.mnuPrepareColumnReshapeGeneralSummaries.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeGeneralSummaries.Text = "General Summaries..."
         '
         'ToolStripSeparator10
         '
         Me.ToolStripSeparator10.Name = "ToolStripSeparator10"
-        Me.ToolStripSeparator10.Size = New System.Drawing.Size(292, 6)
+        Me.ToolStripSeparator10.Size = New System.Drawing.Size(194, 6)
         '
         'mnuPrepareColumnReshapeStack
         '
         Me.mnuPrepareColumnReshapeStack.Name = "mnuPrepareColumnReshapeStack"
-        Me.mnuPrepareColumnReshapeStack.Size = New System.Drawing.Size(295, 34)
+        Me.mnuPrepareColumnReshapeStack.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeStack.Tag = "Stack..."
         Me.mnuPrepareColumnReshapeStack.Text = "Stack (Pivot Longer)..."
         '
         'mnuPrepareColumnReshapeUnstack
         '
         Me.mnuPrepareColumnReshapeUnstack.Name = "mnuPrepareColumnReshapeUnstack"
-        Me.mnuPrepareColumnReshapeUnstack.Size = New System.Drawing.Size(295, 34)
+        Me.mnuPrepareColumnReshapeUnstack.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeUnstack.Tag = "Unstack..."
         Me.mnuPrepareColumnReshapeUnstack.Text = "Unstack (Pivot Wider)..."
         '
         'mnuPrepareColumnReshapeMerge
         '
         Me.mnuPrepareColumnReshapeMerge.Name = "mnuPrepareColumnReshapeMerge"
-        Me.mnuPrepareColumnReshapeMerge.Size = New System.Drawing.Size(295, 34)
+        Me.mnuPrepareColumnReshapeMerge.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeMerge.Tag = "Merge (Join)..."
         Me.mnuPrepareColumnReshapeMerge.Text = "Merge (Join)..."
         '
         'ToolStripSeparator11
         '
         Me.ToolStripSeparator11.Name = "ToolStripSeparator11"
-        Me.ToolStripSeparator11.Size = New System.Drawing.Size(292, 6)
+        Me.ToolStripSeparator11.Size = New System.Drawing.Size(194, 6)
         '
         'mnuPrepareAppendDataFrame
         '
         Me.mnuPrepareAppendDataFrame.Name = "mnuPrepareAppendDataFrame"
-        Me.mnuPrepareAppendDataFrame.Size = New System.Drawing.Size(295, 34)
+        Me.mnuPrepareAppendDataFrame.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareAppendDataFrame.Text = "Append (Bind Rows)..."
         '
         'mnuPrepareColumnReshapeSubset
         '
         Me.mnuPrepareColumnReshapeSubset.Name = "mnuPrepareColumnReshapeSubset"
-        Me.mnuPrepareColumnReshapeSubset.Size = New System.Drawing.Size(295, 34)
+        Me.mnuPrepareColumnReshapeSubset.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeSubset.Tag = "Subset..."
         Me.mnuPrepareColumnReshapeSubset.Text = "Subset..."
         '
         'mnuPrepareColumnReshapeRandomSubset
         '
         Me.mnuPrepareColumnReshapeRandomSubset.Name = "mnuPrepareColumnReshapeRandomSubset"
-        Me.mnuPrepareColumnReshapeRandomSubset.Size = New System.Drawing.Size(295, 34)
+        Me.mnuPrepareColumnReshapeRandomSubset.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeRandomSubset.Tag = "Random_Subset..."
         Me.mnuPrepareColumnReshapeRandomSubset.Text = "Random Subset..."
         '
         'mnuPrepareColumnReshapeTranspose
         '
         Me.mnuPrepareColumnReshapeTranspose.Name = "mnuPrepareColumnReshapeTranspose"
-        Me.mnuPrepareColumnReshapeTranspose.Size = New System.Drawing.Size(295, 34)
+        Me.mnuPrepareColumnReshapeTranspose.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeTranspose.Tag = "Transpose..."
         Me.mnuPrepareColumnReshapeTranspose.Text = "Transpose..."
         '
         'mnuPrepareDataReshapeScaleOrDistance
         '
         Me.mnuPrepareDataReshapeScaleOrDistance.Name = "mnuPrepareDataReshapeScaleOrDistance"
-        Me.mnuPrepareDataReshapeScaleOrDistance.Size = New System.Drawing.Size(295, 34)
+        Me.mnuPrepareDataReshapeScaleOrDistance.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareDataReshapeScaleOrDistance.Text = "Scale/Distance..."
         '
         'mnuPrepareDataReshapeRandomSplit
         '
         Me.mnuPrepareDataReshapeRandomSplit.Name = "mnuPrepareDataReshapeRandomSplit"
-        Me.mnuPrepareDataReshapeRandomSplit.Size = New System.Drawing.Size(295, 34)
+        Me.mnuPrepareDataReshapeRandomSplit.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareDataReshapeRandomSplit.Text = "Random Split..."
         '
         'ToolStripSeparator7
         '
         Me.ToolStripSeparator7.Name = "ToolStripSeparator7"
-        Me.ToolStripSeparator7.Size = New System.Drawing.Size(248, 6)
+        Me.ToolStripSeparator7.Size = New System.Drawing.Size(166, 6)
         '
         'mnuPrepareKeysAndLinks
         '
         Me.mnuPrepareKeysAndLinks.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareKeysAndLinksAddKey, Me.mnuPrepareKeysAndLinksViewAndRemoveKey, Me.mnuPrepareKeysAndLinksAddLink, Me.mnuPrepareKeysAndLinksViewAndRemoveKeys, Me.mnuPrepareKeysAndLinksAddComment})
         Me.mnuPrepareKeysAndLinks.Name = "mnuPrepareKeysAndLinks"
-        Me.mnuPrepareKeysAndLinks.Size = New System.Drawing.Size(251, 34)
+        Me.mnuPrepareKeysAndLinks.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareKeysAndLinks.Text = "Keys and Links"
         '
         'mnuPrepareKeysAndLinksAddKey
         '
         Me.mnuPrepareKeysAndLinksAddKey.Name = "mnuPrepareKeysAndLinksAddKey"
-        Me.mnuPrepareKeysAndLinksAddKey.Size = New System.Drawing.Size(311, 34)
+        Me.mnuPrepareKeysAndLinksAddKey.Size = New System.Drawing.Size(207, 22)
         Me.mnuPrepareKeysAndLinksAddKey.Text = "Add Key..."
         '
         'mnuPrepareKeysAndLinksViewAndRemoveKey
         '
         Me.mnuPrepareKeysAndLinksViewAndRemoveKey.Name = "mnuPrepareKeysAndLinksViewAndRemoveKey"
-        Me.mnuPrepareKeysAndLinksViewAndRemoveKey.Size = New System.Drawing.Size(311, 34)
+        Me.mnuPrepareKeysAndLinksViewAndRemoveKey.Size = New System.Drawing.Size(207, 22)
         Me.mnuPrepareKeysAndLinksViewAndRemoveKey.Text = "View and Remove Keys..."
         '
         'mnuPrepareKeysAndLinksAddLink
         '
         Me.mnuPrepareKeysAndLinksAddLink.Name = "mnuPrepareKeysAndLinksAddLink"
-        Me.mnuPrepareKeysAndLinksAddLink.Size = New System.Drawing.Size(311, 34)
+        Me.mnuPrepareKeysAndLinksAddLink.Size = New System.Drawing.Size(207, 22)
         Me.mnuPrepareKeysAndLinksAddLink.Text = "Add Link..."
         '
         'mnuPrepareKeysAndLinksViewAndRemoveKeys
         '
         Me.mnuPrepareKeysAndLinksViewAndRemoveKeys.Name = "mnuPrepareKeysAndLinksViewAndRemoveKeys"
-        Me.mnuPrepareKeysAndLinksViewAndRemoveKeys.Size = New System.Drawing.Size(311, 34)
+        Me.mnuPrepareKeysAndLinksViewAndRemoveKeys.Size = New System.Drawing.Size(207, 22)
         Me.mnuPrepareKeysAndLinksViewAndRemoveKeys.Text = "View and Remove Links..."
         '
         'mnuPrepareKeysAndLinksAddComment
         '
         Me.mnuPrepareKeysAndLinksAddComment.Name = "mnuPrepareKeysAndLinksAddComment"
-        Me.mnuPrepareKeysAndLinksAddComment.Size = New System.Drawing.Size(311, 34)
+        Me.mnuPrepareKeysAndLinksAddComment.Size = New System.Drawing.Size(207, 22)
         Me.mnuPrepareKeysAndLinksAddComment.Text = "Add Comment..."
         '
         'mnuPrepareDataBook
         '
         Me.mnuPrepareDataBook.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataObjectDataFrameMetadata, Me.mnuPrepareDataObjectRenameDataFrame, Me.mnuPrepareDataObjectReorderDataFrames, Me.mnuPrepareDataObjectCopyDataFrame, Me.mnuPrepareDataObjectDeleteDataFrame, Me.ToolStripSeparator21, Me.mnuPrepareDataObjectHideDataframes, Me.mnuPrepareDataObjectMetadata, Me.mnuPrepareDataObjectRenameMetadata, Me.mnuPrepareDataObjectReorderMetadata, Me.mnuPrepareDataObjectDeleteMetadata})
         Me.mnuPrepareDataBook.Name = "mnuPrepareDataBook"
-        Me.mnuPrepareDataBook.Size = New System.Drawing.Size(251, 34)
+        Me.mnuPrepareDataBook.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareDataBook.Tag = "Data_Object"
         Me.mnuPrepareDataBook.Text = "Data Book"
         '
@@ -4391,7 +4387,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataObjectDataFrameMetadata.Enabled = False
         Me.mnuPrepareDataObjectDataFrameMetadata.Name = "mnuPrepareDataObjectDataFrameMetadata"
-        Me.mnuPrepareDataObjectDataFrameMetadata.Size = New System.Drawing.Size(318, 34)
+        Me.mnuPrepareDataObjectDataFrameMetadata.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectDataFrameMetadata.Tag = "Data_Frame_Metadata..."
         Me.mnuPrepareDataObjectDataFrameMetadata.Text = "Data Frame Metadata..."
         Me.mnuPrepareDataObjectDataFrameMetadata.Visible = False
@@ -4399,46 +4395,46 @@ Partial Class frmMain
         'mnuPrepareDataObjectRenameDataFrame
         '
         Me.mnuPrepareDataObjectRenameDataFrame.Name = "mnuPrepareDataObjectRenameDataFrame"
-        Me.mnuPrepareDataObjectRenameDataFrame.Size = New System.Drawing.Size(318, 34)
+        Me.mnuPrepareDataObjectRenameDataFrame.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectRenameDataFrame.Tag = "ReName_Data_Frame..."
         Me.mnuPrepareDataObjectRenameDataFrame.Text = "Rename Data Frame..."
         '
         'mnuPrepareDataObjectReorderDataFrames
         '
         Me.mnuPrepareDataObjectReorderDataFrames.Name = "mnuPrepareDataObjectReorderDataFrames"
-        Me.mnuPrepareDataObjectReorderDataFrames.Size = New System.Drawing.Size(318, 34)
+        Me.mnuPrepareDataObjectReorderDataFrames.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectReorderDataFrames.Tag = "Reorder_Data_Frames..."
         Me.mnuPrepareDataObjectReorderDataFrames.Text = "Reorder Data Frames..."
         '
         'mnuPrepareDataObjectCopyDataFrame
         '
         Me.mnuPrepareDataObjectCopyDataFrame.Name = "mnuPrepareDataObjectCopyDataFrame"
-        Me.mnuPrepareDataObjectCopyDataFrame.Size = New System.Drawing.Size(318, 34)
+        Me.mnuPrepareDataObjectCopyDataFrame.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectCopyDataFrame.Tag = "Copy_Data_Frame..."
         Me.mnuPrepareDataObjectCopyDataFrame.Text = "Copy Data Frame..."
         '
         'mnuPrepareDataObjectDeleteDataFrame
         '
         Me.mnuPrepareDataObjectDeleteDataFrame.Name = "mnuPrepareDataObjectDeleteDataFrame"
-        Me.mnuPrepareDataObjectDeleteDataFrame.Size = New System.Drawing.Size(318, 34)
+        Me.mnuPrepareDataObjectDeleteDataFrame.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectDeleteDataFrame.Tag = "Delete_Data_Frame..."
         Me.mnuPrepareDataObjectDeleteDataFrame.Text = "Delete Data Frames..."
         '
         'ToolStripSeparator21
         '
         Me.ToolStripSeparator21.Name = "ToolStripSeparator21"
-        Me.ToolStripSeparator21.Size = New System.Drawing.Size(315, 6)
+        Me.ToolStripSeparator21.Size = New System.Drawing.Size(207, 6)
         '
         'mnuPrepareDataObjectHideDataframes
         '
         Me.mnuPrepareDataObjectHideDataframes.Name = "mnuPrepareDataObjectHideDataframes"
-        Me.mnuPrepareDataObjectHideDataframes.Size = New System.Drawing.Size(318, 34)
+        Me.mnuPrepareDataObjectHideDataframes.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectHideDataframes.Text = "Hide/Show Data Frames..."
         '
         'mnuPrepareDataObjectMetadata
         '
         Me.mnuPrepareDataObjectMetadata.Name = "mnuPrepareDataObjectMetadata"
-        Me.mnuPrepareDataObjectMetadata.Size = New System.Drawing.Size(318, 34)
+        Me.mnuPrepareDataObjectMetadata.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectMetadata.Tag = "Metadata..."
         Me.mnuPrepareDataObjectMetadata.Text = "Metadata..."
         '
@@ -4446,7 +4442,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataObjectRenameMetadata.Enabled = False
         Me.mnuPrepareDataObjectRenameMetadata.Name = "mnuPrepareDataObjectRenameMetadata"
-        Me.mnuPrepareDataObjectRenameMetadata.Size = New System.Drawing.Size(318, 34)
+        Me.mnuPrepareDataObjectRenameMetadata.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectRenameMetadata.Tag = "Rename_Metadata..."
         Me.mnuPrepareDataObjectRenameMetadata.Text = "Rename Metadata..."
         Me.mnuPrepareDataObjectRenameMetadata.Visible = False
@@ -4455,7 +4451,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataObjectReorderMetadata.Enabled = False
         Me.mnuPrepareDataObjectReorderMetadata.Name = "mnuPrepareDataObjectReorderMetadata"
-        Me.mnuPrepareDataObjectReorderMetadata.Size = New System.Drawing.Size(318, 34)
+        Me.mnuPrepareDataObjectReorderMetadata.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectReorderMetadata.Tag = "Reorder_Metadata..."
         Me.mnuPrepareDataObjectReorderMetadata.Text = "Reorder Metadata..."
         Me.mnuPrepareDataObjectReorderMetadata.Visible = False
@@ -4464,7 +4460,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataObjectDeleteMetadata.Enabled = False
         Me.mnuPrepareDataObjectDeleteMetadata.Name = "mnuPrepareDataObjectDeleteMetadata"
-        Me.mnuPrepareDataObjectDeleteMetadata.Size = New System.Drawing.Size(318, 34)
+        Me.mnuPrepareDataObjectDeleteMetadata.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectDeleteMetadata.Tag = "Delete_Metadata..."
         Me.mnuPrepareDataObjectDeleteMetadata.Text = "Delete Metadata..."
         Me.mnuPrepareDataObjectDeleteMetadata.Visible = False
@@ -4473,35 +4469,35 @@ Partial Class frmMain
         '
         Me.mnuPrepareRObjects.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareRObjectsView, Me.mnuPrepareRObjectsRename, Me.mnuPrepareRObjectsReorder, Me.mnuPrepareRObjectsDelete})
         Me.mnuPrepareRObjects.Name = "mnuPrepareRObjects"
-        Me.mnuPrepareRObjects.Size = New System.Drawing.Size(251, 34)
+        Me.mnuPrepareRObjects.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareRObjects.Tag = "R_Objects"
         Me.mnuPrepareRObjects.Text = "R Objects"
         '
         'mnuPrepareRObjectsView
         '
         Me.mnuPrepareRObjectsView.Name = "mnuPrepareRObjectsView"
-        Me.mnuPrepareRObjectsView.Size = New System.Drawing.Size(189, 34)
+        Me.mnuPrepareRObjectsView.Size = New System.Drawing.Size(126, 22)
         Me.mnuPrepareRObjectsView.Tag = "View..."
         Me.mnuPrepareRObjectsView.Text = "View..."
         '
         'mnuPrepareRObjectsRename
         '
         Me.mnuPrepareRObjectsRename.Name = "mnuPrepareRObjectsRename"
-        Me.mnuPrepareRObjectsRename.Size = New System.Drawing.Size(189, 34)
+        Me.mnuPrepareRObjectsRename.Size = New System.Drawing.Size(126, 22)
         Me.mnuPrepareRObjectsRename.Tag = "Rename..."
         Me.mnuPrepareRObjectsRename.Text = "Rename..."
         '
         'mnuPrepareRObjectsReorder
         '
         Me.mnuPrepareRObjectsReorder.Name = "mnuPrepareRObjectsReorder"
-        Me.mnuPrepareRObjectsReorder.Size = New System.Drawing.Size(189, 34)
+        Me.mnuPrepareRObjectsReorder.Size = New System.Drawing.Size(126, 22)
         Me.mnuPrepareRObjectsReorder.Tag = "Reorder"
         Me.mnuPrepareRObjectsReorder.Text = "Reorder..."
         '
         'mnuPrepareRObjectsDelete
         '
         Me.mnuPrepareRObjectsDelete.Name = "mnuPrepareRObjectsDelete"
-        Me.mnuPrepareRObjectsDelete.Size = New System.Drawing.Size(189, 34)
+        Me.mnuPrepareRObjectsDelete.Size = New System.Drawing.Size(126, 22)
         Me.mnuPrepareRObjectsDelete.Tag = "Delete..."
         Me.mnuPrepareRObjectsDelete.Text = "Delete..."
         '
@@ -4509,78 +4505,78 @@ Partial Class frmMain
         '
         Me.mnuStructured.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredCircular, Me.mnuStructuredLow_Flow, Me.mnuStructuredSurvival, Me.mnuStructuredTimeSeries, Me.ToolStripSeparator63, Me.mnuStructuredClimatic, Me.mnuStructuredProcurement, Me.mnuStructuredOptionByContext, Me.mnuStructuredSurvey})
         Me.mnuStructured.Name = "mnuStructured"
-        Me.mnuStructured.Size = New System.Drawing.Size(109, 29)
+        Me.mnuStructured.Size = New System.Drawing.Size(74, 22)
         Me.mnuStructured.Text = "Structured"
         '
         'mnuStructuredCircular
         '
         Me.mnuStructuredCircular.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredCircularDefine, Me.mnuStructuredCircularCalculator, Me.mnuStructuredCircularSummaries, Me.ToolStripSeparator46, Me.mnuStructuredCircularDensityPlot, Me.ToolStripSeparator67, Me.mnuStructuredCircularWindRose, Me.mnuStructuredCircularWindPollutionRose, Me.mnuStructuredCircularOtherRosePlots, Me.ToolStripSeparator68, Me.mnuStructuredCircularCirclize})
         Me.mnuStructuredCircular.Name = "mnuStructuredCircular"
-        Me.mnuStructuredCircular.Size = New System.Drawing.Size(281, 34)
+        Me.mnuStructuredCircular.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredCircular.Text = "Circular"
         '
         'mnuStructuredCircularDefine
         '
         Me.mnuStructuredCircularDefine.Name = "mnuStructuredCircularDefine"
-        Me.mnuStructuredCircularDefine.Size = New System.Drawing.Size(287, 34)
+        Me.mnuStructuredCircularDefine.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularDefine.Text = "Define..."
         '
         'mnuStructuredCircularCalculator
         '
         Me.mnuStructuredCircularCalculator.Name = "mnuStructuredCircularCalculator"
-        Me.mnuStructuredCircularCalculator.Size = New System.Drawing.Size(287, 34)
+        Me.mnuStructuredCircularCalculator.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularCalculator.Text = "Calculator..."
         '
         'mnuStructuredCircularSummaries
         '
         Me.mnuStructuredCircularSummaries.Name = "mnuStructuredCircularSummaries"
-        Me.mnuStructuredCircularSummaries.Size = New System.Drawing.Size(287, 34)
+        Me.mnuStructuredCircularSummaries.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularSummaries.Text = "Summaries..."
         '
         'ToolStripSeparator46
         '
         Me.ToolStripSeparator46.Name = "ToolStripSeparator46"
-        Me.ToolStripSeparator46.Size = New System.Drawing.Size(284, 6)
+        Me.ToolStripSeparator46.Size = New System.Drawing.Size(189, 6)
         '
         'mnuStructuredCircularDensityPlot
         '
         Me.mnuStructuredCircularDensityPlot.Name = "mnuStructuredCircularDensityPlot"
-        Me.mnuStructuredCircularDensityPlot.Size = New System.Drawing.Size(287, 34)
+        Me.mnuStructuredCircularDensityPlot.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularDensityPlot.Text = "Circular Plots..."
         '
         'ToolStripSeparator67
         '
         Me.ToolStripSeparator67.Name = "ToolStripSeparator67"
-        Me.ToolStripSeparator67.Size = New System.Drawing.Size(284, 6)
+        Me.ToolStripSeparator67.Size = New System.Drawing.Size(189, 6)
         '
         'mnuStructuredCircularWindRose
         '
         Me.mnuStructuredCircularWindRose.Name = "mnuStructuredCircularWindRose"
-        Me.mnuStructuredCircularWindRose.Size = New System.Drawing.Size(287, 34)
+        Me.mnuStructuredCircularWindRose.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularWindRose.Text = "Wind Rose..."
         '
         'mnuStructuredCircularWindPollutionRose
         '
         Me.mnuStructuredCircularWindPollutionRose.Name = "mnuStructuredCircularWindPollutionRose"
-        Me.mnuStructuredCircularWindPollutionRose.Size = New System.Drawing.Size(287, 34)
+        Me.mnuStructuredCircularWindPollutionRose.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularWindPollutionRose.Text = "Wind/Pollution Rose..."
         '
         'mnuStructuredCircularOtherRosePlots
         '
         Me.mnuStructuredCircularOtherRosePlots.Name = "mnuStructuredCircularOtherRosePlots"
-        Me.mnuStructuredCircularOtherRosePlots.Size = New System.Drawing.Size(287, 34)
+        Me.mnuStructuredCircularOtherRosePlots.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularOtherRosePlots.Text = "Other Rose Plots..."
         '
         'ToolStripSeparator68
         '
         Me.ToolStripSeparator68.Name = "ToolStripSeparator68"
-        Me.ToolStripSeparator68.Size = New System.Drawing.Size(284, 6)
+        Me.ToolStripSeparator68.Size = New System.Drawing.Size(189, 6)
         '
         'mnuStructuredCircularCirclize
         '
         Me.mnuStructuredCircularCirclize.Enabled = False
         Me.mnuStructuredCircularCirclize.Name = "mnuStructuredCircularCirclize"
-        Me.mnuStructuredCircularCirclize.Size = New System.Drawing.Size(287, 34)
+        Me.mnuStructuredCircularCirclize.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularCirclize.Text = "Circlize..."
         Me.mnuStructuredCircularCirclize.Visible = False
         '
@@ -4588,126 +4584,126 @@ Partial Class frmMain
         '
         Me.mnuStructuredLow_Flow.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredLow_FlowDefine})
         Me.mnuStructuredLow_Flow.Name = "mnuStructuredLow_Flow"
-        Me.mnuStructuredLow_Flow.Size = New System.Drawing.Size(281, 34)
+        Me.mnuStructuredLow_Flow.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredLow_Flow.Text = "Low_Flow"
         Me.mnuStructuredLow_Flow.Visible = False
         '
         'mnuStructuredLow_FlowDefine
         '
         Me.mnuStructuredLow_FlowDefine.Name = "mnuStructuredLow_FlowDefine"
-        Me.mnuStructuredLow_FlowDefine.Size = New System.Drawing.Size(177, 34)
+        Me.mnuStructuredLow_FlowDefine.Size = New System.Drawing.Size(117, 22)
         Me.mnuStructuredLow_FlowDefine.Text = "Define..."
         '
         'mnuStructuredSurvival
         '
         Me.mnuStructuredSurvival.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredSurvivalDefine})
         Me.mnuStructuredSurvival.Name = "mnuStructuredSurvival"
-        Me.mnuStructuredSurvival.Size = New System.Drawing.Size(281, 34)
+        Me.mnuStructuredSurvival.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredSurvival.Text = "Survival"
         '
         'mnuStructuredSurvivalDefine
         '
         Me.mnuStructuredSurvivalDefine.Name = "mnuStructuredSurvivalDefine"
-        Me.mnuStructuredSurvivalDefine.Size = New System.Drawing.Size(177, 34)
+        Me.mnuStructuredSurvivalDefine.Size = New System.Drawing.Size(117, 22)
         Me.mnuStructuredSurvivalDefine.Text = "Define..."
         '
         'mnuStructuredTimeSeries
         '
         Me.mnuStructuredTimeSeries.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredTimeSeriesDefine, Me.ToolStripSeparator60, Me.mnuStructuredTimeSeriesDescribe, Me.ToolStripSeparator61, Me.mnuStructuredTimeSeriesModel, Me.ToolStripSeparator62})
         Me.mnuStructuredTimeSeries.Name = "mnuStructuredTimeSeries"
-        Me.mnuStructuredTimeSeries.Size = New System.Drawing.Size(281, 34)
+        Me.mnuStructuredTimeSeries.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredTimeSeries.Text = "Time Series"
         Me.mnuStructuredTimeSeries.Visible = False
         '
         'mnuStructuredTimeSeriesDefine
         '
         Me.mnuStructuredTimeSeriesDefine.Name = "mnuStructuredTimeSeriesDefine"
-        Me.mnuStructuredTimeSeriesDefine.Size = New System.Drawing.Size(182, 34)
+        Me.mnuStructuredTimeSeriesDefine.Size = New System.Drawing.Size(119, 22)
         Me.mnuStructuredTimeSeriesDefine.Text = "Define..."
         '
         'ToolStripSeparator60
         '
         Me.ToolStripSeparator60.Name = "ToolStripSeparator60"
-        Me.ToolStripSeparator60.Size = New System.Drawing.Size(179, 6)
+        Me.ToolStripSeparator60.Size = New System.Drawing.Size(116, 6)
         '
         'mnuStructuredTimeSeriesDescribe
         '
         Me.mnuStructuredTimeSeriesDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredTimeSeriesDescribeOneVariable, Me.mnuStructuredTimeSeriesDescribeGeneral})
         Me.mnuStructuredTimeSeriesDescribe.Name = "mnuStructuredTimeSeriesDescribe"
-        Me.mnuStructuredTimeSeriesDescribe.Size = New System.Drawing.Size(182, 34)
+        Me.mnuStructuredTimeSeriesDescribe.Size = New System.Drawing.Size(119, 22)
         Me.mnuStructuredTimeSeriesDescribe.Text = "Describe"
         '
         'mnuStructuredTimeSeriesDescribeOneVariable
         '
         Me.mnuStructuredTimeSeriesDescribeOneVariable.Name = "mnuStructuredTimeSeriesDescribeOneVariable"
-        Me.mnuStructuredTimeSeriesDescribeOneVariable.Size = New System.Drawing.Size(226, 34)
+        Me.mnuStructuredTimeSeriesDescribeOneVariable.Size = New System.Drawing.Size(149, 22)
         Me.mnuStructuredTimeSeriesDescribeOneVariable.Text = "One Variable..."
         '
         'mnuStructuredTimeSeriesDescribeGeneral
         '
         Me.mnuStructuredTimeSeriesDescribeGeneral.Name = "mnuStructuredTimeSeriesDescribeGeneral"
-        Me.mnuStructuredTimeSeriesDescribeGeneral.Size = New System.Drawing.Size(226, 34)
+        Me.mnuStructuredTimeSeriesDescribeGeneral.Size = New System.Drawing.Size(149, 22)
         Me.mnuStructuredTimeSeriesDescribeGeneral.Text = "General..."
         '
         'ToolStripSeparator61
         '
         Me.ToolStripSeparator61.Name = "ToolStripSeparator61"
-        Me.ToolStripSeparator61.Size = New System.Drawing.Size(179, 6)
+        Me.ToolStripSeparator61.Size = New System.Drawing.Size(116, 6)
         '
         'mnuStructuredTimeSeriesModel
         '
         Me.mnuStructuredTimeSeriesModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredTimeSeriesModelOneVariable, Me.mnuStructuredTimeSeriesModelGeneral})
         Me.mnuStructuredTimeSeriesModel.Name = "mnuStructuredTimeSeriesModel"
-        Me.mnuStructuredTimeSeriesModel.Size = New System.Drawing.Size(182, 34)
+        Me.mnuStructuredTimeSeriesModel.Size = New System.Drawing.Size(119, 22)
         Me.mnuStructuredTimeSeriesModel.Text = "Model"
         '
         'mnuStructuredTimeSeriesModelOneVariable
         '
         Me.mnuStructuredTimeSeriesModelOneVariable.Name = "mnuStructuredTimeSeriesModelOneVariable"
-        Me.mnuStructuredTimeSeriesModelOneVariable.Size = New System.Drawing.Size(226, 34)
+        Me.mnuStructuredTimeSeriesModelOneVariable.Size = New System.Drawing.Size(149, 22)
         Me.mnuStructuredTimeSeriesModelOneVariable.Text = "One Variable..."
         '
         'mnuStructuredTimeSeriesModelGeneral
         '
         Me.mnuStructuredTimeSeriesModelGeneral.Name = "mnuStructuredTimeSeriesModelGeneral"
-        Me.mnuStructuredTimeSeriesModelGeneral.Size = New System.Drawing.Size(226, 34)
+        Me.mnuStructuredTimeSeriesModelGeneral.Size = New System.Drawing.Size(149, 22)
         Me.mnuStructuredTimeSeriesModelGeneral.Text = "General..."
         '
         'ToolStripSeparator62
         '
         Me.ToolStripSeparator62.Name = "ToolStripSeparator62"
-        Me.ToolStripSeparator62.Size = New System.Drawing.Size(179, 6)
+        Me.ToolStripSeparator62.Size = New System.Drawing.Size(116, 6)
         '
         'ToolStripSeparator63
         '
         Me.ToolStripSeparator63.Name = "ToolStripSeparator63"
-        Me.ToolStripSeparator63.Size = New System.Drawing.Size(278, 6)
+        Me.ToolStripSeparator63.Size = New System.Drawing.Size(182, 6)
         '
         'mnuStructuredClimatic
         '
         Me.mnuStructuredClimatic.Name = "mnuStructuredClimatic"
-        Me.mnuStructuredClimatic.Size = New System.Drawing.Size(281, 34)
+        Me.mnuStructuredClimatic.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredClimatic.Text = "Climatic..."
         Me.mnuStructuredClimatic.Visible = False
         '
         'mnuStructuredProcurement
         '
         Me.mnuStructuredProcurement.Name = "mnuStructuredProcurement"
-        Me.mnuStructuredProcurement.Size = New System.Drawing.Size(281, 34)
+        Me.mnuStructuredProcurement.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredProcurement.Text = "Procurement..."
         Me.mnuStructuredProcurement.Visible = False
         '
         'mnuStructuredOptionByContext
         '
         Me.mnuStructuredOptionByContext.Name = "mnuStructuredOptionByContext"
-        Me.mnuStructuredOptionByContext.Size = New System.Drawing.Size(281, 34)
+        Me.mnuStructuredOptionByContext.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredOptionByContext.Text = "Options by Context..."
         Me.mnuStructuredOptionByContext.Visible = False
         '
         'mnuStructuredSurvey
         '
         Me.mnuStructuredSurvey.Name = "mnuStructuredSurvey"
-        Me.mnuStructuredSurvey.Size = New System.Drawing.Size(281, 34)
+        Me.mnuStructuredSurvey.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredSurvey.Text = "Survey"
         Me.mnuStructuredSurvey.Visible = False
         '
@@ -4715,651 +4711,627 @@ Partial Class frmMain
         '
         Me.mnuTricot.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotImportFromClimMob, Me.mnuTricotTransformClimMob, Me.mnuTricotDefineTricotData, Me.mnuTricotGenotypeData, Me.ToolStripSeparator20, Me.mnuTricotDescribe, Me.mnuTricotModelPlackettLuce})
         Me.mnuTricot.Name = "mnuTricot"
-        Me.mnuTricot.Size = New System.Drawing.Size(70, 29)
+        Me.mnuTricot.Size = New System.Drawing.Size(49, 22)
         Me.mnuTricot.Text = "Tricot"
         '
         'mnuTricotImportFromClimMob
         '
         Me.mnuTricotImportFromClimMob.Name = "mnuTricotImportFromClimMob"
-        Me.mnuTricotImportFromClimMob.Size = New System.Drawing.Size(303, 34)
+        Me.mnuTricotImportFromClimMob.Size = New System.Drawing.Size(201, 22)
         Me.mnuTricotImportFromClimMob.Text = "Import from ClimMob..."
         '
         'mnuTricotTransformClimMob
         '
         Me.mnuTricotTransformClimMob.Name = "mnuTricotTransformClimMob"
-        Me.mnuTricotTransformClimMob.Size = New System.Drawing.Size(303, 34)
+        Me.mnuTricotTransformClimMob.Size = New System.Drawing.Size(201, 22)
         Me.mnuTricotTransformClimMob.Text = "Transform ClimMob..."
         '
         'mnuTricotDefineTricotData
         '
         Me.mnuTricotDefineTricotData.Name = "mnuTricotDefineTricotData"
-        Me.mnuTricotDefineTricotData.Size = New System.Drawing.Size(303, 34)
+        Me.mnuTricotDefineTricotData.Size = New System.Drawing.Size(201, 22)
         Me.mnuTricotDefineTricotData.Text = "Define Tricot Data..."
         '
         'mnuTricotGenotypeData
         '
         Me.mnuTricotGenotypeData.Name = "mnuTricotGenotypeData"
-        Me.mnuTricotGenotypeData.Size = New System.Drawing.Size(303, 34)
+        Me.mnuTricotGenotypeData.Size = New System.Drawing.Size(201, 22)
         Me.mnuTricotGenotypeData.Text = "Genotype Data..."
         '
         'ToolStripSeparator20
         '
         Me.ToolStripSeparator20.Name = "ToolStripSeparator20"
-        Me.ToolStripSeparator20.Size = New System.Drawing.Size(300, 6)
+        Me.ToolStripSeparator20.Size = New System.Drawing.Size(198, 6)
         '
         'mnuTricotDescribe
         '
         Me.mnuTricotDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotDescribeTraits, Me.mnuTricotDescribeCorrelations})
         Me.mnuTricotDescribe.Name = "mnuTricotDescribe"
-        Me.mnuTricotDescribe.Size = New System.Drawing.Size(303, 34)
+        Me.mnuTricotDescribe.Size = New System.Drawing.Size(201, 22)
         Me.mnuTricotDescribe.Text = "Describe"
         '
         'mnuTricotDescribeTraits
         '
         Me.mnuTricotDescribeTraits.Name = "mnuTricotDescribeTraits"
-        Me.mnuTricotDescribeTraits.Size = New System.Drawing.Size(221, 34)
+        Me.mnuTricotDescribeTraits.Size = New System.Drawing.Size(147, 22)
         Me.mnuTricotDescribeTraits.Text = "Traits..."
         '
         'mnuTricotDescribeCorrelations
         '
         Me.mnuTricotDescribeCorrelations.Name = "mnuTricotDescribeCorrelations"
-        Me.mnuTricotDescribeCorrelations.Size = New System.Drawing.Size(221, 34)
+        Me.mnuTricotDescribeCorrelations.Size = New System.Drawing.Size(147, 22)
         Me.mnuTricotDescribeCorrelations.Text = "Correlations..."
         '
         'mnuTricotModelPlackettLuce
         '
         Me.mnuTricotModelPlackettLuce.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotModelWithoutCovariates, Me.mnuTricotModelTree, Me.mnuTricotModelOverall, Me.mnuTricotModelCharacterisation})
         Me.mnuTricotModelPlackettLuce.Name = "mnuTricotModelPlackettLuce"
-        Me.mnuTricotModelPlackettLuce.Size = New System.Drawing.Size(303, 34)
+        Me.mnuTricotModelPlackettLuce.Size = New System.Drawing.Size(201, 22)
         Me.mnuTricotModelPlackettLuce.Text = "Model (Plackett-Luce)"
         '
         'mnuTricotModelWithoutCovariates
         '
         Me.mnuTricotModelWithoutCovariates.Name = "mnuTricotModelWithoutCovariates"
-        Me.mnuTricotModelWithoutCovariates.Size = New System.Drawing.Size(277, 34)
+        Me.mnuTricotModelWithoutCovariates.Size = New System.Drawing.Size(203, 22)
         Me.mnuTricotModelWithoutCovariates.Text = "Without Covariates..."
         '
         'mnuTricotModelTree
         '
         Me.mnuTricotModelTree.Name = "mnuTricotModelTree"
-        Me.mnuTricotModelTree.Size = New System.Drawing.Size(277, 34)
+        Me.mnuTricotModelTree.Size = New System.Drawing.Size(203, 22)
         Me.mnuTricotModelTree.Text = "Tree..."
         '
         'mnuTricotModelOverall
         '
         Me.mnuTricotModelOverall.Name = "mnuTricotModelOverall"
-        Me.mnuTricotModelOverall.Size = New System.Drawing.Size(304, 34)
+        Me.mnuTricotModelOverall.Size = New System.Drawing.Size(203, 22)
         Me.mnuTricotModelOverall.Text = "Model (One Covariate)..."
         '
         'mnuTricotModelCharacterisation
         '
         Me.mnuTricotModelCharacterisation.Name = "mnuTricotModelCharacterisation"
-        Me.mnuTricotModelCharacterisation.Size = New System.Drawing.Size(277, 34)
+        Me.mnuTricotModelCharacterisation.Size = New System.Drawing.Size(203, 22)
         Me.mnuTricotModelCharacterisation.Text = "Characterisation..."
         '
         'mnuTricotXp
         '
         Me.mnuTricotXp.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuItem3, Me.ToolStripMenuItem4, Me.ToolStripMenuItem5, Me.ToolStripMenuItem6, Me.ToolStripSeparator84, Me.ToolStripMenuItem7, Me.ToolStripMenuItem10})
         Me.mnuTricotXp.Name = "mnuTricotXp"
-        Me.mnuTricotXp.Size = New System.Drawing.Size(91, 29)
+        Me.mnuTricotXp.Size = New System.Drawing.Size(63, 22)
         Me.mnuTricotXp.Text = "TricotXP"
         '
         'ToolStripMenuItem3
         '
         Me.ToolStripMenuItem3.Name = "ToolStripMenuItem3"
-        Me.ToolStripMenuItem3.Size = New System.Drawing.Size(303, 34)
+        Me.ToolStripMenuItem3.Size = New System.Drawing.Size(201, 22)
         Me.ToolStripMenuItem3.Text = "Import from ClimMob..."
         '
         'ToolStripMenuItem4
         '
         Me.ToolStripMenuItem4.Name = "ToolStripMenuItem4"
-        Me.ToolStripMenuItem4.Size = New System.Drawing.Size(303, 34)
+        Me.ToolStripMenuItem4.Size = New System.Drawing.Size(201, 22)
         Me.ToolStripMenuItem4.Text = "Transform ClimMob..."
         '
         'ToolStripMenuItem5
         '
         Me.ToolStripMenuItem5.Name = "ToolStripMenuItem5"
-        Me.ToolStripMenuItem5.Size = New System.Drawing.Size(303, 34)
+        Me.ToolStripMenuItem5.Size = New System.Drawing.Size(201, 22)
         Me.ToolStripMenuItem5.Text = "Define Tricot Data..."
         '
         'ToolStripMenuItem6
         '
         Me.ToolStripMenuItem6.Name = "ToolStripMenuItem6"
-        Me.ToolStripMenuItem6.Size = New System.Drawing.Size(303, 34)
+        Me.ToolStripMenuItem6.Size = New System.Drawing.Size(201, 22)
         Me.ToolStripMenuItem6.Text = "Genotype Data..."
         '
         'ToolStripSeparator84
         '
         Me.ToolStripSeparator84.Name = "ToolStripSeparator84"
-        Me.ToolStripSeparator84.Size = New System.Drawing.Size(300, 6)
+        Me.ToolStripSeparator84.Size = New System.Drawing.Size(198, 6)
         '
         'ToolStripMenuItem7
         '
         Me.ToolStripMenuItem7.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotXpDescribeTraits, Me.ToolStripMenuItem9})
         Me.ToolStripMenuItem7.Name = "ToolStripMenuItem7"
-        Me.ToolStripMenuItem7.Size = New System.Drawing.Size(303, 34)
+        Me.ToolStripMenuItem7.Size = New System.Drawing.Size(201, 22)
         Me.ToolStripMenuItem7.Text = "Describe"
         '
         'mnuTricotXpDescribeTraits
         '
         Me.mnuTricotXpDescribeTraits.Name = "mnuTricotXpDescribeTraits"
-        Me.mnuTricotXpDescribeTraits.Size = New System.Drawing.Size(221, 34)
+        Me.mnuTricotXpDescribeTraits.Size = New System.Drawing.Size(147, 22)
         Me.mnuTricotXpDescribeTraits.Text = "Traits..."
         '
         'ToolStripMenuItem9
         '
         Me.ToolStripMenuItem9.Name = "ToolStripMenuItem9"
-        Me.ToolStripMenuItem9.Size = New System.Drawing.Size(221, 34)
+        Me.ToolStripMenuItem9.Size = New System.Drawing.Size(147, 22)
         Me.ToolStripMenuItem9.Text = "Correlations..."
         '
         'ToolStripMenuItem10
         '
         Me.ToolStripMenuItem10.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuItem11, Me.ToolStripMenuItem12, Me.ToolStripMenuItem13, Me.ToolStripMenuItem14})
         Me.ToolStripMenuItem10.Name = "ToolStripMenuItem10"
-        Me.ToolStripMenuItem10.Size = New System.Drawing.Size(303, 34)
+        Me.ToolStripMenuItem10.Size = New System.Drawing.Size(201, 22)
         Me.ToolStripMenuItem10.Text = "Model (Plackett-Luce)"
         '
         'ToolStripMenuItem11
         '
         Me.ToolStripMenuItem11.Name = "ToolStripMenuItem11"
-        Me.ToolStripMenuItem11.Size = New System.Drawing.Size(277, 34)
+        Me.ToolStripMenuItem11.Size = New System.Drawing.Size(184, 22)
         Me.ToolStripMenuItem11.Text = "Without Covariates..."
         '
         'ToolStripMenuItem12
         '
         Me.ToolStripMenuItem12.Name = "ToolStripMenuItem12"
-        Me.ToolStripMenuItem12.Size = New System.Drawing.Size(277, 34)
+        Me.ToolStripMenuItem12.Size = New System.Drawing.Size(184, 22)
         Me.ToolStripMenuItem12.Text = "Tree..."
         '
         'ToolStripMenuItem13
         '
         Me.ToolStripMenuItem13.Name = "ToolStripMenuItem13"
-        Me.ToolStripMenuItem13.Size = New System.Drawing.Size(277, 34)
+        Me.ToolStripMenuItem13.Size = New System.Drawing.Size(184, 22)
         Me.ToolStripMenuItem13.Text = "Overall..."
         '
         'ToolStripMenuItem14
         '
         Me.ToolStripMenuItem14.Name = "ToolStripMenuItem14"
-        Me.ToolStripMenuItem14.Size = New System.Drawing.Size(277, 34)
+        Me.ToolStripMenuItem14.Size = New System.Drawing.Size(184, 22)
         Me.ToolStripMenuItem14.Text = "Characterisation..."
         '
         'mnuOptionsByContext
         '
         Me.mnuOptionsByContext.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCheckData, Me.mnuOptionsByContextDefine, Me.mnuOptionsByContextPrepare, Me.mnuOptionsByContextDescribe, Me.mnuOptionsByContextModel, Me.mnuOptionsByContextCropModel})
         Me.mnuOptionsByContext.Name = "mnuOptionsByContext"
-        Me.mnuOptionsByContext.Size = New System.Drawing.Size(124, 29)
+        Me.mnuOptionsByContext.Size = New System.Drawing.Size(83, 22)
         Me.mnuOptionsByContext.Text = "Experiments"
         '
         'mnuOptionsByContextCheckData
         '
         Me.mnuOptionsByContextCheckData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCheckDataDuplicateRows, Me.mnuOptionsByContextCheckDataCompareColumns, Me.ToolStripSeparator47, Me.mnuOptionsByContextCheckDataOneVariableSummarise, Me.mnuOptionsByContextCheckDataOneVariableGraph, Me.mnuOptionsByContextCheckDataOneVariableFrequencies})
         Me.mnuOptionsByContextCheckData.Name = "mnuOptionsByContextCheckData"
-        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(209, 34)
+        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(137, 22)
         Me.mnuOptionsByContextCheckData.Text = "Check Data"
         '
         'mnuOptionsByContextCheckDataDuplicateRows
         '
         Me.mnuOptionsByContextCheckDataDuplicateRows.Name = "mnuOptionsByContextCheckDataDuplicateRows"
-        Me.mnuOptionsByContextCheckDataDuplicateRows.Size = New System.Drawing.Size(324, 34)
+        Me.mnuOptionsByContextCheckDataDuplicateRows.Size = New System.Drawing.Size(215, 22)
         Me.mnuOptionsByContextCheckDataDuplicateRows.Text = "Duplicate Rows..."
         '
         'mnuOptionsByContextCheckDataCompareColumns
         '
         Me.mnuOptionsByContextCheckDataCompareColumns.Name = "mnuOptionsByContextCheckDataCompareColumns"
-        Me.mnuOptionsByContextCheckDataCompareColumns.Size = New System.Drawing.Size(324, 34)
+        Me.mnuOptionsByContextCheckDataCompareColumns.Size = New System.Drawing.Size(215, 22)
         Me.mnuOptionsByContextCheckDataCompareColumns.Text = "Compare Columns..."
         '
         'ToolStripSeparator47
         '
         Me.ToolStripSeparator47.Name = "ToolStripSeparator47"
-        Me.ToolStripSeparator47.Size = New System.Drawing.Size(321, 6)
+        Me.ToolStripSeparator47.Size = New System.Drawing.Size(212, 6)
         '
         'mnuOptionsByContextCheckDataOneVariableSummarise
         '
         Me.mnuOptionsByContextCheckDataOneVariableSummarise.Name = "mnuOptionsByContextCheckDataOneVariableSummarise"
-        Me.mnuOptionsByContextCheckDataOneVariableSummarise.Size = New System.Drawing.Size(324, 34)
+        Me.mnuOptionsByContextCheckDataOneVariableSummarise.Size = New System.Drawing.Size(215, 22)
         Me.mnuOptionsByContextCheckDataOneVariableSummarise.Text = "One Variable Summarise..."
         '
         'mnuOptionsByContextCheckDataOneVariableGraph
         '
         Me.mnuOptionsByContextCheckDataOneVariableGraph.Name = "mnuOptionsByContextCheckDataOneVariableGraph"
-        Me.mnuOptionsByContextCheckDataOneVariableGraph.Size = New System.Drawing.Size(324, 34)
+        Me.mnuOptionsByContextCheckDataOneVariableGraph.Size = New System.Drawing.Size(215, 22)
         Me.mnuOptionsByContextCheckDataOneVariableGraph.Text = "One Variable Graph..."
         '
         'mnuOptionsByContextCheckDataOneVariableFrequencies
         '
         Me.mnuOptionsByContextCheckDataOneVariableFrequencies.Name = "mnuOptionsByContextCheckDataOneVariableFrequencies"
-        Me.mnuOptionsByContextCheckDataOneVariableFrequencies.Size = New System.Drawing.Size(324, 34)
+        Me.mnuOptionsByContextCheckDataOneVariableFrequencies.Size = New System.Drawing.Size(215, 22)
         Me.mnuOptionsByContextCheckDataOneVariableFrequencies.Text = "One Variable Frequencies..."
         '
         'mnuOptionsByContextDefine
         '
         Me.mnuOptionsByContextDefine.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDefineOnStation, Me.mnuOptionsByContextDefineOnFarm})
         Me.mnuOptionsByContextDefine.Name = "mnuOptionsByContextDefine"
-        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(209, 34)
+        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(137, 22)
         Me.mnuOptionsByContextDefine.Text = "Define"
         '
         'mnuOptionsByContextDefineOnStation
         '
         Me.mnuOptionsByContextDefineOnStation.Name = "mnuOptionsByContextDefineOnStation"
-        Me.mnuOptionsByContextDefineOnStation.Size = New System.Drawing.Size(222, 34)
+        Me.mnuOptionsByContextDefineOnStation.Size = New System.Drawing.Size(147, 22)
         Me.mnuOptionsByContextDefineOnStation.Text = "On - Station..."
         '
         'mnuOptionsByContextDefineOnFarm
         '
         Me.mnuOptionsByContextDefineOnFarm.Name = "mnuOptionsByContextDefineOnFarm"
-        Me.mnuOptionsByContextDefineOnFarm.Size = New System.Drawing.Size(222, 34)
+        Me.mnuOptionsByContextDefineOnFarm.Size = New System.Drawing.Size(147, 22)
         Me.mnuOptionsByContextDefineOnFarm.Text = "On - Farm..."
         '
         'mnuOptionsByContextPrepare
         '
         Me.mnuOptionsByContextPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions, Me.ToolStripSeparator48, Me.mnuOptionsByContextMergeAdditionalData, Me.mnuOptionsByContextPrepareStack, Me.mnuOptionsByContextPrepareUnstack})
         Me.mnuOptionsByContextPrepare.Name = "mnuOptionsByContextPrepare"
-        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(209, 34)
+        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(137, 22)
         Me.mnuOptionsByContextPrepare.Text = "Prepare"
         '
         'mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions
         '
         Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions.Name = "mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions"
-        Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions.Size = New System.Drawing.Size(421, 34)
+        Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions.Size = New System.Drawing.Size(282, 22)
         Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions.Text = "Calculate Difference Between Options..."
         '
         'ToolStripSeparator48
         '
         Me.ToolStripSeparator48.Name = "ToolStripSeparator48"
-        Me.ToolStripSeparator48.Size = New System.Drawing.Size(418, 6)
+        Me.ToolStripSeparator48.Size = New System.Drawing.Size(279, 6)
         '
         'mnuOptionsByContextMergeAdditionalData
         '
         Me.mnuOptionsByContextMergeAdditionalData.Name = "mnuOptionsByContextMergeAdditionalData"
-        Me.mnuOptionsByContextMergeAdditionalData.Size = New System.Drawing.Size(421, 34)
+        Me.mnuOptionsByContextMergeAdditionalData.Size = New System.Drawing.Size(282, 22)
         Me.mnuOptionsByContextMergeAdditionalData.Text = "Merge Additional Data..."
         '
         'mnuOptionsByContextPrepareStack
         '
         Me.mnuOptionsByContextPrepareStack.Name = "mnuOptionsByContextPrepareStack"
-        Me.mnuOptionsByContextPrepareStack.Size = New System.Drawing.Size(421, 34)
+        Me.mnuOptionsByContextPrepareStack.Size = New System.Drawing.Size(282, 22)
         Me.mnuOptionsByContextPrepareStack.Text = "Stack (Pivot Longer)..."
         '
         'mnuOptionsByContextPrepareUnstack
         '
         Me.mnuOptionsByContextPrepareUnstack.Name = "mnuOptionsByContextPrepareUnstack"
-        Me.mnuOptionsByContextPrepareUnstack.Size = New System.Drawing.Size(421, 34)
+        Me.mnuOptionsByContextPrepareUnstack.Size = New System.Drawing.Size(282, 22)
         Me.mnuOptionsByContextPrepareUnstack.Text = "Unstack (Pivot Wider)..."
         '
         'mnuOptionsByContextDescribe
         '
         Me.mnuOptionsByContextDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDescribeCompareTwoTreatments, Me.mnuOptionsByContextDescribeCompareMultipleTreatments, Me.mnuOptionsByContextDescribeBoxplot})
         Me.mnuOptionsByContextDescribe.Name = "mnuOptionsByContextDescribe"
-        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(209, 34)
+        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(137, 22)
         Me.mnuOptionsByContextDescribe.Text = "Describe"
         '
         'mnuOptionsByContextDescribeCompareTwoTreatments
         '
         Me.mnuOptionsByContextDescribeCompareTwoTreatments.Name = "mnuOptionsByContextDescribeCompareTwoTreatments"
-        Me.mnuOptionsByContextDescribeCompareTwoTreatments.Size = New System.Drawing.Size(337, 34)
+        Me.mnuOptionsByContextDescribeCompareTwoTreatments.Size = New System.Drawing.Size(224, 22)
         Me.mnuOptionsByContextDescribeCompareTwoTreatments.Text = "Compare Two Options..."
         '
         'mnuOptionsByContextDescribeCompareMultipleTreatments
         '
         Me.mnuOptionsByContextDescribeCompareMultipleTreatments.Enabled = False
         Me.mnuOptionsByContextDescribeCompareMultipleTreatments.Name = "mnuOptionsByContextDescribeCompareMultipleTreatments"
-        Me.mnuOptionsByContextDescribeCompareMultipleTreatments.Size = New System.Drawing.Size(337, 34)
+        Me.mnuOptionsByContextDescribeCompareMultipleTreatments.Size = New System.Drawing.Size(224, 22)
         Me.mnuOptionsByContextDescribeCompareMultipleTreatments.Text = "Compare Multiple Options..."
         '
         'mnuOptionsByContextDescribeBoxplot
         '
         Me.mnuOptionsByContextDescribeBoxplot.Name = "mnuOptionsByContextDescribeBoxplot"
-        Me.mnuOptionsByContextDescribeBoxplot.Size = New System.Drawing.Size(337, 34)
+        Me.mnuOptionsByContextDescribeBoxplot.Size = New System.Drawing.Size(224, 22)
         Me.mnuOptionsByContextDescribeBoxplot.Text = "Boxplot..."
         '
         'mnuOptionsByContextModel
         '
         Me.mnuOptionsByContextModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextModelFitModel, Me.mnuOptionsByContextGeneralFitModel})
         Me.mnuOptionsByContextModel.Name = "mnuOptionsByContextModel"
-        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(209, 34)
+        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(137, 22)
         Me.mnuOptionsByContextModel.Text = "Model"
         '
         'mnuOptionsByContextModelFitModel
         '
         Me.mnuOptionsByContextModelFitModel.Name = "mnuOptionsByContextModelFitModel"
-        Me.mnuOptionsByContextModelFitModel.Size = New System.Drawing.Size(265, 34)
+        Me.mnuOptionsByContextModelFitModel.Size = New System.Drawing.Size(176, 22)
         Me.mnuOptionsByContextModelFitModel.Text = "Fit Model..."
         '
         'mnuOptionsByContextGeneralFitModel
         '
         Me.mnuOptionsByContextGeneralFitModel.Name = "mnuOptionsByContextGeneralFitModel"
-        Me.mnuOptionsByContextGeneralFitModel.Size = New System.Drawing.Size(265, 34)
+        Me.mnuOptionsByContextGeneralFitModel.Size = New System.Drawing.Size(176, 22)
         Me.mnuOptionsByContextGeneralFitModel.Text = "General Fit Model..."
         '
         'mnuOptionsByContextCropModel
         '
         Me.mnuOptionsByContextCropModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCropModelApsimxExamples})
         Me.mnuOptionsByContextCropModel.Name = "mnuOptionsByContextCropModel"
-        Me.mnuOptionsByContextCropModel.Size = New System.Drawing.Size(209, 34)
+        Me.mnuOptionsByContextCropModel.Size = New System.Drawing.Size(137, 22)
         Me.mnuOptionsByContextCropModel.Text = "Crop Model"
         '
         'mnuOptionsByContextCropModelApsimxExamples
         '
         Me.mnuOptionsByContextCropModelApsimxExamples.Name = "mnuOptionsByContextCropModelApsimxExamples"
-        Me.mnuOptionsByContextCropModelApsimxExamples.Size = New System.Drawing.Size(264, 34)
+        Me.mnuOptionsByContextCropModelApsimxExamples.Size = New System.Drawing.Size(174, 22)
         Me.mnuOptionsByContextCropModelApsimxExamples.Text = "Apsimx Examples..."
         '
         'mnuProcurement
         '
         Me.mnuProcurement.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementOpenFromLibrary, Me.mnuProcurementDefineData, Me.mnuProcurementPrepare, Me.mnuProcurementDescribe, Me.mnuProcurementMapping, Me.mnuProcurementModel, Me.ToolStripSeparator45, Me.mnuProcurementDefineRedFlags, Me.mnuProcurementUseCRI})
         Me.mnuProcurement.Name = "mnuProcurement"
-        Me.mnuProcurement.Size = New System.Drawing.Size(129, 29)
+        Me.mnuProcurement.Size = New System.Drawing.Size(88, 22)
         Me.mnuProcurement.Text = "Procurement"
         '
         'mnuProcurementOpenFromLibrary
         '
         Me.mnuProcurementOpenFromLibrary.Name = "mnuProcurementOpenFromLibrary"
-        Me.mnuProcurementOpenFromLibrary.Size = New System.Drawing.Size(327, 34)
+        Me.mnuProcurementOpenFromLibrary.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementOpenFromLibrary.Text = "Open From Library..."
         '
         'mnuProcurementDefineData
         '
         Me.mnuProcurementDefineData.Name = "mnuProcurementDefineData"
-        Me.mnuProcurementDefineData.Size = New System.Drawing.Size(327, 34)
+        Me.mnuProcurementDefineData.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementDefineData.Text = "Define Procurement Data..."
         '
         'mnuProcurementPrepare
         '
         Me.mnuProcurementPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementPrepareFilterByCountry, Me.ToolStripSeparator42, Me.mnuProcurementPrepareDefineContractValueCategories, Me.mnuProcurementPrepareRecodeNumericIntoQuantiles, Me.mnuProcurementPrepareSetFactorReferenceLevel, Me.mnuProcurementPrepareUseAwardDate, Me.ToolStripSeparator43, Me.mnuProcurementPrepareSummariseRedFlagsByCountryorOther, Me.mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther, Me.mnuProcurementPrepareMergeAdditionalData})
         Me.mnuProcurementPrepare.Name = "mnuProcurementPrepare"
-        Me.mnuProcurementPrepare.Size = New System.Drawing.Size(327, 34)
+        Me.mnuProcurementPrepare.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementPrepare.Text = "Prepare"
         '
         'mnuProcurementPrepareFilterByCountry
         '
         Me.mnuProcurementPrepareFilterByCountry.Name = "mnuProcurementPrepareFilterByCountry"
-        Me.mnuProcurementPrepareFilterByCountry.Size = New System.Drawing.Size(539, 34)
+        Me.mnuProcurementPrepareFilterByCountry.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareFilterByCountry.Text = "Filter by Country (or other)..."
         '
         'ToolStripSeparator42
         '
         Me.ToolStripSeparator42.Name = "ToolStripSeparator42"
-        Me.ToolStripSeparator42.Size = New System.Drawing.Size(536, 6)
+        Me.ToolStripSeparator42.Size = New System.Drawing.Size(355, 6)
         '
         'mnuProcurementPrepareDefineContractValueCategories
         '
         Me.mnuProcurementPrepareDefineContractValueCategories.Name = "mnuProcurementPrepareDefineContractValueCategories"
-        Me.mnuProcurementPrepareDefineContractValueCategories.Size = New System.Drawing.Size(539, 34)
+        Me.mnuProcurementPrepareDefineContractValueCategories.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareDefineContractValueCategories.Text = "Define Contract Value Categories..."
         '
         'mnuProcurementPrepareRecodeNumericIntoQuantiles
         '
         Me.mnuProcurementPrepareRecodeNumericIntoQuantiles.Name = "mnuProcurementPrepareRecodeNumericIntoQuantiles"
-        Me.mnuProcurementPrepareRecodeNumericIntoQuantiles.Size = New System.Drawing.Size(539, 34)
+        Me.mnuProcurementPrepareRecodeNumericIntoQuantiles.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareRecodeNumericIntoQuantiles.Text = "Recode Numeric into Quantiles..."
         '
         'mnuProcurementPrepareSetFactorReferenceLevel
         '
         Me.mnuProcurementPrepareSetFactorReferenceLevel.Name = "mnuProcurementPrepareSetFactorReferenceLevel"
-        Me.mnuProcurementPrepareSetFactorReferenceLevel.Size = New System.Drawing.Size(539, 34)
+        Me.mnuProcurementPrepareSetFactorReferenceLevel.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareSetFactorReferenceLevel.Text = "Set Factor Reference Level..."
         '
         'mnuProcurementPrepareUseAwardDate
         '
         Me.mnuProcurementPrepareUseAwardDate.Name = "mnuProcurementPrepareUseAwardDate"
-        Me.mnuProcurementPrepareUseAwardDate.Size = New System.Drawing.Size(539, 34)
+        Me.mnuProcurementPrepareUseAwardDate.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareUseAwardDate.Text = "Use Award Date (or other)..."
         '
         'ToolStripSeparator43
         '
         Me.ToolStripSeparator43.Name = "ToolStripSeparator43"
-        Me.ToolStripSeparator43.Size = New System.Drawing.Size(536, 6)
+        Me.ToolStripSeparator43.Size = New System.Drawing.Size(355, 6)
         '
         'mnuProcurementPrepareSummariseRedFlagsByCountryorOther
         '
         Me.mnuProcurementPrepareSummariseRedFlagsByCountryorOther.Name = "mnuProcurementPrepareSummariseRedFlagsByCountryorOther"
-        Me.mnuProcurementPrepareSummariseRedFlagsByCountryorOther.Size = New System.Drawing.Size(539, 34)
+        Me.mnuProcurementPrepareSummariseRedFlagsByCountryorOther.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareSummariseRedFlagsByCountryorOther.Text = "Summarise Red Flags by Country (or other)..."
         '
         'mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther
         '
         Me.mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther.Name = "mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther"
-        Me.mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther.Size = New System.Drawing.Size(539, 34)
+        Me.mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther.Text = "Summarise Red Flags by Country and Year (or other)..."
         '
         'mnuProcurementPrepareMergeAdditionalData
         '
         Me.mnuProcurementPrepareMergeAdditionalData.Name = "mnuProcurementPrepareMergeAdditionalData"
-        Me.mnuProcurementPrepareMergeAdditionalData.Size = New System.Drawing.Size(539, 34)
+        Me.mnuProcurementPrepareMergeAdditionalData.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareMergeAdditionalData.Text = "Merge Additional Data..."
         '
         'mnuProcurementDescribe
         '
         Me.mnuProcurementDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementDescribeOneVariableSummarise, Me.mnuProcurementDescribeOneVariableGraph, Me.ToolStripSeparator44, Me.mnuProcurementDescribeCategorical, Me.mnuProcurementDescribeNumeric})
         Me.mnuProcurementDescribe.Name = "mnuProcurementDescribe"
-        Me.mnuProcurementDescribe.Size = New System.Drawing.Size(327, 34)
+        Me.mnuProcurementDescribe.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementDescribe.Text = "Describe"
         '
         'mnuProcurementDescribeOneVariableSummarise
         '
         Me.mnuProcurementDescribeOneVariableSummarise.Name = "mnuProcurementDescribeOneVariableSummarise"
-        Me.mnuProcurementDescribeOneVariableSummarise.Size = New System.Drawing.Size(319, 34)
+        Me.mnuProcurementDescribeOneVariableSummarise.Size = New System.Drawing.Size(211, 22)
         Me.mnuProcurementDescribeOneVariableSummarise.Text = "One Variable Summarise..."
         '
         'mnuProcurementDescribeOneVariableGraph
         '
         Me.mnuProcurementDescribeOneVariableGraph.Name = "mnuProcurementDescribeOneVariableGraph"
-        Me.mnuProcurementDescribeOneVariableGraph.Size = New System.Drawing.Size(319, 34)
+        Me.mnuProcurementDescribeOneVariableGraph.Size = New System.Drawing.Size(211, 22)
         Me.mnuProcurementDescribeOneVariableGraph.Text = "One Variable Graph..."
         '
         'ToolStripSeparator44
         '
         Me.ToolStripSeparator44.Name = "ToolStripSeparator44"
-        Me.ToolStripSeparator44.Size = New System.Drawing.Size(316, 6)
+        Me.ToolStripSeparator44.Size = New System.Drawing.Size(208, 6)
         '
         'mnuProcurementDescribeCategorical
         '
         Me.mnuProcurementDescribeCategorical.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementDescribeCategoricalOneVarFreq, Me.mnuProcurementDescribeCategoricalTwoVarFreq, Me.ToolStripSeparator52, Me.mnuProcurementDescribeCategoricalBarCharts, Me.mnuProcurementDescribeCategoricalMosaic, Me.mnuProcurementDescribeCategoricalTreemap, Me.DisplayTopNToolStripMenuItem})
         Me.mnuProcurementDescribeCategorical.Name = "mnuProcurementDescribeCategorical"
-        Me.mnuProcurementDescribeCategorical.Size = New System.Drawing.Size(319, 34)
+        Me.mnuProcurementDescribeCategorical.Size = New System.Drawing.Size(211, 22)
         Me.mnuProcurementDescribeCategorical.Text = "Categorical"
         '
         'mnuProcurementDescribeCategoricalOneVarFreq
         '
         Me.mnuProcurementDescribeCategoricalOneVarFreq.Name = "mnuProcurementDescribeCategoricalOneVarFreq"
-        Me.mnuProcurementDescribeCategoricalOneVarFreq.Size = New System.Drawing.Size(482, 34)
+        Me.mnuProcurementDescribeCategoricalOneVarFreq.Size = New System.Drawing.Size(320, 22)
         Me.mnuProcurementDescribeCategoricalOneVarFreq.Text = "One Variable Frequencies..."
         '
         'mnuProcurementDescribeCategoricalTwoVarFreq
         '
         Me.mnuProcurementDescribeCategoricalTwoVarFreq.Name = "mnuProcurementDescribeCategoricalTwoVarFreq"
-        Me.mnuProcurementDescribeCategoricalTwoVarFreq.Size = New System.Drawing.Size(482, 34)
+        Me.mnuProcurementDescribeCategoricalTwoVarFreq.Size = New System.Drawing.Size(320, 22)
         Me.mnuProcurementDescribeCategoricalTwoVarFreq.Text = "Two Variable Frequencies by Sector (or other)..."
         '
         'ToolStripSeparator52
         '
         Me.ToolStripSeparator52.Name = "ToolStripSeparator52"
-        Me.ToolStripSeparator52.Size = New System.Drawing.Size(479, 6)
+        Me.ToolStripSeparator52.Size = New System.Drawing.Size(317, 6)
         '
         'mnuProcurementDescribeCategoricalBarCharts
         '
         Me.mnuProcurementDescribeCategoricalBarCharts.Name = "mnuProcurementDescribeCategoricalBarCharts"
-        Me.mnuProcurementDescribeCategoricalBarCharts.Size = New System.Drawing.Size(482, 34)
+        Me.mnuProcurementDescribeCategoricalBarCharts.Size = New System.Drawing.Size(320, 22)
         Me.mnuProcurementDescribeCategoricalBarCharts.Text = "Bar Chart..."
         '
         'mnuProcurementDescribeCategoricalMosaic
         '
         Me.mnuProcurementDescribeCategoricalMosaic.Name = "mnuProcurementDescribeCategoricalMosaic"
-        Me.mnuProcurementDescribeCategoricalMosaic.Size = New System.Drawing.Size(482, 34)
+        Me.mnuProcurementDescribeCategoricalMosaic.Size = New System.Drawing.Size(320, 22)
         Me.mnuProcurementDescribeCategoricalMosaic.Text = "Mosaic Plot..."
         '
         'mnuProcurementDescribeCategoricalTreemap
         '
         Me.mnuProcurementDescribeCategoricalTreemap.Name = "mnuProcurementDescribeCategoricalTreemap"
-        Me.mnuProcurementDescribeCategoricalTreemap.Size = New System.Drawing.Size(482, 34)
+        Me.mnuProcurementDescribeCategoricalTreemap.Size = New System.Drawing.Size(320, 22)
         Me.mnuProcurementDescribeCategoricalTreemap.Text = "Treemap..."
         '
         'DisplayTopNToolStripMenuItem
         '
         Me.DisplayTopNToolStripMenuItem.Name = "DisplayTopNToolStripMenuItem"
-        Me.DisplayTopNToolStripMenuItem.Size = New System.Drawing.Size(482, 34)
+        Me.DisplayTopNToolStripMenuItem.Size = New System.Drawing.Size(320, 22)
         Me.DisplayTopNToolStripMenuItem.Text = "Display Top N..."
         '
         'mnuProcurementDescribeNumeric
         '
         Me.mnuProcurementDescribeNumeric.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementDescribeNumericBoxplot, Me.HistogramToolStripMenuItem, Me.ToolStripSeparator53, Me.mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers})
         Me.mnuProcurementDescribeNumeric.Name = "mnuProcurementDescribeNumeric"
-        Me.mnuProcurementDescribeNumeric.Size = New System.Drawing.Size(319, 34)
+        Me.mnuProcurementDescribeNumeric.Size = New System.Drawing.Size(211, 22)
         Me.mnuProcurementDescribeNumeric.Text = "Numeric"
         '
         'mnuProcurementDescribeNumericBoxplot
         '
         Me.mnuProcurementDescribeNumericBoxplot.Name = "mnuProcurementDescribeNumericBoxplot"
-        Me.mnuProcurementDescribeNumericBoxplot.Size = New System.Drawing.Size(389, 34)
+        Me.mnuProcurementDescribeNumericBoxplot.Size = New System.Drawing.Size(258, 22)
         Me.mnuProcurementDescribeNumericBoxplot.Text = "Boxplot..."
         '
         'HistogramToolStripMenuItem
         '
         Me.HistogramToolStripMenuItem.Name = "HistogramToolStripMenuItem"
-        Me.HistogramToolStripMenuItem.Size = New System.Drawing.Size(389, 34)
+        Me.HistogramToolStripMenuItem.Size = New System.Drawing.Size(258, 22)
         Me.HistogramToolStripMenuItem.Text = "Histogram..."
         '
         'ToolStripSeparator53
         '
         Me.ToolStripSeparator53.Name = "ToolStripSeparator53"
-        Me.ToolStripSeparator53.Size = New System.Drawing.Size(386, 6)
+        Me.ToolStripSeparator53.Size = New System.Drawing.Size(255, 6)
         '
         'mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers
         '
         Me.mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers.Name = "mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers"
-        Me.mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers.Size = New System.Drawing.Size(389, 34)
+        Me.mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers.Size = New System.Drawing.Size(258, 22)
         Me.mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers.Text = "Correlations (Red Flags or others)..."
         '
         'mnuProcurementMapping
         '
         Me.mnuProcurementMapping.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementMappingMapCountryValues})
         Me.mnuProcurementMapping.Name = "mnuProcurementMapping"
-        Me.mnuProcurementMapping.Size = New System.Drawing.Size(327, 34)
+        Me.mnuProcurementMapping.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementMapping.Text = "Mapping"
         '
         'mnuProcurementMappingMapCountryValues
         '
         Me.mnuProcurementMappingMapCountryValues.Name = "mnuProcurementMappingMapCountryValues"
-        Me.mnuProcurementMappingMapCountryValues.Size = New System.Drawing.Size(285, 34)
+        Me.mnuProcurementMappingMapCountryValues.Size = New System.Drawing.Size(189, 22)
         Me.mnuProcurementMappingMapCountryValues.Text = "Map Country Values..."
         '
         'mnuProcurementModel
         '
         Me.mnuProcurementModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementModelDefineCorruption, Me.mnuProcurementModelFitModelToolStripMenuItem})
         Me.mnuProcurementModel.Name = "mnuProcurementModel"
-        Me.mnuProcurementModel.Size = New System.Drawing.Size(327, 34)
+        Me.mnuProcurementModel.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementModel.Text = "Model"
         '
         'mnuProcurementModelDefineCorruption
         '
         Me.mnuProcurementModelDefineCorruption.Name = "mnuProcurementModelDefineCorruption"
-        Me.mnuProcurementModelDefineCorruption.Size = New System.Drawing.Size(351, 34)
+        Me.mnuProcurementModelDefineCorruption.Size = New System.Drawing.Size(233, 22)
         Me.mnuProcurementModelDefineCorruption.Text = "Define Corruption Indicators..."
         '
         'mnuProcurementModelFitModelToolStripMenuItem
         '
         Me.mnuProcurementModelFitModelToolStripMenuItem.Name = "mnuProcurementModelFitModelToolStripMenuItem"
-        Me.mnuProcurementModelFitModelToolStripMenuItem.Size = New System.Drawing.Size(351, 34)
+        Me.mnuProcurementModelFitModelToolStripMenuItem.Size = New System.Drawing.Size(233, 22)
         Me.mnuProcurementModelFitModelToolStripMenuItem.Text = "Fit Model..."
         '
         'ToolStripSeparator45
         '
         Me.ToolStripSeparator45.Name = "ToolStripSeparator45"
-        Me.ToolStripSeparator45.Size = New System.Drawing.Size(324, 6)
+        Me.ToolStripSeparator45.Size = New System.Drawing.Size(213, 6)
         '
         'mnuProcurementDefineRedFlags
         '
         Me.mnuProcurementDefineRedFlags.Name = "mnuProcurementDefineRedFlags"
-        Me.mnuProcurementDefineRedFlags.Size = New System.Drawing.Size(327, 34)
+        Me.mnuProcurementDefineRedFlags.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementDefineRedFlags.Text = "Define Red Flag Variables..."
         '
         'mnuProcurementUseCRI
         '
         Me.mnuProcurementUseCRI.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementCTFVCalculateCRI, Me.mnuProcurementUseCRISummariseCRIbyCountry})
         Me.mnuProcurementUseCRI.Name = "mnuProcurementUseCRI"
-        Me.mnuProcurementUseCRI.Size = New System.Drawing.Size(327, 34)
+        Me.mnuProcurementUseCRI.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementUseCRI.Text = "Corruption Risk Index (CRI)"
         '
         'mnuProcurementCTFVCalculateCRI
         '
         Me.mnuProcurementCTFVCalculateCRI.Name = "mnuProcurementCTFVCalculateCRI"
-        Me.mnuProcurementCTFVCalculateCRI.Size = New System.Drawing.Size(418, 34)
+        Me.mnuProcurementCTFVCalculateCRI.Size = New System.Drawing.Size(278, 22)
         Me.mnuProcurementCTFVCalculateCRI.Text = "Define Corruption Risk Index (CRI)..."
         '
         'mnuProcurementUseCRISummariseCRIbyCountry
         '
         Me.mnuProcurementUseCRISummariseCRIbyCountry.Name = "mnuProcurementUseCRISummariseCRIbyCountry"
-        Me.mnuProcurementUseCRISummariseCRIbyCountry.Size = New System.Drawing.Size(418, 34)
+        Me.mnuProcurementUseCRISummariseCRIbyCountry.Size = New System.Drawing.Size(278, 22)
         Me.mnuProcurementUseCRISummariseCRIbyCountry.Text = "Summarise CRI by Country (or other)..."
         '
         'mnuTools
         '
-        Me.mnuTools.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuToolsRunRCode, Me.mnuToolsRestartR, Me.mnuToolsCheckForUpdates, Me.mnuToolsClearOutputWindow, Me.ToolStripSeparator5, Me.mnuToolsSaveCurrentOptions, Me.mnuToolsRestoreBackup, Me.mnuToolsInstallRPackage, Me.mnuToolsOptions})
+        Me.mnuTools.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuToolsRestartR, Me.mnuToolsCheckForUpdates, Me.mnuToolsClearOutputWindow, Me.ToolStripSeparator5, Me.mnuToolsRestoreBackup, Me.mnuToolsInstallRPackage, Me.mnuToolsOptions})
         Me.mnuTools.Name = "mnuTools"
-        Me.mnuTools.Size = New System.Drawing.Size(69, 29)
+        Me.mnuTools.Size = New System.Drawing.Size(47, 22)
         Me.mnuTools.Text = "Tools"
-        '
-        'mnuToolsRunRCode
-        '
-        Me.mnuToolsRunRCode.Enabled = False
-        Me.mnuToolsRunRCode.Name = "mnuToolsRunRCode"
-        Me.mnuToolsRunRCode.Size = New System.Drawing.Size(326, 34)
-        Me.mnuToolsRunRCode.Tag = "Run_R_Code..."
-        Me.mnuToolsRunRCode.Text = "Run R Code..."
-        '
-        'mnuToolsRestartR
-        '
-        Me.mnuToolsRestartR.Enabled = False
-        Me.mnuToolsRestartR.Name = "mnuToolsRestartR"
-        Me.mnuToolsRestartR.Size = New System.Drawing.Size(326, 34)
-        Me.mnuToolsRestartR.Tag = "Restart_R"
-        Me.mnuToolsRestartR.Text = "Restart R"
         '
         'mnuToolsCheckForUpdates
         '
         Me.mnuToolsCheckForUpdates.Name = "mnuToolsCheckForUpdates"
-        Me.mnuToolsCheckForUpdates.Size = New System.Drawing.Size(326, 34)
+        Me.mnuToolsCheckForUpdates.Size = New System.Drawing.Size(217, 22)
         Me.mnuToolsCheckForUpdates.Tag = "Check_for_Updates (Online)"
         Me.mnuToolsCheckForUpdates.Text = "Check for Updates (Online)"
         '
         'mnuToolsClearOutputWindow
         '
         Me.mnuToolsClearOutputWindow.Name = "mnuToolsClearOutputWindow"
-        Me.mnuToolsClearOutputWindow.Size = New System.Drawing.Size(326, 34)
+        Me.mnuToolsClearOutputWindow.Size = New System.Drawing.Size(217, 22)
         Me.mnuToolsClearOutputWindow.Tag = "Clear_Output_Window..."
         Me.mnuToolsClearOutputWindow.Text = "Clear Output Window..."
         '
         'ToolStripSeparator5
         '
         Me.ToolStripSeparator5.Name = "ToolStripSeparator5"
-        Me.ToolStripSeparator5.Size = New System.Drawing.Size(323, 6)
-        '
-        'mnuToolsSaveCurrentOptions
-        '
-        Me.mnuToolsSaveCurrentOptions.Enabled = False
-        Me.mnuToolsSaveCurrentOptions.Name = "mnuToolsSaveCurrentOptions"
-        Me.mnuToolsSaveCurrentOptions.Size = New System.Drawing.Size(326, 34)
-        Me.mnuToolsSaveCurrentOptions.Tag = "Save_Current_Options..."
-        Me.mnuToolsSaveCurrentOptions.Text = "Save Current Options..."
+        Me.ToolStripSeparator5.Size = New System.Drawing.Size(214, 6)
         '
         'mnuToolsRestoreBackup
         '
         Me.mnuToolsRestoreBackup.Name = "mnuToolsRestoreBackup"
-        Me.mnuToolsRestoreBackup.Size = New System.Drawing.Size(326, 34)
+        Me.mnuToolsRestoreBackup.Size = New System.Drawing.Size(217, 22)
         Me.mnuToolsRestoreBackup.Tag = "Load_Options..."
         Me.mnuToolsRestoreBackup.Text = "Restore Backup..."
         '
         'mnuToolsInstallRPackage
         '
         Me.mnuToolsInstallRPackage.Name = "mnuToolsInstallRPackage"
-        Me.mnuToolsInstallRPackage.Size = New System.Drawing.Size(326, 34)
+        Me.mnuToolsInstallRPackage.Size = New System.Drawing.Size(217, 22)
         Me.mnuToolsInstallRPackage.Text = "Install R Package... (Online)"
         '
         'mnuToolsOptions
         '
         Me.mnuToolsOptions.Name = "mnuToolsOptions"
-        Me.mnuToolsOptions.Size = New System.Drawing.Size(326, 34)
+        Me.mnuToolsOptions.Size = New System.Drawing.Size(217, 22)
         Me.mnuToolsOptions.Tag = "Options..."
         Me.mnuToolsOptions.Text = "Options..."
         '
@@ -5373,8 +5345,7 @@ Partial Class frmMain
         '
         Me.splOverall.BackColor = System.Drawing.Color.LightGray
         Me.splOverall.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.splOverall.Location = New System.Drawing.Point(0, 72)
-        Me.splOverall.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.splOverall.Location = New System.Drawing.Point(0, 61)
         Me.splOverall.Name = "splOverall"
         Me.splOverall.Orientation = System.Windows.Forms.Orientation.Horizontal
         '
@@ -5387,9 +5358,9 @@ Partial Class frmMain
         '
         Me.splOverall.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splOverall.Panel2.Controls.Add(Me.splDataOutput)
-        Me.splOverall.Size = New System.Drawing.Size(1251, 619)
-        Me.splOverall.SplitterDistance = 242
-        Me.splOverall.SplitterWidth = 8
+        Me.splOverall.Size = New System.Drawing.Size(834, 399)
+        Me.splOverall.SplitterDistance = 155
+        Me.splOverall.SplitterWidth = 5
         Me.splOverall.TabIndex = 10
         '
         'splExtraWindows
@@ -5397,7 +5368,6 @@ Partial Class frmMain
         Me.splExtraWindows.BackColor = System.Drawing.Color.LightGray
         Me.splExtraWindows.Dock = System.Windows.Forms.DockStyle.Fill
         Me.splExtraWindows.Location = New System.Drawing.Point(0, 0)
-        Me.splExtraWindows.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.splExtraWindows.Name = "splExtraWindows"
         '
         'splExtraWindows.Panel1
@@ -5409,9 +5379,9 @@ Partial Class frmMain
         '
         Me.splExtraWindows.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splExtraWindows.Panel2.Controls.Add(Me.ucrScriptWindow)
-        Me.splExtraWindows.Size = New System.Drawing.Size(1251, 242)
-        Me.splExtraWindows.SplitterDistance = 378
-        Me.splExtraWindows.SplitterWidth = 8
+        Me.splExtraWindows.Size = New System.Drawing.Size(834, 155)
+        Me.splExtraWindows.SplitterDistance = 252
+        Me.splExtraWindows.SplitterWidth = 5
         Me.splExtraWindows.TabIndex = 0
         '
         'splMetadata
@@ -5419,7 +5389,6 @@ Partial Class frmMain
         Me.splMetadata.BackColor = System.Drawing.Color.LightGray
         Me.splMetadata.Dock = System.Windows.Forms.DockStyle.Fill
         Me.splMetadata.Location = New System.Drawing.Point(0, 0)
-        Me.splMetadata.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.splMetadata.Name = "splMetadata"
         '
         'splMetadata.Panel1
@@ -5430,9 +5399,9 @@ Partial Class frmMain
         '
         Me.splMetadata.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splMetadata.Panel2.Controls.Add(Me.ucrDataFrameMeta)
-        Me.splMetadata.Size = New System.Drawing.Size(378, 242)
-        Me.splMetadata.SplitterDistance = 102
-        Me.splMetadata.SplitterWidth = 8
+        Me.splMetadata.Size = New System.Drawing.Size(252, 155)
+        Me.splMetadata.SplitterDistance = 68
+        Me.splMetadata.SplitterWidth = 5
         Me.splMetadata.TabIndex = 0
         '
         'ucrColumnMeta
@@ -5443,9 +5412,9 @@ Partial Class frmMain
         Me.ucrColumnMeta.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrColumnMeta.IsEnabled = False
         Me.ucrColumnMeta.Location = New System.Drawing.Point(0, 0)
-        Me.ucrColumnMeta.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrColumnMeta.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrColumnMeta.Name = "ucrColumnMeta"
-        Me.ucrColumnMeta.Size = New System.Drawing.Size(102, 242)
+        Me.ucrColumnMeta.Size = New System.Drawing.Size(68, 155)
         Me.ucrColumnMeta.TabIndex = 0
         '
         'ucrDataFrameMeta
@@ -5454,9 +5423,9 @@ Partial Class frmMain
         Me.ucrDataFrameMeta.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
         Me.ucrDataFrameMeta.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrDataFrameMeta.Location = New System.Drawing.Point(0, 0)
-        Me.ucrDataFrameMeta.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrDataFrameMeta.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrDataFrameMeta.Name = "ucrDataFrameMeta"
-        Me.ucrDataFrameMeta.Size = New System.Drawing.Size(268, 242)
+        Me.ucrDataFrameMeta.Size = New System.Drawing.Size(179, 155)
         Me.ucrDataFrameMeta.TabIndex = 0
         '
         'ucrScriptWindow
@@ -5465,9 +5434,9 @@ Partial Class frmMain
         Me.ucrScriptWindow.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
         Me.ucrScriptWindow.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrScriptWindow.Location = New System.Drawing.Point(0, 0)
-        Me.ucrScriptWindow.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrScriptWindow.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrScriptWindow.Name = "ucrScriptWindow"
-        Me.ucrScriptWindow.Size = New System.Drawing.Size(865, 242)
+        Me.ucrScriptWindow.Size = New System.Drawing.Size(577, 155)
         Me.ucrScriptWindow.strActiveTabText = ""
         Me.ucrScriptWindow.TabIndex = 2
         Me.ucrScriptWindow.Tag = "Script_Window"
@@ -5477,7 +5446,6 @@ Partial Class frmMain
         Me.splDataOutput.BackColor = System.Drawing.Color.LightGray
         Me.splDataOutput.Dock = System.Windows.Forms.DockStyle.Fill
         Me.splDataOutput.Location = New System.Drawing.Point(0, 0)
-        Me.splDataOutput.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.splDataOutput.Name = "splDataOutput"
         '
         'splDataOutput.Panel1
@@ -5489,9 +5457,9 @@ Partial Class frmMain
         '
         Me.splDataOutput.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splDataOutput.Panel2.Controls.Add(Me.ucrOutput)
-        Me.splDataOutput.Size = New System.Drawing.Size(1251, 369)
-        Me.splDataOutput.SplitterDistance = 573
-        Me.splDataOutput.SplitterWidth = 8
+        Me.splDataOutput.Size = New System.Drawing.Size(834, 239)
+        Me.splDataOutput.SplitterDistance = 382
+        Me.splDataOutput.SplitterWidth = 5
         Me.splDataOutput.TabIndex = 0
         '
         'ucrDataViewer
@@ -5501,9 +5469,9 @@ Partial Class frmMain
         Me.ucrDataViewer.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
         Me.ucrDataViewer.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrDataViewer.Location = New System.Drawing.Point(0, 0)
-        Me.ucrDataViewer.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrDataViewer.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrDataViewer.Name = "ucrDataViewer"
-        Me.ucrDataViewer.Size = New System.Drawing.Size(573, 369)
+        Me.ucrDataViewer.Size = New System.Drawing.Size(382, 239)
         Me.ucrDataViewer.TabIndex = 0
         Me.ucrDataViewer.Tag = "Data_View"
         '
@@ -5513,9 +5481,9 @@ Partial Class frmMain
         Me.ucrOutput.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
         Me.ucrOutput.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrOutput.Location = New System.Drawing.Point(0, 0)
-        Me.ucrOutput.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrOutput.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrOutput.Name = "ucrOutput"
-        Me.ucrOutput.Size = New System.Drawing.Size(670, 369)
+        Me.ucrOutput.Size = New System.Drawing.Size(447, 239)
         Me.ucrOutput.TabIndex = 0
         '
         'mnuPlotly
@@ -5553,11 +5521,19 @@ Partial Class frmMain
         Me.mnuLogFile.Text = "Log Window..."
         Me.mnuLogFile.ToolTipText = "Log Window"
         '
+        'mnuToolsRestartR
+        '
+        Me.mnuToolsRestartR.Enabled = False
+        Me.mnuToolsRestartR.Name = "mnuToolsRestartR"
+        Me.mnuToolsRestartR.Size = New System.Drawing.Size(217, 22)
+        Me.mnuToolsRestartR.Tag = "Restart_R"
+        Me.mnuToolsRestartR.Text = "Restart R"
+        '
         'frmMain
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
-        Me.ClientSize = New System.Drawing.Size(1251, 723)
+        Me.ClientSize = New System.Drawing.Size(834, 482)
         Me.Controls.Add(Me.splOverall)
         Me.Controls.Add(Me.stsStrip)
         Me.Controls.Add(Me.Tool_strip)
@@ -5565,7 +5541,6 @@ Partial Class frmMain
         Me.Icon = CType(resources.GetObject("$this.Icon"), System.Drawing.Icon)
         Me.IsMdiContainer = True
         Me.MainMenuStrip = Me.mnuBar
-        Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.Name = "frmMain"
         Me.Text = "R-Instat .."
         Me.WindowState = System.Windows.Forms.FormWindowState.Maximized
@@ -5753,11 +5728,8 @@ Partial Class frmMain
     Friend WithEvents mnuModelOtherGeneralANOVAGeneral As ToolStripMenuItem
     Friend WithEvents mnuModelOtherGeneralRegression As ToolStripMenuItem
     Friend WithEvents mnuModelOtherGeneralLogLinear As ToolStripMenuItem
-    Friend WithEvents mnuToolsRunRCode As ToolStripMenuItem
-    Friend WithEvents mnuToolsRestartR As ToolStripMenuItem
     Friend WithEvents mnuToolsClearOutputWindow As ToolStripMenuItem
     Friend WithEvents ToolStripSeparator5 As ToolStripSeparator
-    Friend WithEvents mnuToolsSaveCurrentOptions As ToolStripMenuItem
     Friend WithEvents mnuToolsRestoreBackup As ToolStripMenuItem
     Friend WithEvents ToolStripSeparator22 As ToolStripSeparator
     Friend WithEvents mnuModelOtherOneVariableGoodnessofFit As ToolStripMenuItem
@@ -6318,4 +6290,5 @@ Partial Class frmMain
     Friend WithEvents ToolStripMenuItem13 As ToolStripMenuItem
     Friend WithEvents ToolStripMenuItem14 As ToolStripMenuItem
     Friend WithEvents mnuViewTricotXpMenu As ToolStripMenuItem
+    Friend WithEvents mnuToolsRestartR As ToolStripMenuItem
 End Class

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -170,22 +170,22 @@ Partial Class frmMain
         Me.mnuHelpWindows = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator81 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuHelpMenus = New System.Windows.Forms.ToolStripMenuItem()
-        Me.MenusAndDialogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuMenusHelp = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator82 = New System.Windows.Forms.ToolStripSeparator()
-        Me.FileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.EditToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.PrepareToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.DescribeToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ModelToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ToolsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ViewToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuFileHelp = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuEditHelp = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuPrepareHelp = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuDescribeHelp = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuModelHelp = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuToolsHelp = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuViewHelp = New System.Windows.Forms.ToolStripMenuItem()
         Me.OptionalMenuToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.StructuredToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ClimaticToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ProcurementToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ExperimentsToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
-        Me.TricotMenuToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.TricotXPMenuToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuStructuredHelp = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuClimaticHelp = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuProcurementHelp = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuExperimentsHelp = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuTricotMenuHelp = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuTricotXPMenuHelp = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuHelpAboutR = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuHelpLearningStatistics = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuHelpRPackages = New System.Windows.Forms.ToolStripMenuItem()
@@ -631,15 +631,13 @@ Partial Class frmMain
         Me.mnuTricotDefineTricotData = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator20 = New System.Windows.Forms.ToolStripSeparator()
         Me.PrepareToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
-        Me.VisualizeToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.PivotTablesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.OneVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.DuplicatesKeyVariableCheckToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuVisualizeTricot = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuPivotTablesTricot = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuOneVariableTricot = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuDuplicatesTricot = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotDescribe = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotDescribeTraits = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotDescribeCorrelations = New System.Windows.Forms.ToolStripMenuItem()
-        Me.TwoThreeVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.GraphSummariseToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotModelPlackettLuce = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotModelWithoutCovariates = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotModelTree = New System.Windows.Forms.ToolStripMenuItem()
@@ -749,6 +747,16 @@ Partial Class frmMain
         Me.mnuDataFrameMetadata = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuScriptFile = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuLogFile = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuSummariseTricot = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuDescribeGraphTricots = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator83 = New System.Windows.Forms.ToolStripSeparator()
+        Me.TidyToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuTidyTransformTricot = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuTidyDuplicateRows = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuTidyAddMergeColumns = New System.Windows.Forms.ToolStripMenuItem()
+        Me.AddKeyToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator85 = New System.Windows.Forms.ToolStripSeparator()
+        Me.ToolStripSeparator86 = New System.Windows.Forms.ToolStripSeparator()
         Me.stsStrip.SuspendLayout()
         Me.Tool_strip.SuspendLayout()
         Me.mnuBar.SuspendLayout()
@@ -789,18 +797,18 @@ Partial Class frmMain
         'mnuDescribeOneVariableVisualiseData
         '
         Me.mnuDescribeOneVariableVisualiseData.Name = "mnuDescribeOneVariableVisualiseData"
-        Me.mnuDescribeOneVariableVisualiseData.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeOneVariableVisualiseData.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableVisualiseData.Text = "Visualise Data..."
         '
         'ToolStripSeparator72
         '
         Me.ToolStripSeparator72.Name = "ToolStripSeparator72"
-        Me.ToolStripSeparator72.Size = New System.Drawing.Size(177, 6)
+        Me.ToolStripSeparator72.Size = New System.Drawing.Size(152, 6)
         '
         'mnuDescribeOneVariableSummarise
         '
         Me.mnuDescribeOneVariableSummarise.Name = "mnuDescribeOneVariableSummarise"
-        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableSummarise.Tag = "Summarise..."
         Me.mnuDescribeOneVariableSummarise.Text = "Summarise..."
         Me.mnuDescribeOneVariableSummarise.ToolTipText = "One Variable Summarise, Skim and Customised"
@@ -808,26 +816,26 @@ Partial Class frmMain
         'mnuDescribeOneVariableGraph
         '
         Me.mnuDescribeOneVariableGraph.Name = "mnuDescribeOneVariableGraph"
-        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableGraph.Tag = "Graph..."
         Me.mnuDescribeOneVariableGraph.Text = "Graph..."
         '
         'ToolStripSeparator33
         '
         Me.ToolStripSeparator33.Name = "ToolStripSeparator33"
-        Me.ToolStripSeparator33.Size = New System.Drawing.Size(177, 6)
+        Me.ToolStripSeparator33.Size = New System.Drawing.Size(152, 6)
         '
         'mnuDescribeOneVariableFrequencies
         '
         Me.mnuDescribeOneVariableFrequencies.Name = "mnuDescribeOneVariableFrequencies"
-        Me.mnuDescribeOneVariableFrequencies.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeOneVariableFrequencies.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableFrequencies.Text = "Frequencies..."
         Me.mnuDescribeOneVariableFrequencies.ToolTipText = "Table or Graph. Also Stem and Leaf Plots"
         '
         'mnuDescribeOneVariableRatingData
         '
         Me.mnuDescribeOneVariableRatingData.Name = "mnuDescribeOneVariableRatingData"
-        Me.mnuDescribeOneVariableRatingData.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeOneVariableRatingData.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableRatingData.Text = "Rating Data..."
         Me.mnuDescribeOneVariableRatingData.ToolTipText = "Table, Stacked Graph or Likert Graph"
         '
@@ -1680,106 +1688,106 @@ Partial Class frmMain
         '
         'mnuHelpMenus
         '
-        Me.mnuHelpMenus.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.MenusAndDialogsToolStripMenuItem, Me.ToolStripSeparator82, Me.FileToolStripMenuItem, Me.EditToolStripMenuItem, Me.PrepareToolStripMenuItem, Me.DescribeToolStripMenuItem, Me.ModelToolStripMenuItem, Me.ToolsToolStripMenuItem, Me.ViewToolStripMenuItem})
+        Me.mnuHelpMenus.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuMenusHelp, Me.ToolStripSeparator82, Me.mnuFileHelp, Me.mnuEditHelp, Me.mnuPrepareHelp, Me.mnuDescribeHelp, Me.mnuModelHelp, Me.mnuToolsHelp, Me.mnuViewHelp})
         Me.mnuHelpMenus.Name = "mnuHelpMenus"
         Me.mnuHelpMenus.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpMenus.Text = "Menu"
         '
-        'MenusAndDialogsToolStripMenuItem
+        'mnuMenusHelp
         '
-        Me.MenusAndDialogsToolStripMenuItem.Name = "MenusAndDialogsToolStripMenuItem"
-        Me.MenusAndDialogsToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
-        Me.MenusAndDialogsToolStripMenuItem.Text = "Menus and Dialogs..."
+        Me.mnuMenusHelp.Name = "mnuMenusHelp"
+        Me.mnuMenusHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuMenusHelp.Text = "Menus ..."
         '
         'ToolStripSeparator82
         '
         Me.ToolStripSeparator82.Name = "ToolStripSeparator82"
-        Me.ToolStripSeparator82.Size = New System.Drawing.Size(181, 6)
+        Me.ToolStripSeparator82.Size = New System.Drawing.Size(177, 6)
         '
-        'FileToolStripMenuItem
+        'mnuFileHelp
         '
-        Me.FileToolStripMenuItem.Name = "FileToolStripMenuItem"
-        Me.FileToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
-        Me.FileToolStripMenuItem.Text = "File..."
+        Me.mnuFileHelp.Name = "mnuFileHelp"
+        Me.mnuFileHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuFileHelp.Text = "File..."
         '
-        'EditToolStripMenuItem
+        'mnuEditHelp
         '
-        Me.EditToolStripMenuItem.Name = "EditToolStripMenuItem"
-        Me.EditToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
-        Me.EditToolStripMenuItem.Text = "Edit..."
+        Me.mnuEditHelp.Name = "mnuEditHelp"
+        Me.mnuEditHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuEditHelp.Text = "Edit..."
         '
-        'PrepareToolStripMenuItem
+        'mnuPrepareHelp
         '
-        Me.PrepareToolStripMenuItem.Name = "PrepareToolStripMenuItem"
-        Me.PrepareToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
-        Me.PrepareToolStripMenuItem.Text = "Prepare..."
+        Me.mnuPrepareHelp.Name = "mnuPrepareHelp"
+        Me.mnuPrepareHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuPrepareHelp.Text = "Prepare..."
         '
-        'DescribeToolStripMenuItem
+        'mnuDescribeHelp
         '
-        Me.DescribeToolStripMenuItem.Name = "DescribeToolStripMenuItem"
-        Me.DescribeToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
-        Me.DescribeToolStripMenuItem.Text = "Describe..."
+        Me.mnuDescribeHelp.Name = "mnuDescribeHelp"
+        Me.mnuDescribeHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuDescribeHelp.Text = "Describe..."
         '
-        'ModelToolStripMenuItem
+        'mnuModelHelp
         '
-        Me.ModelToolStripMenuItem.Name = "ModelToolStripMenuItem"
-        Me.ModelToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
-        Me.ModelToolStripMenuItem.Text = "Model..."
+        Me.mnuModelHelp.Name = "mnuModelHelp"
+        Me.mnuModelHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuModelHelp.Text = "Model..."
         '
-        'ToolsToolStripMenuItem
+        'mnuToolsHelp
         '
-        Me.ToolsToolStripMenuItem.Name = "ToolsToolStripMenuItem"
-        Me.ToolsToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
-        Me.ToolsToolStripMenuItem.Text = "Tools..."
+        Me.mnuToolsHelp.Name = "mnuToolsHelp"
+        Me.mnuToolsHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuToolsHelp.Text = "Tools..."
         '
-        'ViewToolStripMenuItem
+        'mnuViewHelp
         '
-        Me.ViewToolStripMenuItem.Name = "ViewToolStripMenuItem"
-        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
-        Me.ViewToolStripMenuItem.Text = "View..."
+        Me.mnuViewHelp.Name = "mnuViewHelp"
+        Me.mnuViewHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuViewHelp.Text = "View..."
         '
         'OptionalMenuToolStripMenuItem
         '
-        Me.OptionalMenuToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.StructuredToolStripMenuItem1, Me.ClimaticToolStripMenuItem1, Me.ProcurementToolStripMenuItem1, Me.ExperimentsToolStripMenuItem1, Me.TricotMenuToolStripMenuItem, Me.TricotXPMenuToolStripMenuItem})
+        Me.OptionalMenuToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticHelp, Me.mnuStructuredHelp, Me.mnuTricotMenuHelp, Me.mnuTricotXPMenuHelp, Me.mnuExperimentsHelp, Me.mnuProcurementHelp})
         Me.OptionalMenuToolStripMenuItem.Name = "OptionalMenuToolStripMenuItem"
         Me.OptionalMenuToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
         Me.OptionalMenuToolStripMenuItem.Text = "Optional Menu"
         '
-        'StructuredToolStripMenuItem1
+        'mnuStructuredHelp
         '
-        Me.StructuredToolStripMenuItem1.Name = "StructuredToolStripMenuItem1"
-        Me.StructuredToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.StructuredToolStripMenuItem1.Text = "Structured"
+        Me.mnuStructuredHelp.Name = "mnuStructuredHelp"
+        Me.mnuStructuredHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuStructuredHelp.Text = "Structured..."
         '
-        'ClimaticToolStripMenuItem1
+        'mnuClimaticHelp
         '
-        Me.ClimaticToolStripMenuItem1.Name = "ClimaticToolStripMenuItem1"
-        Me.ClimaticToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.ClimaticToolStripMenuItem1.Text = "Climatic"
+        Me.mnuClimaticHelp.Name = "mnuClimaticHelp"
+        Me.mnuClimaticHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuClimaticHelp.Text = "Climatic..."
         '
-        'ProcurementToolStripMenuItem1
+        'mnuProcurementHelp
         '
-        Me.ProcurementToolStripMenuItem1.Name = "ProcurementToolStripMenuItem1"
-        Me.ProcurementToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.ProcurementToolStripMenuItem1.Text = "Procurement"
+        Me.mnuProcurementHelp.Name = "mnuProcurementHelp"
+        Me.mnuProcurementHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuProcurementHelp.Text = "Procurement..."
         '
-        'ExperimentsToolStripMenuItem1
+        'mnuExperimentsHelp
         '
-        Me.ExperimentsToolStripMenuItem1.Name = "ExperimentsToolStripMenuItem1"
-        Me.ExperimentsToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.ExperimentsToolStripMenuItem1.Text = "Experiments"
+        Me.mnuExperimentsHelp.Name = "mnuExperimentsHelp"
+        Me.mnuExperimentsHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuExperimentsHelp.Text = "Experiments..."
         '
-        'TricotMenuToolStripMenuItem
+        'mnuTricotMenuHelp
         '
-        Me.TricotMenuToolStripMenuItem.Name = "TricotMenuToolStripMenuItem"
-        Me.TricotMenuToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.TricotMenuToolStripMenuItem.Text = "Tricot Menu"
+        Me.mnuTricotMenuHelp.Name = "mnuTricotMenuHelp"
+        Me.mnuTricotMenuHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuTricotMenuHelp.Text = "Tricot Menu..."
         '
-        'TricotXPMenuToolStripMenuItem
+        'mnuTricotXPMenuHelp
         '
-        Me.TricotXPMenuToolStripMenuItem.Name = "TricotXPMenuToolStripMenuItem"
-        Me.TricotXPMenuToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.TricotXPMenuToolStripMenuItem.Text = "Tricot XP Menu"
+        Me.mnuTricotXPMenuHelp.Name = "mnuTricotXPMenuHelp"
+        Me.mnuTricotXPMenuHelp.Size = New System.Drawing.Size(180, 22)
+        Me.mnuTricotXPMenuHelp.Text = "Tricot XP Menu..."
         '
         'mnuHelpAboutR
         '
@@ -4731,7 +4739,7 @@ Partial Class frmMain
         '
         'mnuTricot
         '
-        Me.mnuTricot.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotImportFromClimMob, Me.mnuTricotTransformClimMob, Me.mnuTricotDefineTricotData, Me.ToolStripSeparator20, Me.PrepareToolStripMenuItem1, Me.mnuTricotDescribe, Me.mnuTricotModelPlackettLuce})
+        Me.mnuTricot.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotImportFromClimMob, Me.mnuTricotTransformClimMob, Me.mnuTricotDefineTricotData, Me.ToolStripSeparator20, Me.PrepareToolStripMenuItem1, Me.mnuTricotDescribe, Me.TidyToolStripMenuItem, Me.mnuTricotModelPlackettLuce})
         Me.mnuTricot.Name = "mnuTricot"
         Me.mnuTricot.Size = New System.Drawing.Size(49, 22)
         Me.mnuTricot.Text = "Tricot"
@@ -4761,38 +4769,38 @@ Partial Class frmMain
         '
         'PrepareToolStripMenuItem1
         '
-        Me.PrepareToolStripMenuItem1.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.VisualizeToolStripMenuItem, Me.PivotTablesToolStripMenuItem, Me.OneVariableToolStripMenuItem, Me.DuplicatesKeyVariableCheckToolStripMenuItem})
+        Me.PrepareToolStripMenuItem1.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuVisualizeTricot, Me.mnuPivotTablesTricot, Me.mnuOneVariableTricot, Me.mnuDuplicatesTricot})
         Me.PrepareToolStripMenuItem1.Name = "PrepareToolStripMenuItem1"
         Me.PrepareToolStripMenuItem1.Size = New System.Drawing.Size(201, 22)
         Me.PrepareToolStripMenuItem1.Text = "Prepare"
         '
-        'VisualizeToolStripMenuItem
+        'mnuVisualizeTricot
         '
-        Me.VisualizeToolStripMenuItem.Name = "VisualizeToolStripMenuItem"
-        Me.VisualizeToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
-        Me.VisualizeToolStripMenuItem.Text = "Visualize"
+        Me.mnuVisualizeTricot.Name = "mnuVisualizeTricot"
+        Me.mnuVisualizeTricot.Size = New System.Drawing.Size(248, 22)
+        Me.mnuVisualizeTricot.Text = "Visualise Data..."
         '
-        'PivotTablesToolStripMenuItem
+        'mnuPivotTablesTricot
         '
-        Me.PivotTablesToolStripMenuItem.Name = "PivotTablesToolStripMenuItem"
-        Me.PivotTablesToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
-        Me.PivotTablesToolStripMenuItem.Text = "Pivot Tables"
+        Me.mnuPivotTablesTricot.Name = "mnuPivotTablesTricot"
+        Me.mnuPivotTablesTricot.Size = New System.Drawing.Size(248, 22)
+        Me.mnuPivotTablesTricot.Text = "Pivot Tables..."
         '
-        'OneVariableToolStripMenuItem
+        'mnuOneVariableTricot
         '
-        Me.OneVariableToolStripMenuItem.Name = "OneVariableToolStripMenuItem"
-        Me.OneVariableToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
-        Me.OneVariableToolStripMenuItem.Text = "One Variable"
+        Me.mnuOneVariableTricot.Name = "mnuOneVariableTricot"
+        Me.mnuOneVariableTricot.Size = New System.Drawing.Size(248, 22)
+        Me.mnuOneVariableTricot.Text = "One Variable..."
         '
-        'DuplicatesKeyVariableCheckToolStripMenuItem
+        'mnuDuplicatesTricot
         '
-        Me.DuplicatesKeyVariableCheckToolStripMenuItem.Name = "DuplicatesKeyVariableCheckToolStripMenuItem"
-        Me.DuplicatesKeyVariableCheckToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
-        Me.DuplicatesKeyVariableCheckToolStripMenuItem.Text = "Duplicates (Key Variable Check)"
+        Me.mnuDuplicatesTricot.Name = "mnuDuplicatesTricot"
+        Me.mnuDuplicatesTricot.Size = New System.Drawing.Size(248, 22)
+        Me.mnuDuplicatesTricot.Text = "Duplicates (Key Variable Check)..."
         '
         'mnuTricotDescribe
         '
-        Me.mnuTricotDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotDescribeTraits, Me.mnuTricotDescribeCorrelations, Me.TwoThreeVariableToolStripMenuItem})
+        Me.mnuTricotDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuSummariseTricot, Me.mnuDescribeGraphTricots, Me.ToolStripSeparator83, Me.mnuTricotDescribeTraits, Me.mnuTricotDescribeCorrelations})
         Me.mnuTricotDescribe.Name = "mnuTricotDescribe"
         Me.mnuTricotDescribe.Size = New System.Drawing.Size(201, 22)
         Me.mnuTricotDescribe.Text = "Describe"
@@ -4800,27 +4808,14 @@ Partial Class frmMain
         'mnuTricotDescribeTraits
         '
         Me.mnuTricotDescribeTraits.Name = "mnuTricotDescribeTraits"
-        Me.mnuTricotDescribeTraits.Size = New System.Drawing.Size(180, 22)
+        Me.mnuTricotDescribeTraits.Size = New System.Drawing.Size(211, 22)
         Me.mnuTricotDescribeTraits.Text = "Traits..."
         '
         'mnuTricotDescribeCorrelations
         '
         Me.mnuTricotDescribeCorrelations.Name = "mnuTricotDescribeCorrelations"
-        Me.mnuTricotDescribeCorrelations.Size = New System.Drawing.Size(180, 22)
+        Me.mnuTricotDescribeCorrelations.Size = New System.Drawing.Size(211, 22)
         Me.mnuTricotDescribeCorrelations.Text = "Correlations..."
-        '
-        'TwoThreeVariableToolStripMenuItem
-        '
-        Me.TwoThreeVariableToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.GraphSummariseToolStripMenuItem})
-        Me.TwoThreeVariableToolStripMenuItem.Name = "TwoThreeVariableToolStripMenuItem"
-        Me.TwoThreeVariableToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.TwoThreeVariableToolStripMenuItem.Text = "Two/ Three Variable"
-        '
-        'GraphSummariseToolStripMenuItem
-        '
-        Me.GraphSummariseToolStripMenuItem.Name = "GraphSummariseToolStripMenuItem"
-        Me.GraphSummariseToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.GraphSummariseToolStripMenuItem.Text = "graph summarise"
         '
         'mnuTricotModelPlackettLuce
         '
@@ -4899,13 +4894,13 @@ Partial Class frmMain
         'mnuTricotXpDescribeTraits
         '
         Me.mnuTricotXpDescribeTraits.Name = "mnuTricotXpDescribeTraits"
-        Me.mnuTricotXpDescribeTraits.Size = New System.Drawing.Size(180, 22)
+        Me.mnuTricotXpDescribeTraits.Size = New System.Drawing.Size(147, 22)
         Me.mnuTricotXpDescribeTraits.Text = "Traits..."
         '
         'ToolStripMenuItem9
         '
         Me.ToolStripMenuItem9.Name = "ToolStripMenuItem9"
-        Me.ToolStripMenuItem9.Size = New System.Drawing.Size(180, 22)
+        Me.ToolStripMenuItem9.Size = New System.Drawing.Size(147, 22)
         Me.ToolStripMenuItem9.Text = "Correlations..."
         '
         'ToolStripMenuItem10
@@ -5588,6 +5583,64 @@ Partial Class frmMain
         Me.mnuLogFile.Size = New System.Drawing.Size(180, 22)
         Me.mnuLogFile.Text = "Log Window..."
         Me.mnuLogFile.ToolTipText = "Log Window"
+        '
+        'mnuSummariseTricot
+        '
+        Me.mnuSummariseTricot.Name = "mnuSummariseTricot"
+        Me.mnuSummariseTricot.Size = New System.Drawing.Size(211, 22)
+        Me.mnuSummariseTricot.Text = "Summarise 2/3 variables..."
+        '
+        'mnuDescribeGraphTricots
+        '
+        Me.mnuDescribeGraphTricots.Name = "mnuDescribeGraphTricots"
+        Me.mnuDescribeGraphTricots.Size = New System.Drawing.Size(211, 22)
+        Me.mnuDescribeGraphTricots.Text = "Graph 2/3 Variables..."
+        '
+        'ToolStripSeparator83
+        '
+        Me.ToolStripSeparator83.Name = "ToolStripSeparator83"
+        Me.ToolStripSeparator83.Size = New System.Drawing.Size(208, 6)
+        '
+        'TidyToolStripMenuItem
+        '
+        Me.TidyToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTidyTransformTricot, Me.ToolStripSeparator85, Me.mnuTidyDuplicateRows, Me.mnuTidyAddMergeColumns, Me.ToolStripSeparator86, Me.AddKeyToolStripMenuItem})
+        Me.TidyToolStripMenuItem.Name = "TidyToolStripMenuItem"
+        Me.TidyToolStripMenuItem.Size = New System.Drawing.Size(201, 22)
+        Me.TidyToolStripMenuItem.Text = "Tidy Data"
+        '
+        'mnuTidyTransformTricot
+        '
+        Me.mnuTidyTransformTricot.Name = "mnuTidyTransformTricot"
+        Me.mnuTidyTransformTricot.Size = New System.Drawing.Size(192, 22)
+        Me.mnuTidyTransformTricot.Text = "Transform Tricot..."
+        '
+        'mnuTidyDuplicateRows
+        '
+        Me.mnuTidyDuplicateRows.Name = "mnuTidyDuplicateRows"
+        Me.mnuTidyDuplicateRows.Size = New System.Drawing.Size(192, 22)
+        Me.mnuTidyDuplicateRows.Text = "Duplicate Rows..."
+        '
+        'mnuTidyAddMergeColumns
+        '
+        Me.mnuTidyAddMergeColumns.Name = "mnuTidyAddMergeColumns"
+        Me.mnuTidyAddMergeColumns.Size = New System.Drawing.Size(192, 22)
+        Me.mnuTidyAddMergeColumns.Text = "Add (Merge Columns)"
+        '
+        'AddKeyToolStripMenuItem
+        '
+        Me.AddKeyToolStripMenuItem.Name = "AddKeyToolStripMenuItem"
+        Me.AddKeyToolStripMenuItem.Size = New System.Drawing.Size(192, 22)
+        Me.AddKeyToolStripMenuItem.Text = "Add Key..."
+        '
+        'ToolStripSeparator85
+        '
+        Me.ToolStripSeparator85.Name = "ToolStripSeparator85"
+        Me.ToolStripSeparator85.Size = New System.Drawing.Size(189, 6)
+        '
+        'ToolStripSeparator86
+        '
+        Me.ToolStripSeparator86.Name = "ToolStripSeparator86"
+        Me.ToolStripSeparator86.Size = New System.Drawing.Size(189, 6)
         '
         'frmMain
         '
@@ -6287,16 +6340,16 @@ Partial Class frmMain
     Friend WithEvents mnuDescribeSummaries As ToolStripMenuItem
     Friend WithEvents mnuDescribePresentation As ToolStripMenuItem
 
-    Friend WithEvents MenusAndDialogsToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents FileToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents EditToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents PrepareToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents DescribeToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents ModelToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents mnuMenusHelp As ToolStripMenuItem
+    Friend WithEvents mnuFileHelp As ToolStripMenuItem
+    Friend WithEvents mnuEditHelp As ToolStripMenuItem
+    Friend WithEvents mnuPrepareHelp As ToolStripMenuItem
+    Friend WithEvents mnuDescribeHelp As ToolStripMenuItem
+    Friend WithEvents mnuModelHelp As ToolStripMenuItem
     Friend WithEvents ToolStripSeparator81 As ToolStripSeparator
     Friend WithEvents ToolStripSeparator82 As ToolStripSeparator
-    Friend WithEvents ToolsToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents ViewToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents mnuToolsHelp As ToolStripMenuItem
+    Friend WithEvents mnuViewHelp As ToolStripMenuItem
     Friend WithEvents mnuSwapDataLogScript As ToolStripMenuItem
     Friend WithEvents mnuHelpResourcesSite As ToolStripMenuItem
     Friend WithEvents mnuImportFromOpenAppBuilder As ToolStripMenuItem
@@ -6346,17 +6399,25 @@ Partial Class frmMain
     Friend WithEvents mnuViewTricotXpMenu As ToolStripMenuItem
     Friend WithEvents mnuToolsRestartR As ToolStripMenuItem
     Friend WithEvents PrepareToolStripMenuItem1 As ToolStripMenuItem
-    Friend WithEvents VisualizeToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents PivotTablesToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents OneVariableToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents DuplicatesKeyVariableCheckToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents TwoThreeVariableToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents GraphSummariseToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents mnuVisualizeTricot As ToolStripMenuItem
+    Friend WithEvents mnuPivotTablesTricot As ToolStripMenuItem
+    Friend WithEvents mnuOneVariableTricot As ToolStripMenuItem
+    Friend WithEvents mnuDuplicatesTricot As ToolStripMenuItem
     Friend WithEvents OptionalMenuToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents StructuredToolStripMenuItem1 As ToolStripMenuItem
-    Friend WithEvents ClimaticToolStripMenuItem1 As ToolStripMenuItem
-    Friend WithEvents ProcurementToolStripMenuItem1 As ToolStripMenuItem
-    Friend WithEvents ExperimentsToolStripMenuItem1 As ToolStripMenuItem
-    Friend WithEvents TricotMenuToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents TricotXPMenuToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents mnuStructuredHelp As ToolStripMenuItem
+    Friend WithEvents mnuClimaticHelp As ToolStripMenuItem
+    Friend WithEvents mnuProcurementHelp As ToolStripMenuItem
+    Friend WithEvents mnuExperimentsHelp As ToolStripMenuItem
+    Friend WithEvents mnuTricotMenuHelp As ToolStripMenuItem
+    Friend WithEvents mnuTricotXPMenuHelp As ToolStripMenuItem
+    Friend WithEvents mnuSummariseTricot As ToolStripMenuItem
+    Friend WithEvents mnuDescribeGraphTricots As ToolStripMenuItem
+    Friend WithEvents ToolStripSeparator83 As ToolStripSeparator
+    Friend WithEvents TidyToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents mnuTidyTransformTricot As ToolStripMenuItem
+    Friend WithEvents mnuTidyDuplicateRows As ToolStripMenuItem
+    Friend WithEvents mnuTidyAddMergeColumns As ToolStripMenuItem
+    Friend WithEvents AddKeyToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents ToolStripSeparator85 As ToolStripSeparator
+    Friend WithEvents ToolStripSeparator86 As ToolStripSeparator
 End Class

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -636,11 +636,10 @@ Partial Class frmMain
         Me.OneVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.DuplicatesKeyVariableCheckToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotDescribe = New System.Windows.Forms.ToolStripMenuItem()
-        Me.GraphTwoThreeVariablesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.TwoThreeVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ToolStripSeparator83 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuTricotDescribeTraits = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotDescribeCorrelations = New System.Windows.Forms.ToolStripMenuItem()
+        Me.TwoThreeVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.GraphSummariseToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotModelPlackettLuce = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotModelWithoutCovariates = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotModelTree = New System.Windows.Forms.ToolStripMenuItem()
@@ -739,7 +738,11 @@ Partial Class frmMain
         Me.splOverall = New System.Windows.Forms.SplitContainer()
         Me.splExtraWindows = New System.Windows.Forms.SplitContainer()
         Me.splMetadata = New System.Windows.Forms.SplitContainer()
+        Me.ucrColumnMeta = New instat.ucrColumnMetadata()
+        Me.ucrDataFrameMeta = New instat.ucrDataFrameMetadata()
+        Me.ucrScriptWindow = New instat.ucrScript()
         Me.splDataOutput = New System.Windows.Forms.SplitContainer()
+        Me.ucrDataViewer = New instat.ucrDataView()
         Me.ucrOutput = New instat.ucrOutputWindow()
         Me.mnuPlotly = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuColumnMetadata = New System.Windows.Forms.ToolStripMenuItem()
@@ -755,10 +758,14 @@ Partial Class frmMain
         Me.splOverall.SuspendLayout()
         CType(Me.splExtraWindows, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.splExtraWindows.Panel1.SuspendLayout()
+        Me.splExtraWindows.Panel2.SuspendLayout()
         Me.splExtraWindows.SuspendLayout()
         CType(Me.splMetadata, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.splMetadata.Panel1.SuspendLayout()
+        Me.splMetadata.Panel2.SuspendLayout()
         Me.splMetadata.SuspendLayout()
         CType(Me.splDataOutput, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.splDataOutput.Panel1.SuspendLayout()
         Me.splDataOutput.Panel2.SuspendLayout()
         Me.splDataOutput.SuspendLayout()
         Me.SuspendLayout()
@@ -782,18 +789,18 @@ Partial Class frmMain
         'mnuDescribeOneVariableVisualiseData
         '
         Me.mnuDescribeOneVariableVisualiseData.Name = "mnuDescribeOneVariableVisualiseData"
-        Me.mnuDescribeOneVariableVisualiseData.Size = New System.Drawing.Size(155, 22)
+        Me.mnuDescribeOneVariableVisualiseData.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeOneVariableVisualiseData.Text = "Visualise Data..."
         '
         'ToolStripSeparator72
         '
         Me.ToolStripSeparator72.Name = "ToolStripSeparator72"
-        Me.ToolStripSeparator72.Size = New System.Drawing.Size(152, 6)
+        Me.ToolStripSeparator72.Size = New System.Drawing.Size(177, 6)
         '
         'mnuDescribeOneVariableSummarise
         '
         Me.mnuDescribeOneVariableSummarise.Name = "mnuDescribeOneVariableSummarise"
-        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(155, 22)
+        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeOneVariableSummarise.Tag = "Summarise..."
         Me.mnuDescribeOneVariableSummarise.Text = "Summarise..."
         Me.mnuDescribeOneVariableSummarise.ToolTipText = "One Variable Summarise, Skim and Customised"
@@ -801,26 +808,26 @@ Partial Class frmMain
         'mnuDescribeOneVariableGraph
         '
         Me.mnuDescribeOneVariableGraph.Name = "mnuDescribeOneVariableGraph"
-        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(155, 22)
+        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeOneVariableGraph.Tag = "Graph..."
         Me.mnuDescribeOneVariableGraph.Text = "Graph..."
         '
         'ToolStripSeparator33
         '
         Me.ToolStripSeparator33.Name = "ToolStripSeparator33"
-        Me.ToolStripSeparator33.Size = New System.Drawing.Size(152, 6)
+        Me.ToolStripSeparator33.Size = New System.Drawing.Size(177, 6)
         '
         'mnuDescribeOneVariableFrequencies
         '
         Me.mnuDescribeOneVariableFrequencies.Name = "mnuDescribeOneVariableFrequencies"
-        Me.mnuDescribeOneVariableFrequencies.Size = New System.Drawing.Size(155, 22)
+        Me.mnuDescribeOneVariableFrequencies.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeOneVariableFrequencies.Text = "Frequencies..."
         Me.mnuDescribeOneVariableFrequencies.ToolTipText = "Table or Graph. Also Stem and Leaf Plots"
         '
         'mnuDescribeOneVariableRatingData
         '
         Me.mnuDescribeOneVariableRatingData.Name = "mnuDescribeOneVariableRatingData"
-        Me.mnuDescribeOneVariableRatingData.Size = New System.Drawing.Size(155, 22)
+        Me.mnuDescribeOneVariableRatingData.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeOneVariableRatingData.Text = "Rating Data..."
         Me.mnuDescribeOneVariableRatingData.ToolTipText = "Table, Stacked Graph or Likert Graph"
         '
@@ -1681,59 +1688,59 @@ Partial Class frmMain
         'MenusAndDialogsToolStripMenuItem
         '
         Me.MenusAndDialogsToolStripMenuItem.Name = "MenusAndDialogsToolStripMenuItem"
-        Me.MenusAndDialogsToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.MenusAndDialogsToolStripMenuItem.Text = "Menus ..."
+        Me.MenusAndDialogsToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
+        Me.MenusAndDialogsToolStripMenuItem.Text = "Menus and Dialogs..."
         '
         'ToolStripSeparator82
         '
         Me.ToolStripSeparator82.Name = "ToolStripSeparator82"
-        Me.ToolStripSeparator82.Size = New System.Drawing.Size(177, 6)
+        Me.ToolStripSeparator82.Size = New System.Drawing.Size(181, 6)
         '
         'FileToolStripMenuItem
         '
         Me.FileToolStripMenuItem.Name = "FileToolStripMenuItem"
-        Me.FileToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.FileToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.FileToolStripMenuItem.Text = "File..."
         '
         'EditToolStripMenuItem
         '
         Me.EditToolStripMenuItem.Name = "EditToolStripMenuItem"
-        Me.EditToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.EditToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.EditToolStripMenuItem.Text = "Edit..."
         '
         'PrepareToolStripMenuItem
         '
         Me.PrepareToolStripMenuItem.Name = "PrepareToolStripMenuItem"
-        Me.PrepareToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.PrepareToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.PrepareToolStripMenuItem.Text = "Prepare..."
         '
         'DescribeToolStripMenuItem
         '
         Me.DescribeToolStripMenuItem.Name = "DescribeToolStripMenuItem"
-        Me.DescribeToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.DescribeToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.DescribeToolStripMenuItem.Text = "Describe..."
         '
         'ModelToolStripMenuItem
         '
         Me.ModelToolStripMenuItem.Name = "ModelToolStripMenuItem"
-        Me.ModelToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.ModelToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.ModelToolStripMenuItem.Text = "Model..."
         '
         'ToolsToolStripMenuItem
         '
         Me.ToolsToolStripMenuItem.Name = "ToolsToolStripMenuItem"
-        Me.ToolsToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.ToolsToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.ToolsToolStripMenuItem.Text = "Tools..."
         '
         'ViewToolStripMenuItem
         '
         Me.ViewToolStripMenuItem.Name = "ViewToolStripMenuItem"
-        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.ViewToolStripMenuItem.Text = "View..."
         '
         'OptionalMenuToolStripMenuItem
         '
-        Me.OptionalMenuToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.StructuredToolStripMenuItem1, Me.ClimaticToolStripMenuItem1, Me.TricotXPMenuToolStripMenuItem, Me.TricotMenuToolStripMenuItem, Me.ExperimentsToolStripMenuItem1, Me.ProcurementToolStripMenuItem1})
+        Me.OptionalMenuToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.StructuredToolStripMenuItem1, Me.ClimaticToolStripMenuItem1, Me.ProcurementToolStripMenuItem1, Me.ExperimentsToolStripMenuItem1, Me.TricotMenuToolStripMenuItem, Me.TricotXPMenuToolStripMenuItem})
         Me.OptionalMenuToolStripMenuItem.Name = "OptionalMenuToolStripMenuItem"
         Me.OptionalMenuToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
         Me.OptionalMenuToolStripMenuItem.Text = "Optional Menu"
@@ -1742,37 +1749,37 @@ Partial Class frmMain
         '
         Me.StructuredToolStripMenuItem1.Name = "StructuredToolStripMenuItem1"
         Me.StructuredToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.StructuredToolStripMenuItem1.Text = "Structured..."
+        Me.StructuredToolStripMenuItem1.Text = "Structured"
         '
         'ClimaticToolStripMenuItem1
         '
         Me.ClimaticToolStripMenuItem1.Name = "ClimaticToolStripMenuItem1"
         Me.ClimaticToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.ClimaticToolStripMenuItem1.Text = "Climatic..."
+        Me.ClimaticToolStripMenuItem1.Text = "Climatic"
         '
         'ProcurementToolStripMenuItem1
         '
         Me.ProcurementToolStripMenuItem1.Name = "ProcurementToolStripMenuItem1"
         Me.ProcurementToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.ProcurementToolStripMenuItem1.Text = "Procurement..."
+        Me.ProcurementToolStripMenuItem1.Text = "Procurement"
         '
         'ExperimentsToolStripMenuItem1
         '
         Me.ExperimentsToolStripMenuItem1.Name = "ExperimentsToolStripMenuItem1"
         Me.ExperimentsToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.ExperimentsToolStripMenuItem1.Text = "Experiments..."
+        Me.ExperimentsToolStripMenuItem1.Text = "Experiments"
         '
         'TricotMenuToolStripMenuItem
         '
         Me.TricotMenuToolStripMenuItem.Name = "TricotMenuToolStripMenuItem"
         Me.TricotMenuToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.TricotMenuToolStripMenuItem.Text = "Tricot Menu..."
+        Me.TricotMenuToolStripMenuItem.Text = "Tricot Menu"
         '
         'TricotXPMenuToolStripMenuItem
         '
         Me.TricotXPMenuToolStripMenuItem.Name = "TricotXPMenuToolStripMenuItem"
         Me.TricotXPMenuToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.TricotXPMenuToolStripMenuItem.Text = "Tricot XP Menu..."
+        Me.TricotXPMenuToolStripMenuItem.Text = "Tricot XP Menu"
         '
         'mnuHelpAboutR
         '
@@ -4785,39 +4792,35 @@ Partial Class frmMain
         '
         'mnuTricotDescribe
         '
-        Me.mnuTricotDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.GraphTwoThreeVariablesToolStripMenuItem, Me.TwoThreeVariableToolStripMenuItem, Me.ToolStripSeparator83, Me.mnuTricotDescribeTraits, Me.mnuTricotDescribeCorrelations})
+        Me.mnuTricotDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotDescribeTraits, Me.mnuTricotDescribeCorrelations, Me.TwoThreeVariableToolStripMenuItem})
         Me.mnuTricotDescribe.Name = "mnuTricotDescribe"
         Me.mnuTricotDescribe.Size = New System.Drawing.Size(201, 22)
         Me.mnuTricotDescribe.Text = "Describe"
         '
-        'GraphTwoThreeVariablesToolStripMenuItem
-        '
-        Me.GraphTwoThreeVariablesToolStripMenuItem.Name = "GraphTwoThreeVariablesToolStripMenuItem"
-        Me.GraphTwoThreeVariablesToolStripMenuItem.Size = New System.Drawing.Size(249, 22)
-        Me.GraphTwoThreeVariablesToolStripMenuItem.Text = "Graph Two/Three Variables..."
-        '
-        'TwoThreeVariableToolStripMenuItem
-        '
-        Me.TwoThreeVariableToolStripMenuItem.Name = "TwoThreeVariableToolStripMenuItem"
-        Me.TwoThreeVariableToolStripMenuItem.Size = New System.Drawing.Size(249, 22)
-        Me.TwoThreeVariableToolStripMenuItem.Text = "Summarise Two/ Three Variable..."
-        '
-        'ToolStripSeparator83
-        '
-        Me.ToolStripSeparator83.Name = "ToolStripSeparator83"
-        Me.ToolStripSeparator83.Size = New System.Drawing.Size(246, 6)
-        '
         'mnuTricotDescribeTraits
         '
         Me.mnuTricotDescribeTraits.Name = "mnuTricotDescribeTraits"
-        Me.mnuTricotDescribeTraits.Size = New System.Drawing.Size(249, 22)
+        Me.mnuTricotDescribeTraits.Size = New System.Drawing.Size(180, 22)
         Me.mnuTricotDescribeTraits.Text = "Traits..."
         '
         'mnuTricotDescribeCorrelations
         '
         Me.mnuTricotDescribeCorrelations.Name = "mnuTricotDescribeCorrelations"
-        Me.mnuTricotDescribeCorrelations.Size = New System.Drawing.Size(249, 22)
+        Me.mnuTricotDescribeCorrelations.Size = New System.Drawing.Size(180, 22)
         Me.mnuTricotDescribeCorrelations.Text = "Correlations..."
+        '
+        'TwoThreeVariableToolStripMenuItem
+        '
+        Me.TwoThreeVariableToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.GraphSummariseToolStripMenuItem})
+        Me.TwoThreeVariableToolStripMenuItem.Name = "TwoThreeVariableToolStripMenuItem"
+        Me.TwoThreeVariableToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.TwoThreeVariableToolStripMenuItem.Text = "Two/ Three Variable"
+        '
+        'GraphSummariseToolStripMenuItem
+        '
+        Me.GraphSummariseToolStripMenuItem.Name = "GraphSummariseToolStripMenuItem"
+        Me.GraphSummariseToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.GraphSummariseToolStripMenuItem.Text = "graph summarise"
         '
         'mnuTricotModelPlackettLuce
         '
@@ -4896,13 +4899,13 @@ Partial Class frmMain
         'mnuTricotXpDescribeTraits
         '
         Me.mnuTricotXpDescribeTraits.Name = "mnuTricotXpDescribeTraits"
-        Me.mnuTricotXpDescribeTraits.Size = New System.Drawing.Size(147, 22)
+        Me.mnuTricotXpDescribeTraits.Size = New System.Drawing.Size(180, 22)
         Me.mnuTricotXpDescribeTraits.Text = "Traits..."
         '
         'ToolStripMenuItem9
         '
         Me.ToolStripMenuItem9.Name = "ToolStripMenuItem9"
-        Me.ToolStripMenuItem9.Size = New System.Drawing.Size(147, 22)
+        Me.ToolStripMenuItem9.Size = New System.Drawing.Size(180, 22)
         Me.ToolStripMenuItem9.Text = "Correlations..."
         '
         'ToolStripMenuItem10
@@ -4947,7 +4950,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextCheckData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCheckDataDuplicateRows, Me.mnuOptionsByContextCheckDataCompareColumns, Me.ToolStripSeparator47, Me.mnuOptionsByContextCheckDataOneVariableSummarise, Me.mnuOptionsByContextCheckDataOneVariableGraph, Me.mnuOptionsByContextCheckDataOneVariableFrequencies})
         Me.mnuOptionsByContextCheckData.Name = "mnuOptionsByContextCheckData"
-        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(137, 22)
+        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextCheckData.Text = "Check Data"
         '
         'mnuOptionsByContextCheckDataDuplicateRows
@@ -4989,7 +4992,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextDefine.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDefineOnStation, Me.mnuOptionsByContextDefineOnFarm})
         Me.mnuOptionsByContextDefine.Name = "mnuOptionsByContextDefine"
-        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(137, 22)
+        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextDefine.Text = "Define"
         '
         'mnuOptionsByContextDefineOnStation
@@ -5008,7 +5011,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions, Me.ToolStripSeparator48, Me.mnuOptionsByContextMergeAdditionalData, Me.mnuOptionsByContextPrepareStack, Me.mnuOptionsByContextPrepareUnstack})
         Me.mnuOptionsByContextPrepare.Name = "mnuOptionsByContextPrepare"
-        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(137, 22)
+        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextPrepare.Text = "Prepare"
         '
         'mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions
@@ -5044,7 +5047,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDescribeCompareTwoTreatments, Me.mnuOptionsByContextDescribeCompareMultipleTreatments, Me.mnuOptionsByContextDescribeBoxplot})
         Me.mnuOptionsByContextDescribe.Name = "mnuOptionsByContextDescribe"
-        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(137, 22)
+        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextDescribe.Text = "Describe"
         '
         'mnuOptionsByContextDescribeCompareTwoTreatments
@@ -5070,7 +5073,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextModelFitModel, Me.mnuOptionsByContextGeneralFitModel})
         Me.mnuOptionsByContextModel.Name = "mnuOptionsByContextModel"
-        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(137, 22)
+        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextModel.Text = "Model"
         '
         'mnuOptionsByContextModelFitModel
@@ -5089,7 +5092,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextCropModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCropModelApsimxExamples})
         Me.mnuOptionsByContextCropModel.Name = "mnuOptionsByContextCropModel"
-        Me.mnuOptionsByContextCropModel.Size = New System.Drawing.Size(137, 22)
+        Me.mnuOptionsByContextCropModel.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextCropModel.Text = "Crop Model"
         '
         'mnuOptionsByContextCropModelApsimxExamples
@@ -5443,6 +5446,7 @@ Partial Class frmMain
         'splExtraWindows.Panel2
         '
         Me.splExtraWindows.Panel2.BackColor = System.Drawing.SystemColors.Control
+        Me.splExtraWindows.Panel2.Controls.Add(Me.ucrScriptWindow)
         Me.splExtraWindows.Size = New System.Drawing.Size(834, 155)
         Me.splExtraWindows.SplitterDistance = 252
         Me.splExtraWindows.SplitterWidth = 5
@@ -5455,13 +5459,55 @@ Partial Class frmMain
         Me.splMetadata.Location = New System.Drawing.Point(0, 0)
         Me.splMetadata.Name = "splMetadata"
         '
+        'splMetadata.Panel1
+        '
+        Me.splMetadata.Panel1.Controls.Add(Me.ucrColumnMeta)
+        '
         'splMetadata.Panel2
         '
         Me.splMetadata.Panel2.BackColor = System.Drawing.SystemColors.Control
+        Me.splMetadata.Panel2.Controls.Add(Me.ucrDataFrameMeta)
         Me.splMetadata.Size = New System.Drawing.Size(252, 155)
         Me.splMetadata.SplitterDistance = 68
         Me.splMetadata.SplitterWidth = 5
         Me.splMetadata.TabIndex = 0
+        '
+        'ucrColumnMeta
+        '
+        Me.ucrColumnMeta.AutoSize = True
+        Me.ucrColumnMeta.BackColor = System.Drawing.SystemColors.Control
+        Me.ucrColumnMeta.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+        Me.ucrColumnMeta.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.ucrColumnMeta.IsEnabled = False
+        Me.ucrColumnMeta.Location = New System.Drawing.Point(0, 0)
+        Me.ucrColumnMeta.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrColumnMeta.Name = "ucrColumnMeta"
+        Me.ucrColumnMeta.Size = New System.Drawing.Size(68, 155)
+        Me.ucrColumnMeta.TabIndex = 0
+        '
+        'ucrDataFrameMeta
+        '
+        Me.ucrDataFrameMeta.AutoSize = True
+        Me.ucrDataFrameMeta.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+        Me.ucrDataFrameMeta.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.ucrDataFrameMeta.Location = New System.Drawing.Point(0, 0)
+        Me.ucrDataFrameMeta.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrDataFrameMeta.Name = "ucrDataFrameMeta"
+        Me.ucrDataFrameMeta.Size = New System.Drawing.Size(179, 155)
+        Me.ucrDataFrameMeta.TabIndex = 0
+        '
+        'ucrScriptWindow
+        '
+        Me.ucrScriptWindow.AutoSize = True
+        Me.ucrScriptWindow.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+        Me.ucrScriptWindow.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.ucrScriptWindow.Location = New System.Drawing.Point(0, 0)
+        Me.ucrScriptWindow.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrScriptWindow.Name = "ucrScriptWindow"
+        Me.ucrScriptWindow.Size = New System.Drawing.Size(577, 155)
+        Me.ucrScriptWindow.strActiveTabText = ""
+        Me.ucrScriptWindow.TabIndex = 2
+        Me.ucrScriptWindow.Tag = "Script_Window"
         '
         'splDataOutput
         '
@@ -5473,6 +5519,7 @@ Partial Class frmMain
         'splDataOutput.Panel1
         '
         Me.splDataOutput.Panel1.BackColor = System.Drawing.SystemColors.Control
+        Me.splDataOutput.Panel1.Controls.Add(Me.ucrDataViewer)
         '
         'splDataOutput.Panel2
         '
@@ -5482,6 +5529,19 @@ Partial Class frmMain
         Me.splDataOutput.SplitterDistance = 382
         Me.splDataOutput.SplitterWidth = 5
         Me.splDataOutput.TabIndex = 0
+        '
+        'ucrDataViewer
+        '
+        Me.ucrDataViewer.AutoSize = True
+        Me.ucrDataViewer.BackColor = System.Drawing.SystemColors.Control
+        Me.ucrDataViewer.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+        Me.ucrDataViewer.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.ucrDataViewer.Location = New System.Drawing.Point(0, 0)
+        Me.ucrDataViewer.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrDataViewer.Name = "ucrDataViewer"
+        Me.ucrDataViewer.Size = New System.Drawing.Size(382, 239)
+        Me.ucrDataViewer.TabIndex = 0
+        Me.ucrDataViewer.Tag = "Data_View"
         '
         'ucrOutput
         '
@@ -5555,10 +5615,18 @@ Partial Class frmMain
         CType(Me.splOverall, System.ComponentModel.ISupportInitialize).EndInit()
         Me.splOverall.ResumeLayout(False)
         Me.splExtraWindows.Panel1.ResumeLayout(False)
+        Me.splExtraWindows.Panel2.ResumeLayout(False)
+        Me.splExtraWindows.Panel2.PerformLayout()
         CType(Me.splExtraWindows, System.ComponentModel.ISupportInitialize).EndInit()
         Me.splExtraWindows.ResumeLayout(False)
+        Me.splMetadata.Panel1.ResumeLayout(False)
+        Me.splMetadata.Panel1.PerformLayout()
+        Me.splMetadata.Panel2.ResumeLayout(False)
+        Me.splMetadata.Panel2.PerformLayout()
         CType(Me.splMetadata, System.ComponentModel.ISupportInitialize).EndInit()
         Me.splMetadata.ResumeLayout(False)
+        Me.splDataOutput.Panel1.ResumeLayout(False)
+        Me.splDataOutput.Panel1.PerformLayout()
         Me.splDataOutput.Panel2.ResumeLayout(False)
         Me.splDataOutput.Panel2.PerformLayout()
         CType(Me.splDataOutput, System.ComponentModel.ISupportInitialize).EndInit()
@@ -5883,10 +5951,13 @@ Partial Class frmMain
     Friend WithEvents ToolStripSeparator35 As ToolStripSeparator
     Friend WithEvents splOverall As SplitContainer
     Friend WithEvents splDataOutput As SplitContainer
+    Friend WithEvents ucrDataViewer As ucrDataView
     Friend WithEvents ucrOutput As ucrOutputWindow
     Friend WithEvents splExtraWindows As SplitContainer
     Friend WithEvents splMetadata As SplitContainer
+    Friend WithEvents ucrColumnMeta As ucrColumnMetadata
     Friend WithEvents mnuViewResetToDefaultLayout As ToolStripMenuItem
+    Friend WithEvents ucrDataFrameMeta As ucrDataFrameMetadata
     Friend WithEvents mnuClimaticFileImportfromIRIDataLibrary As ToolStripMenuItem
     Friend WithEvents mnuDescribeOneVariableRatingData As ToolStripMenuItem
     Friend WithEvents mnuDescribeViewGraph As ToolStripMenuItem
@@ -6147,6 +6218,7 @@ Partial Class frmMain
     Friend WithEvents mnuHelpGlossary As ToolStripMenuItem
     Friend WithEvents mnuHelpPackagesDocumentation As ToolStripMenuItem
     Friend WithEvents mnuDescribeUseTable As ToolStripMenuItem
+    Friend WithEvents ucrScriptWindow As ucrScript
     Friend WithEvents mnuViewOutput As ToolStripMenuItem
     Friend WithEvents mnuViewLogScript As ToolStripMenuItem
     Friend WithEvents mnuTbSave As ToolStripSplitButton
@@ -6279,6 +6351,7 @@ Partial Class frmMain
     Friend WithEvents OneVariableToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents DuplicatesKeyVariableCheckToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents TwoThreeVariableToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents GraphSummariseToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents OptionalMenuToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents StructuredToolStripMenuItem1 As ToolStripMenuItem
     Friend WithEvents ClimaticToolStripMenuItem1 As ToolStripMenuItem
@@ -6286,6 +6359,4 @@ Partial Class frmMain
     Friend WithEvents ExperimentsToolStripMenuItem1 As ToolStripMenuItem
     Friend WithEvents TricotMenuToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents TricotXPMenuToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents GraphTwoThreeVariablesToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents ToolStripSeparator83 As ToolStripSeparator
 End Class

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -719,6 +719,7 @@ Partial Class frmMain
         Me.mnuProcurementCTFVCalculateCRI = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuProcurementUseCRISummariseCRIbyCountry = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTools = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuToolsRestartR = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuToolsCheckForUpdates = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuToolsClearOutputWindow = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator5 = New System.Windows.Forms.ToolStripSeparator()
@@ -740,7 +741,13 @@ Partial Class frmMain
         Me.mnuDataFrameMetadata = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuScriptFile = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuLogFile = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuToolsRestartR = New System.Windows.Forms.ToolStripMenuItem()
+        Me.PrepareToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
+        Me.VisualizeToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.PivotTablesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.OneVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.DuplicatesKeyVariableCheckToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.TwoThreeVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.GraphSummariseToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.stsStrip.SuspendLayout()
         Me.Tool_strip.SuspendLayout()
         Me.mnuBar.SuspendLayout()
@@ -4709,7 +4716,7 @@ Partial Class frmMain
         '
         'mnuTricot
         '
-        Me.mnuTricot.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotImportFromClimMob, Me.mnuTricotTransformClimMob, Me.mnuTricotDefineTricotData, Me.mnuTricotGenotypeData, Me.ToolStripSeparator20, Me.mnuTricotDescribe, Me.mnuTricotModelPlackettLuce})
+        Me.mnuTricot.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotImportFromClimMob, Me.mnuTricotTransformClimMob, Me.mnuTricotDefineTricotData, Me.mnuTricotGenotypeData, Me.ToolStripSeparator20, Me.PrepareToolStripMenuItem1, Me.mnuTricotDescribe, Me.mnuTricotModelPlackettLuce})
         Me.mnuTricot.Name = "mnuTricot"
         Me.mnuTricot.Size = New System.Drawing.Size(49, 22)
         Me.mnuTricot.Text = "Tricot"
@@ -4745,7 +4752,7 @@ Partial Class frmMain
         '
         'mnuTricotDescribe
         '
-        Me.mnuTricotDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotDescribeTraits, Me.mnuTricotDescribeCorrelations})
+        Me.mnuTricotDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotDescribeTraits, Me.mnuTricotDescribeCorrelations, Me.TwoThreeVariableToolStripMenuItem})
         Me.mnuTricotDescribe.Name = "mnuTricotDescribe"
         Me.mnuTricotDescribe.Size = New System.Drawing.Size(201, 22)
         Me.mnuTricotDescribe.Text = "Describe"
@@ -5296,6 +5303,14 @@ Partial Class frmMain
         Me.mnuTools.Size = New System.Drawing.Size(47, 22)
         Me.mnuTools.Text = "Tools"
         '
+        'mnuToolsRestartR
+        '
+        Me.mnuToolsRestartR.Enabled = False
+        Me.mnuToolsRestartR.Name = "mnuToolsRestartR"
+        Me.mnuToolsRestartR.Size = New System.Drawing.Size(217, 22)
+        Me.mnuToolsRestartR.Tag = "Restart_R"
+        Me.mnuToolsRestartR.Text = "Restart R"
+        '
         'mnuToolsCheckForUpdates
         '
         Me.mnuToolsCheckForUpdates.Name = "mnuToolsCheckForUpdates"
@@ -5521,13 +5536,49 @@ Partial Class frmMain
         Me.mnuLogFile.Text = "Log Window..."
         Me.mnuLogFile.ToolTipText = "Log Window"
         '
-        'mnuToolsRestartR
+        'PrepareToolStripMenuItem1
         '
-        Me.mnuToolsRestartR.Enabled = False
-        Me.mnuToolsRestartR.Name = "mnuToolsRestartR"
-        Me.mnuToolsRestartR.Size = New System.Drawing.Size(217, 22)
-        Me.mnuToolsRestartR.Tag = "Restart_R"
-        Me.mnuToolsRestartR.Text = "Restart R"
+        Me.PrepareToolStripMenuItem1.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.VisualizeToolStripMenuItem, Me.PivotTablesToolStripMenuItem, Me.OneVariableToolStripMenuItem, Me.DuplicatesKeyVariableCheckToolStripMenuItem})
+        Me.PrepareToolStripMenuItem1.Name = "PrepareToolStripMenuItem1"
+        Me.PrepareToolStripMenuItem1.Size = New System.Drawing.Size(201, 22)
+        Me.PrepareToolStripMenuItem1.Text = "Prepare"
+        '
+        'VisualizeToolStripMenuItem
+        '
+        Me.VisualizeToolStripMenuItem.Name = "VisualizeToolStripMenuItem"
+        Me.VisualizeToolStripMenuItem.Size = New System.Drawing.Size(240, 22)
+        Me.VisualizeToolStripMenuItem.Text = "Visualize"
+        '
+        'PivotTablesToolStripMenuItem
+        '
+        Me.PivotTablesToolStripMenuItem.Name = "PivotTablesToolStripMenuItem"
+        Me.PivotTablesToolStripMenuItem.Size = New System.Drawing.Size(240, 22)
+        Me.PivotTablesToolStripMenuItem.Text = "Pivot Tables"
+        '
+        'OneVariableToolStripMenuItem
+        '
+        Me.OneVariableToolStripMenuItem.Name = "OneVariableToolStripMenuItem"
+        Me.OneVariableToolStripMenuItem.Size = New System.Drawing.Size(240, 22)
+        Me.OneVariableToolStripMenuItem.Text = "One Variable"
+        '
+        'DuplicatesKeyVariableCheckToolStripMenuItem
+        '
+        Me.DuplicatesKeyVariableCheckToolStripMenuItem.Name = "DuplicatesKeyVariableCheckToolStripMenuItem"
+        Me.DuplicatesKeyVariableCheckToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
+        Me.DuplicatesKeyVariableCheckToolStripMenuItem.Text = "Duplicates (Key Variable Check)"
+        '
+        'TwoThreeVariableToolStripMenuItem
+        '
+        Me.TwoThreeVariableToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.GraphSummariseToolStripMenuItem})
+        Me.TwoThreeVariableToolStripMenuItem.Name = "TwoThreeVariableToolStripMenuItem"
+        Me.TwoThreeVariableToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.TwoThreeVariableToolStripMenuItem.Text = "Two/ Three Variable"
+        '
+        'GraphSummariseToolStripMenuItem
+        '
+        Me.GraphSummariseToolStripMenuItem.Name = "GraphSummariseToolStripMenuItem"
+        Me.GraphSummariseToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.GraphSummariseToolStripMenuItem.Text = "graph summarise"
         '
         'frmMain
         '
@@ -6291,4 +6342,11 @@ Partial Class frmMain
     Friend WithEvents ToolStripMenuItem14 As ToolStripMenuItem
     Friend WithEvents mnuViewTricotXpMenu As ToolStripMenuItem
     Friend WithEvents mnuToolsRestartR As ToolStripMenuItem
+    Friend WithEvents PrepareToolStripMenuItem1 As ToolStripMenuItem
+    Friend WithEvents VisualizeToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents PivotTablesToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents OneVariableToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents DuplicatesKeyVariableCheckToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents TwoThreeVariableToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents GraphSummariseToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -179,6 +179,13 @@ Partial Class frmMain
         Me.ModelToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ViewToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.OptionalMenuToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.StructuredToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ClimaticToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ProcurementToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ExperimentsToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
+        Me.TricotMenuToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.TricotXPMenuToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuHelpAboutR = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuHelpLearningStatistics = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuHelpRPackages = New System.Windows.Forms.ToolStripMenuItem()
@@ -622,11 +629,17 @@ Partial Class frmMain
         Me.mnuTricotImportFromClimMob = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotTransformClimMob = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotDefineTricotData = New System.Windows.Forms.ToolStripMenuItem()
-        Me.mnuTricotGenotypeData = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator20 = New System.Windows.Forms.ToolStripSeparator()
+        Me.PrepareToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
+        Me.VisualizeToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.PivotTablesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.OneVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.DuplicatesKeyVariableCheckToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotDescribe = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotDescribeTraits = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotDescribeCorrelations = New System.Windows.Forms.ToolStripMenuItem()
+        Me.TwoThreeVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.GraphSummariseToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotModelPlackettLuce = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotModelWithoutCovariates = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuTricotModelTree = New System.Windows.Forms.ToolStripMenuItem()
@@ -736,20 +749,6 @@ Partial Class frmMain
         Me.mnuDataFrameMetadata = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuScriptFile = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuLogFile = New System.Windows.Forms.ToolStripMenuItem()
-        Me.PrepareToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
-        Me.VisualizeToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.PivotTablesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.OneVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.DuplicatesKeyVariableCheckToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.TwoThreeVariableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.GraphSummariseToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.OptionalMenuToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.StructuredToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ClimaticToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ProcurementToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ExperimentsToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
-        Me.TricotMenuToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.TricotXPMenuToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.stsStrip.SuspendLayout()
         Me.Tool_strip.SuspendLayout()
         Me.mnuBar.SuspendLayout()
@@ -790,18 +789,18 @@ Partial Class frmMain
         'mnuDescribeOneVariableVisualiseData
         '
         Me.mnuDescribeOneVariableVisualiseData.Name = "mnuDescribeOneVariableVisualiseData"
-        Me.mnuDescribeOneVariableVisualiseData.Size = New System.Drawing.Size(155, 22)
+        Me.mnuDescribeOneVariableVisualiseData.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeOneVariableVisualiseData.Text = "Visualise Data..."
         '
         'ToolStripSeparator72
         '
         Me.ToolStripSeparator72.Name = "ToolStripSeparator72"
-        Me.ToolStripSeparator72.Size = New System.Drawing.Size(152, 6)
+        Me.ToolStripSeparator72.Size = New System.Drawing.Size(177, 6)
         '
         'mnuDescribeOneVariableSummarise
         '
         Me.mnuDescribeOneVariableSummarise.Name = "mnuDescribeOneVariableSummarise"
-        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(155, 22)
+        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeOneVariableSummarise.Tag = "Summarise..."
         Me.mnuDescribeOneVariableSummarise.Text = "Summarise..."
         Me.mnuDescribeOneVariableSummarise.ToolTipText = "One Variable Summarise, Skim and Customised"
@@ -809,26 +808,26 @@ Partial Class frmMain
         'mnuDescribeOneVariableGraph
         '
         Me.mnuDescribeOneVariableGraph.Name = "mnuDescribeOneVariableGraph"
-        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(155, 22)
+        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeOneVariableGraph.Tag = "Graph..."
         Me.mnuDescribeOneVariableGraph.Text = "Graph..."
         '
         'ToolStripSeparator33
         '
         Me.ToolStripSeparator33.Name = "ToolStripSeparator33"
-        Me.ToolStripSeparator33.Size = New System.Drawing.Size(152, 6)
+        Me.ToolStripSeparator33.Size = New System.Drawing.Size(177, 6)
         '
         'mnuDescribeOneVariableFrequencies
         '
         Me.mnuDescribeOneVariableFrequencies.Name = "mnuDescribeOneVariableFrequencies"
-        Me.mnuDescribeOneVariableFrequencies.Size = New System.Drawing.Size(155, 22)
+        Me.mnuDescribeOneVariableFrequencies.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeOneVariableFrequencies.Text = "Frequencies..."
         Me.mnuDescribeOneVariableFrequencies.ToolTipText = "Table or Graph. Also Stem and Leaf Plots"
         '
         'mnuDescribeOneVariableRatingData
         '
         Me.mnuDescribeOneVariableRatingData.Name = "mnuDescribeOneVariableRatingData"
-        Me.mnuDescribeOneVariableRatingData.Size = New System.Drawing.Size(155, 22)
+        Me.mnuDescribeOneVariableRatingData.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeOneVariableRatingData.Text = "Rating Data..."
         Me.mnuDescribeOneVariableRatingData.ToolTipText = "Table, Stacked Graph or Likert Graph"
         '
@@ -1738,6 +1737,49 @@ Partial Class frmMain
         Me.ViewToolStripMenuItem.Name = "ViewToolStripMenuItem"
         Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(184, 22)
         Me.ViewToolStripMenuItem.Text = "View..."
+        '
+        'OptionalMenuToolStripMenuItem
+        '
+        Me.OptionalMenuToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.StructuredToolStripMenuItem1, Me.ClimaticToolStripMenuItem1, Me.ProcurementToolStripMenuItem1, Me.ExperimentsToolStripMenuItem1, Me.TricotMenuToolStripMenuItem, Me.TricotXPMenuToolStripMenuItem})
+        Me.OptionalMenuToolStripMenuItem.Name = "OptionalMenuToolStripMenuItem"
+        Me.OptionalMenuToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
+        Me.OptionalMenuToolStripMenuItem.Text = "Optional Menu"
+        '
+        'StructuredToolStripMenuItem1
+        '
+        Me.StructuredToolStripMenuItem1.Name = "StructuredToolStripMenuItem1"
+        Me.StructuredToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
+        Me.StructuredToolStripMenuItem1.Text = "Structured"
+        '
+        'ClimaticToolStripMenuItem1
+        '
+        Me.ClimaticToolStripMenuItem1.Name = "ClimaticToolStripMenuItem1"
+        Me.ClimaticToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
+        Me.ClimaticToolStripMenuItem1.Text = "Climatic"
+        '
+        'ProcurementToolStripMenuItem1
+        '
+        Me.ProcurementToolStripMenuItem1.Name = "ProcurementToolStripMenuItem1"
+        Me.ProcurementToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
+        Me.ProcurementToolStripMenuItem1.Text = "Procurement"
+        '
+        'ExperimentsToolStripMenuItem1
+        '
+        Me.ExperimentsToolStripMenuItem1.Name = "ExperimentsToolStripMenuItem1"
+        Me.ExperimentsToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
+        Me.ExperimentsToolStripMenuItem1.Text = "Experiments"
+        '
+        'TricotMenuToolStripMenuItem
+        '
+        Me.TricotMenuToolStripMenuItem.Name = "TricotMenuToolStripMenuItem"
+        Me.TricotMenuToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.TricotMenuToolStripMenuItem.Text = "Tricot Menu"
+        '
+        'TricotXPMenuToolStripMenuItem
+        '
+        Me.TricotXPMenuToolStripMenuItem.Name = "TricotXPMenuToolStripMenuItem"
+        Me.TricotXPMenuToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.TricotXPMenuToolStripMenuItem.Text = "Tricot XP Menu"
         '
         'mnuHelpAboutR
         '
@@ -4689,7 +4731,7 @@ Partial Class frmMain
         '
         'mnuTricot
         '
-        Me.mnuTricot.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotImportFromClimMob, Me.mnuTricotTransformClimMob, Me.mnuTricotDefineTricotData, Me.mnuTricotGenotypeData, Me.ToolStripSeparator20, Me.PrepareToolStripMenuItem1, Me.mnuTricotDescribe, Me.mnuTricotModelPlackettLuce})
+        Me.mnuTricot.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotImportFromClimMob, Me.mnuTricotTransformClimMob, Me.mnuTricotDefineTricotData, Me.ToolStripSeparator20, Me.PrepareToolStripMenuItem1, Me.mnuTricotDescribe, Me.mnuTricotModelPlackettLuce})
         Me.mnuTricot.Name = "mnuTricot"
         Me.mnuTricot.Size = New System.Drawing.Size(49, 22)
         Me.mnuTricot.Text = "Tricot"
@@ -4712,16 +4754,41 @@ Partial Class frmMain
         Me.mnuTricotDefineTricotData.Size = New System.Drawing.Size(201, 22)
         Me.mnuTricotDefineTricotData.Text = "Define Tricot Data..."
         '
-        'mnuTricotGenotypeData
-        '
-        Me.mnuTricotGenotypeData.Name = "mnuTricotGenotypeData"
-        Me.mnuTricotGenotypeData.Size = New System.Drawing.Size(201, 22)
-        Me.mnuTricotGenotypeData.Text = "Genotype Data..."
-        '
         'ToolStripSeparator20
         '
         Me.ToolStripSeparator20.Name = "ToolStripSeparator20"
         Me.ToolStripSeparator20.Size = New System.Drawing.Size(198, 6)
+        '
+        'PrepareToolStripMenuItem1
+        '
+        Me.PrepareToolStripMenuItem1.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.VisualizeToolStripMenuItem, Me.PivotTablesToolStripMenuItem, Me.OneVariableToolStripMenuItem, Me.DuplicatesKeyVariableCheckToolStripMenuItem})
+        Me.PrepareToolStripMenuItem1.Name = "PrepareToolStripMenuItem1"
+        Me.PrepareToolStripMenuItem1.Size = New System.Drawing.Size(201, 22)
+        Me.PrepareToolStripMenuItem1.Text = "Prepare"
+        '
+        'VisualizeToolStripMenuItem
+        '
+        Me.VisualizeToolStripMenuItem.Name = "VisualizeToolStripMenuItem"
+        Me.VisualizeToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
+        Me.VisualizeToolStripMenuItem.Text = "Visualize"
+        '
+        'PivotTablesToolStripMenuItem
+        '
+        Me.PivotTablesToolStripMenuItem.Name = "PivotTablesToolStripMenuItem"
+        Me.PivotTablesToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
+        Me.PivotTablesToolStripMenuItem.Text = "Pivot Tables"
+        '
+        'OneVariableToolStripMenuItem
+        '
+        Me.OneVariableToolStripMenuItem.Name = "OneVariableToolStripMenuItem"
+        Me.OneVariableToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
+        Me.OneVariableToolStripMenuItem.Text = "One Variable"
+        '
+        'DuplicatesKeyVariableCheckToolStripMenuItem
+        '
+        Me.DuplicatesKeyVariableCheckToolStripMenuItem.Name = "DuplicatesKeyVariableCheckToolStripMenuItem"
+        Me.DuplicatesKeyVariableCheckToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
+        Me.DuplicatesKeyVariableCheckToolStripMenuItem.Text = "Duplicates (Key Variable Check)"
         '
         'mnuTricotDescribe
         '
@@ -4733,14 +4800,27 @@ Partial Class frmMain
         'mnuTricotDescribeTraits
         '
         Me.mnuTricotDescribeTraits.Name = "mnuTricotDescribeTraits"
-        Me.mnuTricotDescribeTraits.Size = New System.Drawing.Size(147, 22)
+        Me.mnuTricotDescribeTraits.Size = New System.Drawing.Size(180, 22)
         Me.mnuTricotDescribeTraits.Text = "Traits..."
         '
         'mnuTricotDescribeCorrelations
         '
         Me.mnuTricotDescribeCorrelations.Name = "mnuTricotDescribeCorrelations"
-        Me.mnuTricotDescribeCorrelations.Size = New System.Drawing.Size(147, 22)
+        Me.mnuTricotDescribeCorrelations.Size = New System.Drawing.Size(180, 22)
         Me.mnuTricotDescribeCorrelations.Text = "Correlations..."
+        '
+        'TwoThreeVariableToolStripMenuItem
+        '
+        Me.TwoThreeVariableToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.GraphSummariseToolStripMenuItem})
+        Me.TwoThreeVariableToolStripMenuItem.Name = "TwoThreeVariableToolStripMenuItem"
+        Me.TwoThreeVariableToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.TwoThreeVariableToolStripMenuItem.Text = "Two/ Three Variable"
+        '
+        'GraphSummariseToolStripMenuItem
+        '
+        Me.GraphSummariseToolStripMenuItem.Name = "GraphSummariseToolStripMenuItem"
+        Me.GraphSummariseToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.GraphSummariseToolStripMenuItem.Text = "graph summarise"
         '
         'mnuTricotModelPlackettLuce
         '
@@ -4819,13 +4899,13 @@ Partial Class frmMain
         'mnuTricotXpDescribeTraits
         '
         Me.mnuTricotXpDescribeTraits.Name = "mnuTricotXpDescribeTraits"
-        Me.mnuTricotXpDescribeTraits.Size = New System.Drawing.Size(147, 22)
+        Me.mnuTricotXpDescribeTraits.Size = New System.Drawing.Size(180, 22)
         Me.mnuTricotXpDescribeTraits.Text = "Traits..."
         '
         'ToolStripMenuItem9
         '
         Me.ToolStripMenuItem9.Name = "ToolStripMenuItem9"
-        Me.ToolStripMenuItem9.Size = New System.Drawing.Size(147, 22)
+        Me.ToolStripMenuItem9.Size = New System.Drawing.Size(180, 22)
         Me.ToolStripMenuItem9.Text = "Correlations..."
         '
         'ToolStripMenuItem10
@@ -4870,7 +4950,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextCheckData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCheckDataDuplicateRows, Me.mnuOptionsByContextCheckDataCompareColumns, Me.ToolStripSeparator47, Me.mnuOptionsByContextCheckDataOneVariableSummarise, Me.mnuOptionsByContextCheckDataOneVariableGraph, Me.mnuOptionsByContextCheckDataOneVariableFrequencies})
         Me.mnuOptionsByContextCheckData.Name = "mnuOptionsByContextCheckData"
-        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(137, 22)
+        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextCheckData.Text = "Check Data"
         '
         'mnuOptionsByContextCheckDataDuplicateRows
@@ -4912,7 +4992,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextDefine.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDefineOnStation, Me.mnuOptionsByContextDefineOnFarm})
         Me.mnuOptionsByContextDefine.Name = "mnuOptionsByContextDefine"
-        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(137, 22)
+        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextDefine.Text = "Define"
         '
         'mnuOptionsByContextDefineOnStation
@@ -4931,7 +5011,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions, Me.ToolStripSeparator48, Me.mnuOptionsByContextMergeAdditionalData, Me.mnuOptionsByContextPrepareStack, Me.mnuOptionsByContextPrepareUnstack})
         Me.mnuOptionsByContextPrepare.Name = "mnuOptionsByContextPrepare"
-        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(137, 22)
+        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextPrepare.Text = "Prepare"
         '
         'mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions
@@ -4967,7 +5047,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDescribeCompareTwoTreatments, Me.mnuOptionsByContextDescribeCompareMultipleTreatments, Me.mnuOptionsByContextDescribeBoxplot})
         Me.mnuOptionsByContextDescribe.Name = "mnuOptionsByContextDescribe"
-        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(137, 22)
+        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextDescribe.Text = "Describe"
         '
         'mnuOptionsByContextDescribeCompareTwoTreatments
@@ -4993,7 +5073,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextModelFitModel, Me.mnuOptionsByContextGeneralFitModel})
         Me.mnuOptionsByContextModel.Name = "mnuOptionsByContextModel"
-        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(137, 22)
+        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextModel.Text = "Model"
         '
         'mnuOptionsByContextModelFitModel
@@ -5012,7 +5092,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextCropModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCropModelApsimxExamples})
         Me.mnuOptionsByContextCropModel.Name = "mnuOptionsByContextCropModel"
-        Me.mnuOptionsByContextCropModel.Size = New System.Drawing.Size(137, 22)
+        Me.mnuOptionsByContextCropModel.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextCropModel.Text = "Crop Model"
         '
         'mnuOptionsByContextCropModelApsimxExamples
@@ -5508,93 +5588,6 @@ Partial Class frmMain
         Me.mnuLogFile.Size = New System.Drawing.Size(180, 22)
         Me.mnuLogFile.Text = "Log Window..."
         Me.mnuLogFile.ToolTipText = "Log Window"
-        '
-        'PrepareToolStripMenuItem1
-        '
-        Me.PrepareToolStripMenuItem1.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.VisualizeToolStripMenuItem, Me.PivotTablesToolStripMenuItem, Me.OneVariableToolStripMenuItem, Me.DuplicatesKeyVariableCheckToolStripMenuItem})
-        Me.PrepareToolStripMenuItem1.Name = "PrepareToolStripMenuItem1"
-        Me.PrepareToolStripMenuItem1.Size = New System.Drawing.Size(201, 22)
-        Me.PrepareToolStripMenuItem1.Text = "Prepare"
-        '
-        'VisualizeToolStripMenuItem
-        '
-        Me.VisualizeToolStripMenuItem.Name = "VisualizeToolStripMenuItem"
-        Me.VisualizeToolStripMenuItem.Size = New System.Drawing.Size(240, 22)
-        Me.VisualizeToolStripMenuItem.Text = "Visualize"
-        '
-        'PivotTablesToolStripMenuItem
-        '
-        Me.PivotTablesToolStripMenuItem.Name = "PivotTablesToolStripMenuItem"
-        Me.PivotTablesToolStripMenuItem.Size = New System.Drawing.Size(240, 22)
-        Me.PivotTablesToolStripMenuItem.Text = "Pivot Tables"
-        '
-        'OneVariableToolStripMenuItem
-        '
-        Me.OneVariableToolStripMenuItem.Name = "OneVariableToolStripMenuItem"
-        Me.OneVariableToolStripMenuItem.Size = New System.Drawing.Size(240, 22)
-        Me.OneVariableToolStripMenuItem.Text = "One Variable"
-        '
-        'DuplicatesKeyVariableCheckToolStripMenuItem
-        '
-        Me.DuplicatesKeyVariableCheckToolStripMenuItem.Name = "DuplicatesKeyVariableCheckToolStripMenuItem"
-        Me.DuplicatesKeyVariableCheckToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
-        Me.DuplicatesKeyVariableCheckToolStripMenuItem.Text = "Duplicates (Key Variable Check)"
-        '
-        'TwoThreeVariableToolStripMenuItem
-        '
-        Me.TwoThreeVariableToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.GraphSummariseToolStripMenuItem})
-        Me.TwoThreeVariableToolStripMenuItem.Name = "TwoThreeVariableToolStripMenuItem"
-        Me.TwoThreeVariableToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.TwoThreeVariableToolStripMenuItem.Text = "Two/ Three Variable"
-        '
-        'GraphSummariseToolStripMenuItem
-        '
-        Me.GraphSummariseToolStripMenuItem.Name = "GraphSummariseToolStripMenuItem"
-        Me.GraphSummariseToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.GraphSummariseToolStripMenuItem.Text = "graph summarise"
-        '
-        'OptionalMenuToolStripMenuItem
-        '
-        Me.OptionalMenuToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.StructuredToolStripMenuItem1, Me.ClimaticToolStripMenuItem1, Me.ProcurementToolStripMenuItem1, Me.ExperimentsToolStripMenuItem1, Me.TricotMenuToolStripMenuItem, Me.TricotXPMenuToolStripMenuItem})
-        Me.OptionalMenuToolStripMenuItem.Name = "OptionalMenuToolStripMenuItem"
-        Me.OptionalMenuToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
-        Me.OptionalMenuToolStripMenuItem.Text = "Optional Menu"
-        '
-        'StructuredToolStripMenuItem1
-        '
-        Me.StructuredToolStripMenuItem1.Name = "StructuredToolStripMenuItem1"
-        Me.StructuredToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.StructuredToolStripMenuItem1.Text = "Structured"
-        '
-        'ClimaticToolStripMenuItem1
-        '
-        Me.ClimaticToolStripMenuItem1.Name = "ClimaticToolStripMenuItem1"
-        Me.ClimaticToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.ClimaticToolStripMenuItem1.Text = "Climatic"
-        '
-        'ProcurementToolStripMenuItem1
-        '
-        Me.ProcurementToolStripMenuItem1.Name = "ProcurementToolStripMenuItem1"
-        Me.ProcurementToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.ProcurementToolStripMenuItem1.Text = "Procurement"
-        '
-        'ExperimentsToolStripMenuItem1
-        '
-        Me.ExperimentsToolStripMenuItem1.Name = "ExperimentsToolStripMenuItem1"
-        Me.ExperimentsToolStripMenuItem1.Size = New System.Drawing.Size(180, 22)
-        Me.ExperimentsToolStripMenuItem1.Text = "Experiments"
-        '
-        'TricotMenuToolStripMenuItem
-        '
-        Me.TricotMenuToolStripMenuItem.Name = "TricotMenuToolStripMenuItem"
-        Me.TricotMenuToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.TricotMenuToolStripMenuItem.Text = "Tricot Menu"
-        '
-        'TricotXPMenuToolStripMenuItem
-        '
-        Me.TricotXPMenuToolStripMenuItem.Name = "TricotXPMenuToolStripMenuItem"
-        Me.TricotXPMenuToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
-        Me.TricotXPMenuToolStripMenuItem.Text = "Tricot XP Menu"
         '
         'frmMain
         '
@@ -6326,7 +6319,6 @@ Partial Class frmMain
     Friend WithEvents mnuTricotImportFromClimMob As ToolStripMenuItem
     Friend WithEvents mnuTricotTransformClimMob As ToolStripMenuItem
     Friend WithEvents mnuTricotDefineTricotData As ToolStripMenuItem
-    Friend WithEvents mnuTricotGenotypeData As ToolStripMenuItem
     Friend WithEvents ToolStripSeparator20 As ToolStripSeparator
     Friend WithEvents mnuTricotDescribe As ToolStripMenuItem
     Friend WithEvents mnuTricotDescribeTraits As ToolStripMenuItem

--- a/instat/frmMain.resx
+++ b/instat/frmMain.resx
@@ -136,7 +136,7 @@
   <data name="mnuLastGraph.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAASDSURBVEhLvZd/TBtlGMdPE/ePM4txOGBsRreiBOhPWlqg
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAASDSURBVEhLvZd/TBtlGMdPE/ePM4txOGBsRreiBOhPWlqg
         QIFhtqGMyBIWMxPNlqh/zJkYjHEmaiDVJSyTkGUUF0OiiQPDMtlctuGcM3MDSmlhI4FQ2OJglMKgP7je
         lV6/5t5Cy11pwQh8/rm753nf+977vM/7vO9RWGBikoO1bx5AcNG0rlCLN3XfuaHINW+88IXfaGQX9Qq9
         6wgRdrkD2F8yhKwcy8aOeNzBIi35CmRZ6xVqPnc4gSUc6uEpGnmlfQLn/yeI5vNuZL10EwVF9+BjmLCH
@@ -162,7 +162,7 @@
   <data name="mnuMetadata.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAG8AAABvCAYAAADixZ5gAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAlGSURBVHhe7V1La1VXGD0RhFbwBTGodCL4gD4sFCTE1x9w
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAlGSURBVHhe7V1La1VXGD0RhFbwBTGodCL4gD4sFCTE1x9w
         oJhQO6+aUC06Ep10oJhJO2ixFIpaRaG2Kn0MrLU6sFJLO5HEDPpAW1rpRBNNxCQ3RrPLOu01N9/e997v
         O3vvc/dOzoIFNX7nW99ey+bec+4+5yaqQLRI6A8KxIMivIhRhBcxivAiRhFexCjCixhFeBEjU3ijo6Oq
         s7NTNTU1qSRJCmYk/IOP8DMLxOE9ePBAtbW1aYMUzE74ef/+fWp1XYjCGxkZUa2trZp4QXvC1+HhYWp5

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1685,7 +1685,7 @@ Public Class frmMain
         SetToDefaultLayout()
     End Sub
 
-    Private Sub ucrDataViewer_Enter(sender As Object, e As EventArgs) Handles ucrDataViewer.Enter
+    Private Sub ucrDataViewer_Enter(sender As Object, e As EventArgs)
         ctrActive = ucrDataViewer
     End Sub
 
@@ -1693,11 +1693,11 @@ Public Class frmMain
         ctrActive = ucrOutput
     End Sub
 
-    Private Sub ucrColumnMeta_Enter(sender As Object, e As EventArgs) Handles ucrColumnMeta.Enter
+    Private Sub ucrColumnMeta_Enter(sender As Object, e As EventArgs)
         ctrActive = ucrColumnMeta
     End Sub
 
-    Private Sub ucrDataFrameMeta_Enter(sender As Object, e As EventArgs) Handles ucrDataFrameMeta.Enter
+    Private Sub ucrDataFrameMeta_Enter(sender As Object, e As EventArgs)
         ctrActive = ucrDataFrameMeta
     End Sub
 

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -2940,21 +2940,13 @@ Public Class frmMain
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "17")
     End Sub
 
-    Private Sub StructuredToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles StructuredToolStripMenuItem.Click
+    Private Sub StructuredToolStripMenuItem_Click(sender As Object, e As EventArgs)
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "454")
     End Sub
 
-    Private Sub ClimaticToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ClimaticToolStripMenuItem.Click
-        Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "19")
-    End Sub
 
-    Private Sub ProcurementToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ProcurementToolStripMenuItem.Click
-        Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "498")
-    End Sub
 
-    Private Sub ExperimentsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ExperimentsToolStripMenuItem.Click
-        Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "570")
-    End Sub
+
 
     Private Sub ToolsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ToolsToolStripMenuItem.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "8")
@@ -3048,5 +3040,29 @@ Public Class frmMain
 
     Private Sub mnuTricotModelOverall_Click(sender As Object, e As EventArgs) Handles mnuTricotModelOverall.Click
         dlgTricotModelOneVarCov.ShowDialog()
+    End Sub
+
+    Private Sub StructuredToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles StructuredToolStripMenuItem1.Click
+        Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "454")
+    End Sub
+
+    Private Sub ClimaticToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles ClimaticToolStripMenuItem1.Click
+        Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "19")
+    End Sub
+
+    Private Sub ProcurementToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles ProcurementToolStripMenuItem1.Click
+        Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "498")
+    End Sub
+
+    Private Sub ExperimentsToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles ExperimentsToolStripMenuItem1.Click
+        Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "570")
+    End Sub
+
+    Private Sub TricotMenuToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles TricotMenuToolStripMenuItem.Click
+        Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "669")
+    End Sub
+
+    Private Sub TricotXPMenuToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles TricotXPMenuToolStripMenuItem.Click
+        Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "729")
     End Sub
 End Class

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -2920,23 +2920,23 @@ Public Class frmMain
     Private Sub mnuDescribePresentation_Click(sender As Object, e As EventArgs) Handles mnuDescribePresentation.Click
         dlgGeneralTable.ShowDialog()
     End Sub
-    Private Sub FileToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles FileToolStripMenuItem.Click
+    Private Sub FileToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuFileHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "13")
     End Sub
 
-    Private Sub EditToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles EditToolStripMenuItem.Click
+    Private Sub EditToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuEditHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "7")
     End Sub
 
-    Private Sub PrepareToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles PrepareToolStripMenuItem.Click
+    Private Sub PrepareToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuPrepareHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "9")
     End Sub
 
-    Private Sub DescribeToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles DescribeToolStripMenuItem.Click
+    Private Sub DescribeToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuDescribeHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "18")
     End Sub
 
-    Private Sub ModelToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ModelToolStripMenuItem.Click
+    Private Sub ModelToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuModelHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "17")
     End Sub
 
@@ -2948,15 +2948,15 @@ Public Class frmMain
 
 
 
-    Private Sub ToolsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ToolsToolStripMenuItem.Click
+    Private Sub ToolsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuToolsHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "8")
     End Sub
 
-    Private Sub ViewToolStripMenuItem_Click_1(sender As Object, e As EventArgs) Handles ViewToolStripMenuItem.Click
+    Private Sub ViewToolStripMenuItem_Click_1(sender As Object, e As EventArgs) Handles mnuViewHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "21")
     End Sub
 
-    Private Sub MenusAndDialogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles MenusAndDialogsToolStripMenuItem.Click
+    Private Sub MenusAndDialogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuMenusHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "12")
     End Sub
 
@@ -3042,27 +3042,57 @@ Public Class frmMain
         dlgTricotModelOneVarCov.ShowDialog()
     End Sub
 
-    Private Sub StructuredToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles StructuredToolStripMenuItem1.Click
+    Private Sub StructuredToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles mnuStructuredHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "454")
     End Sub
 
-    Private Sub ClimaticToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles ClimaticToolStripMenuItem1.Click
+    Private Sub ClimaticToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles mnuClimaticHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "19")
     End Sub
 
-    Private Sub ProcurementToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles ProcurementToolStripMenuItem1.Click
+    Private Sub ProcurementToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles mnuProcurementHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "498")
     End Sub
 
-    Private Sub ExperimentsToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles ExperimentsToolStripMenuItem1.Click
+    Private Sub ExperimentsToolStripMenuItem1_Click(sender As Object, e As EventArgs) Handles mnuExperimentsHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "570")
     End Sub
 
-    Private Sub TricotMenuToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles TricotMenuToolStripMenuItem.Click
+    Private Sub TricotMenuToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuTricotMenuHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "669")
     End Sub
 
-    Private Sub TricotXPMenuToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles TricotXPMenuToolStripMenuItem.Click
+    Private Sub TricotXPMenuToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuTricotXPMenuHelp.Click
         Help.ShowHelp(Me, strStaticPath & "\" & strHelpFilePath, HelpNavigator.TopicId, "729")
+    End Sub
+
+    Private Sub Summarise23VariablesToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuSummariseTricot.Click
+        dlgDescribeTwoVariable.enumTwovariableMode = dlgDescribeTwoVariable.TwovariableMode.Climatic
+        dlgDescribeTwoVariable.ShowDialog()
+    End Sub
+
+    Private Sub mnuDescribeGraphTricots_Click(sender As Object, e As EventArgs) Handles mnuDescribeGraphTricots.Click
+        dlgDescribeTwoVarGraph.enumTwovarMode = dlgDescribeTwoVarGraph.TwovarMode.Climatic
+        dlgDescribeTwoVarGraph.ShowDialog()
+    End Sub
+
+    Private Sub mnuTidyAddMergeColumns_Click(sender As Object, e As EventArgs) Handles mnuTidyAddMergeColumns.Click
+        dlgMergeAdditionalData.enumMergeMode = dlgMergeAdditionalData.MergeMode.Climatic
+        dlgMergeAdditionalData.ShowDialog()
+    End Sub
+
+    Private Sub DuplicateRowsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles mnuTidyDuplicateRows.Click
+        dlgDuplicateRows.enumDuplicateMode = dlgDuplicateRows.DuplicateMode.Climatic
+        dlgDuplicateRows.ShowDialog()
+    End Sub
+
+    Private Sub AddKeyToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles AddKeyToolStripMenuItem.Click
+        dlgAddKey.enumAddkeyMode = dlgAddKey.AddkeyMode.Climatic
+        dlgAddKey.ShowDialog()
+    End Sub
+
+    Private Sub mnuVisualizeTricot_Click(sender As Object, e As EventArgs) Handles mnuVisualizeTricot.Click
+        dlgVisualizeData.enumVisualizeMode = dlgVisualizeData.VisualizeMode.Describe
+        dlgVisualizeData.ShowDialog()
     End Sub
 End Class

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1685,7 +1685,7 @@ Public Class frmMain
         SetToDefaultLayout()
     End Sub
 
-    Private Sub ucrDataViewer_Enter(sender As Object, e As EventArgs)
+    Private Sub ucrDataViewer_Enter(sender As Object, e As EventArgs) Handles ucrDataViewer.Enter
         ctrActive = ucrDataViewer
     End Sub
 
@@ -1693,11 +1693,11 @@ Public Class frmMain
         ctrActive = ucrOutput
     End Sub
 
-    Private Sub ucrColumnMeta_Enter(sender As Object, e As EventArgs)
+    Private Sub ucrColumnMeta_Enter(sender As Object, e As EventArgs) Handles ucrColumnMeta.Enter
         ctrActive = ucrColumnMeta
     End Sub
 
-    Private Sub ucrDataFrameMeta_Enter(sender As Object, e As EventArgs)
+    Private Sub ucrDataFrameMeta_Enter(sender As Object, e As EventArgs) Handles ucrDataFrameMeta.Enter
         ctrActive = ucrDataFrameMeta
     End Sub
 


### PR DESCRIPTION
@rdstern I have implemented what we discussed, please check
Help menu -  deleted "and dialogues", so it just says Menus. Keep the Menus and Dialogues as they are, within the sub-menu.
Optional help menu should have the same order of the items as the view menu.

Tricot > Describe and added 2 extra elements.


Added a second new menu called Tidy. This has 4 entries as follows:

Finally deleted the menu item Genotype Data...