### PR TITLE
Added New Table before Option for Selected R-Instat Dialogs

### DIFF
--- a/instat/UserTables/dlgGeneralTable.vb
+++ b/instat/UserTables/dlgGeneralTable.vb
@@ -23,8 +23,17 @@ Public Class dlgGeneralTable
     End Sub
 
     Private Sub btnMoreOptions_Click(sender As Object, e As EventArgs) Handles btnMoreOptions.Click
-        sdgTableOptions.Setup(ucrSelectorCols.strCurrentDataFrame, clsBaseOperator)
-        sdgTableOptions.ShowDialog(Me)
+        If rdoSingle.Checked Then
+            sdgBeforeTablesOption.Setup(ucrSelectorCols.strCurrentDataFrame, clsBaseOperator)
+            sdgBeforeTablesOption.ShowDialog(Me)
+        ElseIf rdoMultiple.Checked Then
+            sdgBeforeTablesOption.Setup(ucrSelectorCols.strCurrentDataFrame, clsBaseOperator)
+            sdgBeforeTablesOption.ShowDialog(Me)
+        Else
+            sdgTableOptions.Setup(ucrSelectorCols.strCurrentDataFrame, clsBaseOperator)
+            sdgTableOptions.ShowDialog(Me)
+        End If
+
         ucrInputTitle.SetText(sdgTableOptions.ucrHeader.ucrInputTitle.GetText)
         ucrInputTitleFooter.SetText(sdgTableOptions.ucrHeader.ucrInputTitleFooter.GetText)
         ucrCboSelectThemes.SetText(sdgTableOptions.ucrCboSelectThemes.GetText)

