### PR TITLE
Allowed Proportion and count input to accept factor labels.

### DIFF
--- a/instat/sdgSummaries.vb
+++ b/instat/sdgSummaries.vb
@@ -217,8 +217,7 @@ Public Class sdgSummaries
         ucrInputComboPropTest.SetDropDownStyleAsNonEditable()
 
         ucrInputPropValue.SetParameter(New RParameter("prop_value", 6))
-        ucrInputPropValue.SetValidationTypeAsNumeric()
-        ucrInputPropValue.AddQuotesIfUnrecognised = False
+
 
         ucrInputComboCountTest.SetParameter(New RParameter("count_test", 7))
         Dim dctCountTest As New Dictionary(Of String, String)
@@ -231,8 +230,7 @@ Public Class sdgSummaries
         ucrInputComboCountTest.SetDropDownStyleAsNonEditable()
 
         ucrInputCountValue.SetParameter(New RParameter("count_value", 8))
-        ucrInputCountValue.SetValidationTypeAsNumeric()
-        ucrInputCountValue.AddQuotesIfUnrecognised = False
+
 
         ucrChkProportion.SetParameter(New RParameter("proportion_calc", 42), bNewChangeParameterValue:=True, bNewAddRemoveParameter:=True, strNewValueIfChecked:=Chr(34) & "proportion_calc" & Chr(34), strNewValueIfUnchecked:=Chr(34) & Chr(34))
         ucrChkProportion.SetText("Proportion")
@@ -441,9 +439,9 @@ Public Class sdgSummaries
             ucrPnlPosition.SetRCode(clsDummyFunction, bReset)
         End If
         ucrChkPercentage.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
-        ucrInputPropValue.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
+
         ucrInputComboPropTest.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
-        ucrInputCountValue.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
+
         ucrInputComboCountTest.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
         ucrInputPercentile.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
         ucrNudFraction.SetRCode(clsDefaultFunction, bReset, bCloneIfNeeded:=True)
@@ -455,7 +453,7 @@ Public Class sdgSummaries
 
         ucrChkCount.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkProportion.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
-        ucrChkPercentile.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
+
         ucrChkTrimmedMean.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkNTotal.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkNonMissing.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
@@ -467,6 +465,8 @@ Public Class sdgSummaries
             ucrChkWhichmin.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
             ucrChkWhereMax.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
             ucrChkWhereMin.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
+            ucrChkPercentile.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
+            ucrChkQuantile.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         End If
         ucrChkMode.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkMaximum.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
@@ -508,7 +508,7 @@ Public Class sdgSummaries
         ucrChkMax.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkQ1.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkQ3.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
-        ucrChkQuantile.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
+
         ucrChkSd.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkVar.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
         ucrChkAngVar.SetRCode(clsListFunction, bReset, bCloneIfNeeded:=True)
@@ -701,6 +701,36 @@ Public Class sdgSummaries
             clsDefaultFunction.AddParameter("summary_where_y", ucrReceiverInclude.GetVariableNames, iPosition:=2)
         Else
             clsDefaultFunction.RemoveParameterByName("summary_where_y")
+        End If
+    End Sub
+
+    Private Sub ucrInputPropValue_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputPropValue.ControlValueChanged, ucrChkProportion.ControlValueChanged
+
+        Dim strValue As String = ucrInputPropValue.GetText()
+
+        If ucrChkProportion.Checked AndAlso Not ucrInputPropValue.IsEmpty Then
+            If IsNumeric(strValue) Then
+                clsDefaultFunction.AddParameter("prop_value", strValue, iPosition:=6)
+            Else
+                clsDefaultFunction.AddParameter("prop_value", Chr(34) & "'" & strValue & "'" & Chr(34), iPosition:=6)
+            End If
+        Else
+            clsDefaultFunction.RemoveParameterByName("prop_value")
+        End If
+    End Sub
+
+    Private Sub ucrInputCountValue_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputCountValue.ControlValueChanged, ucrChkCount.ControlValueChanged
+
+        Dim strValue As String = ucrInputCountValue.GetText()
+
+        If ucrChkCount.Checked AndAlso Not ucrInputCountValue.IsEmpty Then
+            If IsNumeric(strValue) Then
+                clsDefaultFunction.AddParameter("count_value", strValue, iPosition:=8)
+            Else
+                clsDefaultFunction.AddParameter("count_value", Chr(34) & "'" & strValue & "'" & Chr(34), iPosition:=8)
+            End If
+        Else
+            clsDefaultFunction.RemoveParameterByName("count_value")
         End If
     End Sub
 


### PR DESCRIPTION
Fixes #9440 
First in the proportion and count, at the prepare data dialogue we were limited to numeric only and not neither factors or ordered factors and that check needed to be removed.

Its now working for  both ordered factors and factor labels for proportion and count and not limited like before
you just need to update the databook.
![collumn_summary](https://github.com/user-attachments/assets/95e4b0c1-9f32-4583-bd32-140e0973e9be)
![erro](https://github.com/user-attachments/assets/2ae2cf82-9fc1-4e32-b6a9-18b23ee6ca59)


@rdstern  I have implemented what we discussed
@lilyclements kindly review