### PR TITLE
Removed repeated Factors in Column(s) within the Describe > Tables > …

### DIFF
--- a/instat/dlgSummaryTables.vb
+++ b/instat/dlgSummaryTables.vb
@@ -221,8 +221,8 @@ Public Class dlgSummaryTables
 
         ' Gt function
         Dim clsGtFunction As New RFunction
-        clsGtFunction.SetPackageName("gt")
-        clsGtFunction.SetRCommand("gt")
+        clsGtFunction.SetPackageName("instatExtras")
+        clsGtFunction.SetRCommand("generate_summary_tables")
 
         ClsTabSpannerDelimFunction.SetPackageName("gt")
         ClsTabSpannerDelimFunction.SetRCommand("tab_spanner_delim")


### PR DESCRIPTION
fixes partly issue #9636 
Removed repeated factors in column(s) of Describe>Tables>Summarise>Frequency  dialogue
![Tablesumm](https://github.com/user-attachments/assets/b0134851-8291-483b-b7e7-2f263b52870c)
I have fixed it to this 
![tablesum](https://github.com/user-attachments/assets/7ef7349a-749d-4d6a-895c-7a842b706220)
@rdstern @lilyclements  Kindly check to confirm
@fran2or I have implemented what we discussed