--- a/instat/UserTables/sdgBeforeTablesOption.Designer.vb
+++ b/instat/UserTables/sdgBeforeTablesOption.Designer.vb
@@ -1,0 +1,216 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class sdgBeforeTablesOption
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.tbpFormatOptions = New System.Windows.Forms.TabControl()
+        Me.tbpHeader = New System.Windows.Forms.TabPage()
+        Me.ucrHeader = New instat.ucrHeader()
+        Me.tbpSourceNotes = New System.Windows.Forms.TabPage()
+        Me.ucrSourceNotes = New instat.ucrSourceNotes()
+        Me.tbpThemes = New System.Windows.Forms.TabPage()
+        Me.ucrChkSelectTheme = New instat.ucrCheck()
+        Me.ucrChkManualTheme = New instat.ucrCheck()
+        Me.ucrCboSelectThemes = New instat.ucrInputComboBox()
+        Me.btnManualTheme = New System.Windows.Forms.Button()
+        Me.tbpOtherStyles = New System.Windows.Forms.TabPage()
+        Me.ucrOtherStyles = New instat.ucrOtherStyles()
+        Me.ucrSdgBaseButtons = New instat.ucrButtonsSubdialogue()
+        Me.tbpFormatOptions.SuspendLayout()
+        Me.tbpHeader.SuspendLayout()
+        Me.tbpSourceNotes.SuspendLayout()
+        Me.tbpThemes.SuspendLayout()
+        Me.tbpOtherStyles.SuspendLayout()
+        Me.SuspendLayout()
+        '
+        'tbpFormatOptions
+        '
+        Me.tbpFormatOptions.Controls.Add(Me.tbpHeader)
+        Me.tbpFormatOptions.Controls.Add(Me.tbpSourceNotes)
+        Me.tbpFormatOptions.Controls.Add(Me.tbpThemes)
+        Me.tbpFormatOptions.Controls.Add(Me.tbpOtherStyles)
+        Me.tbpFormatOptions.Location = New System.Drawing.Point(2, 1)
+        Me.tbpFormatOptions.Name = "tbpFormatOptions"
+        Me.tbpFormatOptions.SelectedIndex = 0
+        Me.tbpFormatOptions.Size = New System.Drawing.Size(645, 389)
+        Me.tbpFormatOptions.TabIndex = 6
+        '
+        'tbpHeader
+        '
+        Me.tbpHeader.Controls.Add(Me.ucrHeader)
+        Me.tbpHeader.Location = New System.Drawing.Point(4, 22)
+        Me.tbpHeader.Name = "tbpHeader"
+        Me.tbpHeader.Padding = New System.Windows.Forms.Padding(3)
+        Me.tbpHeader.Size = New System.Drawing.Size(637, 363)
+        Me.tbpHeader.TabIndex = 0
+        Me.tbpHeader.Text = "Header"
+        Me.tbpHeader.UseVisualStyleBackColor = True
+        '
+        'ucrHeader
+        '
+        Me.ucrHeader.Location = New System.Drawing.Point(7, 6)
+        Me.ucrHeader.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrHeader.Name = "ucrHeader"
+        Me.ucrHeader.Size = New System.Drawing.Size(601, 300)
+        Me.ucrHeader.TabIndex = 16
+        '
+        'tbpSourceNotes
+        '
+        Me.tbpSourceNotes.Controls.Add(Me.ucrSourceNotes)
+        Me.tbpSourceNotes.Location = New System.Drawing.Point(4, 22)
+        Me.tbpSourceNotes.Name = "tbpSourceNotes"
+        Me.tbpSourceNotes.Size = New System.Drawing.Size(637, 363)
+        Me.tbpSourceNotes.TabIndex = 4
+        Me.tbpSourceNotes.Text = "Source Notes"
+        Me.tbpSourceNotes.UseVisualStyleBackColor = True
+        '
+        'ucrSourceNotes
+        '
+        Me.ucrSourceNotes.Location = New System.Drawing.Point(7, 7)
+        Me.ucrSourceNotes.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrSourceNotes.Name = "ucrSourceNotes"
+        Me.ucrSourceNotes.Size = New System.Drawing.Size(581, 190)
+        Me.ucrSourceNotes.TabIndex = 0
+        '
+        'tbpThemes
+        '
+        Me.tbpThemes.Controls.Add(Me.ucrChkSelectTheme)
+        Me.tbpThemes.Controls.Add(Me.ucrChkManualTheme)
+        Me.tbpThemes.Controls.Add(Me.ucrCboSelectThemes)
+        Me.tbpThemes.Controls.Add(Me.btnManualTheme)
+        Me.tbpThemes.Location = New System.Drawing.Point(4, 22)
+        Me.tbpThemes.Margin = New System.Windows.Forms.Padding(2)
+        Me.tbpThemes.Name = "tbpThemes"
+        Me.tbpThemes.Size = New System.Drawing.Size(637, 363)
+        Me.tbpThemes.TabIndex = 6
+        Me.tbpThemes.Text = "Themes"
+        Me.tbpThemes.UseVisualStyleBackColor = True
+        '
+        'ucrChkSelectTheme
+        '
+        Me.ucrChkSelectTheme.AutoSize = True
+        Me.ucrChkSelectTheme.Checked = False
+        Me.ucrChkSelectTheme.Location = New System.Drawing.Point(17, 19)
+        Me.ucrChkSelectTheme.Margin = New System.Windows.Forms.Padding(2)
+        Me.ucrChkSelectTheme.Name = "ucrChkSelectTheme"
+        Me.ucrChkSelectTheme.Size = New System.Drawing.Size(121, 23)
+        Me.ucrChkSelectTheme.TabIndex = 29
+        '
+        'ucrChkManualTheme
+        '
+        Me.ucrChkManualTheme.AutoSize = True
+        Me.ucrChkManualTheme.Checked = False
+        Me.ucrChkManualTheme.Location = New System.Drawing.Point(17, 59)
+        Me.ucrChkManualTheme.Margin = New System.Windows.Forms.Padding(2)
+        Me.ucrChkManualTheme.Name = "ucrChkManualTheme"
+        Me.ucrChkManualTheme.Size = New System.Drawing.Size(121, 23)
+        Me.ucrChkManualTheme.TabIndex = 28
+        '
+        'ucrCboSelectThemes
+        '
+        Me.ucrCboSelectThemes.AddQuotesIfUnrecognised = True
+        Me.ucrCboSelectThemes.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrCboSelectThemes.GetSetSelectedIndex = -1
+        Me.ucrCboSelectThemes.IsReadOnly = False
+        Me.ucrCboSelectThemes.Location = New System.Drawing.Point(153, 19)
+        Me.ucrCboSelectThemes.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrCboSelectThemes.Name = "ucrCboSelectThemes"
+        Me.ucrCboSelectThemes.Size = New System.Drawing.Size(150, 21)
+        Me.ucrCboSelectThemes.TabIndex = 3
+        '
+        'btnManualTheme
+        '
+        Me.btnManualTheme.Location = New System.Drawing.Point(154, 60)
+        Me.btnManualTheme.Margin = New System.Windows.Forms.Padding(2)
+        Me.btnManualTheme.Name = "btnManualTheme"
+        Me.btnManualTheme.Size = New System.Drawing.Size(149, 21)
+        Me.btnManualTheme.TabIndex = 2
+        Me.btnManualTheme.Text = "Custom Theme"
+        Me.btnManualTheme.UseVisualStyleBackColor = True
+        '
+        'tbpOtherStyles
+        '
+        Me.tbpOtherStyles.Controls.Add(Me.ucrOtherStyles)
+        Me.tbpOtherStyles.Location = New System.Drawing.Point(4, 22)
+        Me.tbpOtherStyles.Name = "tbpOtherStyles"
+        Me.tbpOtherStyles.Padding = New System.Windows.Forms.Padding(3)
+        Me.tbpOtherStyles.Size = New System.Drawing.Size(637, 363)
+        Me.tbpOtherStyles.TabIndex = 10
+        Me.tbpOtherStyles.Text = "Other Styles"
+        Me.tbpOtherStyles.UseVisualStyleBackColor = True
+        '
+        'ucrOtherStyles
+        '
+        Me.ucrOtherStyles.Location = New System.Drawing.Point(8, 7)
+        Me.ucrOtherStyles.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrOtherStyles.Name = "ucrOtherStyles"
+        Me.ucrOtherStyles.Size = New System.Drawing.Size(326, 179)
+        Me.ucrOtherStyles.TabIndex = 0
+        '
+        'ucrSdgBaseButtons
+        '
+        Me.ucrSdgBaseButtons.AutoSize = True
+        Me.ucrSdgBaseButtons.Location = New System.Drawing.Point(195, 401)
+        Me.ucrSdgBaseButtons.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrSdgBaseButtons.Name = "ucrSdgBaseButtons"
+        Me.ucrSdgBaseButtons.Size = New System.Drawing.Size(224, 30)
+        Me.ucrSdgBaseButtons.TabIndex = 344
+        '
+        'sdgBeforeTablesOption
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(648, 438)
+        Me.Controls.Add(Me.ucrSdgBaseButtons)
+        Me.Controls.Add(Me.tbpFormatOptions)
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.MaximizeBox = False
+        Me.MinimizeBox = False
+        Me.Name = "sdgBeforeTablesOption"
+        Me.ShowIcon = False
+        Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent
+        Me.Text = "Tables Option"
+        Me.tbpFormatOptions.ResumeLayout(False)
+        Me.tbpHeader.ResumeLayout(False)
+        Me.tbpSourceNotes.ResumeLayout(False)
+        Me.tbpThemes.ResumeLayout(False)
+        Me.tbpThemes.PerformLayout()
+        Me.tbpOtherStyles.ResumeLayout(False)
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents tbpFormatOptions As TabControl
+    Friend WithEvents tbpHeader As TabPage
+    Friend WithEvents ucrHeader As ucrHeader
+    Friend WithEvents tbpSourceNotes As TabPage
+    Friend WithEvents ucrSourceNotes As ucrSourceNotes
+    Friend WithEvents tbpThemes As TabPage
+    Friend WithEvents ucrChkSelectTheme As ucrCheck
+    Friend WithEvents ucrChkManualTheme As ucrCheck
+    Friend WithEvents ucrCboSelectThemes As ucrInputComboBox
+    Friend WithEvents btnManualTheme As Button
+    Friend WithEvents tbpOtherStyles As TabPage
+    Friend WithEvents ucrOtherStyles As ucrOtherStyles
+    Friend WithEvents ucrSdgBaseButtons As ucrButtonsSubdialogue
+End Class

