### PR TITLE
Dropdown for replacing Ordered Factors as done in Factors

### DIFF
--- a/instat/dlgEdit.vb
+++ b/instat/dlgEdit.vb
@@ -221,6 +221,12 @@ Public Class dlgEdit
                     bInputLogical = False
                     bDate = False
                     bNewName = False
+                Case "ordered,factor"
+                    ucrInputRows.Visible = True
+                    bInputRow = True
+                    bInputLogical = False
+                    bDate = False
+                    bNewName = False
                 Case "date"
                     ucrDate.Visible = True
                     bInputRow = False


### PR DESCRIPTION
this fixes #9641 
![edit3](https://github.com/user-attachments/assets/c4decdde-9ec5-489f-8cba-1e84f14855a8)
I put a dropdown  for replacing Ordered Factors as done in Factors 
Edit Cell > New Cell

@rdstern I have implemented what we discussed before . Please review 