--- a/instat/UserTables/sdgBeforeTablesOption.resx
+++ b/instat/UserTables/sdgBeforeTablesOption.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/instat/UserTables/sdgBeforeTablesOption.vb
+++ b/instat/UserTables/sdgBeforeTablesOption.vb
@@ -1,0 +1,156 @@
+﻿' R- Instat
+' Copyright (C) 2015-2017
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License 
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Imports instat.Translations
+
+Public Class sdgBeforeTablesOption
+
+    Private clsOperator As ROperator
+    Private clsThemeRFunction As RFunction
+    Private bFirstload As Boolean = True
+
+    Private Sub sdgBeforeTablesOption_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        If bFirstload Then
+            InitialiseDialog()
+            bFirstload = False
+            'adding these  because it's ignored on first load
+            ucrCboSelectThemes.SetText(dlgGeneralTable.ucrCboSelectThemes.GetText)
+        End If
+        autoTranslate(Me)
+    End Sub
+
+    Private Sub InitialiseDialog()
+        ucrSdgBaseButtons.iHelpTopicID = 146
+        ucrChkSelectTheme.Checked = True
+        ucrChkSelectTheme.SetText("Select Theme")
+        ucrChkManualTheme.SetText("Manual Theme")
+
+        ucrCboSelectThemes.SetItems({"None", "Dark Theme", "538 Theme", "Dot Matrix Theme", "Espn Theme", "Excel Theme", "Guardian Theme", "NY Times Theme", "PFF Theme"})
+        ucrCboSelectThemes.SetDropDownStyleAsNonEditable()
+    End Sub
+
+    ''' <summary>
+    ''' Sets up the sub dialog, this is the simpler version of the main sdgTableOptions dialog but has only 4 options.
+    ''' Expected to be called before showing the dialog. 
+    ''' </summary>
+    ''' <param name="strDataFrameName">Name of the data frame contained in the data book</param>
+    ''' <param name="clsNewOperator">R operator that has a 'gt' parameter that produces a 'gt' object.</param>
+    Public Sub Setup(strDataFrameName As String, clsNewOperator As ROperator)
+        clsOperator = clsNewOperator
+
+        ucrHeader.Setup(clsOperator)
+        ucrSourceNotes.Setup(clsOperator)
+        ucrOtherStyles.Setup(clsOperator)
+
+        ucrHeader.ucrInputTitle.SetText(dlgGeneralTable.ucrInputTitle.GetText)
+        ucrHeader.ucrInputTitleFooter.SetText(dlgGeneralTable.ucrInputTitleFooter.GetText)
+        ucrCboSelectThemes.SetText(dlgGeneralTable.ucrCboSelectThemes.GetText)
+        ucrChkSelectTheme.Checked = dlgGeneralTable.ucrChkSelectTheme.Checked
+        sdgTableStyles.GetNewUserInputAsRFunction()
+        SetupTheme(clsOperator)
+    End Sub
+
+    Private Sub ucrSdgBaseButtons_ClickReturn(sender As Object, e As EventArgs) Handles ucrSdgBaseButtons.ClickReturn
+        ucrHeader.SetValuesToOperator()
+        ucrSourceNotes.SetValuesToOperator()
+        ucrOtherStyles.SetValuesToOperator()
+        SetThemeValuesOnReturn(clsOperator)
+    End Sub
+
+    '-----------------------------------------
+    ' Themes
+
+    Private Sub SetupTheme(clsOperator As ROperator)
+        If clsOperator.ContainsParameter("theme_format") Then
+            clsThemeRFunction = clsOperator.GetParameter("theme_format").clsArgumentCodeStructure
+        Else
+            clsThemeRFunction = New RFunction
+            clsThemeRFunction.SetPackageName("gtExtras")
+        End If
+        If ucrChkManualTheme.Checked Then
+            sdgSummaryThemes.SetRCode(bReset:=True, clsNewThemesTabOption:=clsThemeRFunction)
+        End If
+    End Sub
+
+    Private Sub ucrChkSelectTheme_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkSelectTheme.ControlValueChanged
+        If ucrChkSelectTheme.Checked Then
+            btnManualTheme.Visible = False
+            ucrCboSelectThemes.Visible = True
+        ElseIf ucrChkSelectTheme.Checked Then
+            ucrChkManualTheme.Checked = True
+        Else
+            ucrCboSelectThemes.Visible = False
+        End If
+    End Sub
+
+    Private Sub ucrChkManualTheme_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkManualTheme.ControlValueChanged
+
+        If ucrChkManualTheme.Checked Then
+            btnManualTheme.Visible = True
+            ucrChkSelectTheme.Checked = Not ucrChkManualTheme.Checked
+            btnManualTheme.Visible = ucrChkManualTheme.Checked
+        End If
+    End Sub
+
+    Private Sub btnManualTheme_Click(sender As Object, e As EventArgs) Handles btnManualTheme.Click
+        clsThemeRFunction.SetPackageName("gt")
+        clsThemeRFunction.SetRCommand("tab_options")
+        sdgSummaryThemes.SetRCode(bReset:=True, clsNewThemesTabOption:=clsThemeRFunction)
+        sdgSummaryThemes.ShowDialog(Me)
+    End Sub
+
+    Private Sub ucrCboSelectThemes_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrCboSelectThemes.ControlValueChanged
+
+        If clsThemeRFunction Is Nothing Then
+            Exit Sub
+        End If
+
+        Dim strCommand As String = ""
+        Select Case ucrCboSelectThemes.GetText
+            Case "Dark Theme"
+                strCommand = "gt_theme_dark"
+            Case "538 Theme"
+                strCommand = "gt_theme_538"
+            Case "Dot Matrix Theme"
+                strCommand = "gt_theme_dot_matrix"
+            Case "Espn Theme"
+                strCommand = "gt_theme_espn"
+            Case "Excel Theme"
+                strCommand = "gt_theme_excel"
+            Case "Guardian Theme"
+                strCommand = "gt_theme_guardian"
+            Case "NY Times Theme"
+                strCommand = "gt_theme_nytimes"
+            Case "PFF Theme"
+                strCommand = "gt_theme_pff"
+        End Select
+
+        clsThemeRFunction.SetRCommand(strCommand)
+    End Sub
+
+    Private Sub SetThemeValuesOnReturn(clsOperator As ROperator)
+        ' Set the themes parameter if there was a theme selected
+        If ucrChkManualTheme.Checked Then
+            sdgSummaryThemes.SetRCode(bReset:=True, clsNewThemesTabOption:=clsThemeRFunction)
+        End If
+        If clsThemeRFunction IsNot Nothing AndAlso Not String.IsNullOrEmpty(clsThemeRFunction.strRCommand) Then
+            clsOperator.AddParameter("theme_format", clsRFunctionParameter:=clsThemeRFunction)
+        Else
+            clsOperator.RemoveParameterByName("theme_format")
+        End If
+    End Sub
+    '-----------------------------------------
+End Class

--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -1788,8 +1788,8 @@ Public Class dlgDescribeTwoVariable
     End Sub
 
     Private Sub cmdFormatTable_Click(sender As Object, e As EventArgs) Handles cmdFormatTable.Click
-        sdgTableOptions.Setup(ucrSelectorDescribeTwoVar.strCurrentDataFrame, clsGtTableROperator)
-        sdgTableOptions.ShowDialog(Me)
+        sdgBeforeTablesOption.Setup(ucrSelectorDescribeTwoVar.strCurrentDataFrame, clsGtTableROperator)
+        sdgBeforeTablesOption.ShowDialog(Me)
     End Sub
 
     Private Sub cmdMissingOptions_Click(sender As Object, e As EventArgs) Handles cmdMissingOptions.Click

--- a/instat/dlgOneVariableSummarise.vb
+++ b/instat/dlgOneVariableSummarise.vb
@@ -362,8 +362,8 @@ Public Class dlgOneVariableSummarise
     End Sub
 
     Private Sub cmdTableOptions_Click(sender As Object, e As EventArgs) Handles cmdTableOptions.Click
-        sdgTableOptions.Setup(ucrSelectorOneVarSummarise.strCurrentDataFrame, clsSummaryOperator)
-        sdgTableOptions.ShowDialog(Me)
+        sdgBeforeTablesOption.Setup(ucrSelectorOneVarSummarise.strCurrentDataFrame, clsSummaryOperator)
+        sdgBeforeTablesOption.ShowDialog(Me)
         bResetFormatSubdialog = False
     End Sub
 

--- a/instat/dlgSummaryTables.vb
+++ b/instat/dlgSummaryTables.vb
@@ -324,8 +324,8 @@ Public Class dlgSummaryTables
             Exit Sub
         End If
 
-        sdgTableOptions.Setup(ucrSelectorSummaryTables.strCurrentDataFrame, clsROperator)
-        sdgTableOptions.ShowDialog(Me)
+        sdgBeforeTablesOption.Setup(ucrSelectorSummaryTables.strCurrentDataFrame, clsROperator)
+        sdgBeforeTablesOption.ShowDialog(Me)
 
     End Sub
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -602,6 +602,12 @@
     <Compile Include="UserTables\Rows\ucrRowsGrandSummary.vb">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Include="UserTables\sdgBeforeTablesOption.Designer.vb">
+      <DependentUpon>sdgBeforeTablesOption.vb</DependentUpon>
+    </Compile>
+    <Compile Include="UserTables\sdgBeforeTablesOption.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="UserTables\sdgTableOptions.Designer.vb">
       <DependentUpon>sdgTableOptions.vb</DependentUpon>
     </Compile>
@@ -3672,6 +3678,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="UserTables\Rows\ucrRowsGrandSummary.resx">
       <DependentUpon>ucrRowsGrandSummary.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UserTables\sdgBeforeTablesOption.resx">
+      <DependentUpon>sdgBeforeTablesOption.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="UserTables\sdgTableOptions.resx">
       <DependentUpon>sdgTableOptions.vb</DependentUpon>


### PR DESCRIPTION
Fixes #9851
This PR adds the new dialog for the Tables Option (Before) to the following dialogs;
Describe > One Variable > Summarise
Describe > 2/3 Variables > Summarise
Describe > Tables > Summarise

and the new dialog also appears in the first two options in the Describe > Tables > Presentation, namely;
Single Option 
Multiple Option

@rdstern this is ready for review.
Thanks