### PR TITLE
Added the Table Tab option to the 2 Table Options

### DIFF
--- a/instat/UserTables/Cells/Formats/ucrNewCellFormats.Designer.vb
+++ b/instat/UserTables/Cells/Formats/ucrNewCellFormats.Designer.vb
@@ -1,0 +1,220 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class ucrNewCellFormats
+    Inherits System.Windows.Forms.UserControl
+
+    'UserControl overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.ucrRowExpression = New instat.ucrRowExpression()
+        Me.Label1 = New System.Windows.Forms.Label()
+        Me.Label2 = New System.Windows.Forms.Label()
+        Me.cboSelectFormat = New System.Windows.Forms.ComboBox()
+        Me.ucrReceiverMultipleCols = New instat.ucrReceiverMultiple()
+        Me.lblFormats = New System.Windows.Forms.Label()
+        Me.btnClearFormats = New System.Windows.Forms.Button()
+        Me.lblColumns = New System.Windows.Forms.Label()
+        Me.btnEnterFormat = New System.Windows.Forms.Button()
+        Me.ucrSelectorCols = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.dataGridFormats = New System.Windows.Forms.DataGridView()
+        Me.colCodnition = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.colLabel = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.colRow = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        CType(Me.dataGridFormats, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.SuspendLayout()
+        '
+        'ucrRowExpression
+        '
+        Me.ucrRowExpression.Location = New System.Drawing.Point(236, 156)
+        Me.ucrRowExpression.Name = "ucrRowExpression"
+        Me.ucrRowExpression.Size = New System.Drawing.Size(132, 25)
+        Me.ucrRowExpression.TabIndex = 345
+        '
+        'Label1
+        '
+        Me.Label1.AutoSize = True
+        Me.Label1.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Label1.Location = New System.Drawing.Point(238, 140)
+        Me.Label1.Name = "Label1"
+        Me.Label1.Size = New System.Drawing.Size(134, 13)
+        Me.Label1.TabIndex = 344
+        Me.Label1.Text = "Row Expression (Optional):"
+        '
+        'Label2
+        '
+        Me.Label2.AutoSize = True
+        Me.Label2.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Label2.Location = New System.Drawing.Point(233, 15)
+        Me.Label2.Name = "Label2"
+        Me.Label2.Size = New System.Drawing.Size(75, 13)
+        Me.Label2.TabIndex = 343
+        Me.Label2.Text = "Select Format:"
+        '
+        'cboSelectFormat
+        '
+        Me.cboSelectFormat.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
+        Me.cboSelectFormat.FormattingEnabled = True
+        Me.cboSelectFormat.Items.AddRange(New Object() {"Number", "Date", "Text"})
+        Me.cboSelectFormat.Location = New System.Drawing.Point(236, 31)
+        Me.cboSelectFormat.Name = "cboSelectFormat"
+        Me.cboSelectFormat.Size = New System.Drawing.Size(132, 21)
+        Me.cboSelectFormat.TabIndex = 342
+        '
+        'ucrReceiverMultipleCols
+        '
+        Me.ucrReceiverMultipleCols.AutoSize = True
+        Me.ucrReceiverMultipleCols.frmParent = Nothing
+        Me.ucrReceiverMultipleCols.Location = New System.Drawing.Point(236, 74)
+        Me.ucrReceiverMultipleCols.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverMultipleCols.Name = "ucrReceiverMultipleCols"
+        Me.ucrReceiverMultipleCols.Selector = Nothing
+        Me.ucrReceiverMultipleCols.Size = New System.Drawing.Size(132, 55)
+        Me.ucrReceiverMultipleCols.strNcFilePath = ""
+        Me.ucrReceiverMultipleCols.TabIndex = 341
+        Me.ucrReceiverMultipleCols.ucrSelector = Nothing
+        '
+        'lblFormats
+        '
+        Me.lblFormats.AutoSize = True
+        Me.lblFormats.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblFormats.Location = New System.Drawing.Point(233, 218)
+        Me.lblFormats.Name = "lblFormats"
+        Me.lblFormats.Size = New System.Drawing.Size(47, 13)
+        Me.lblFormats.TabIndex = 340
+        Me.lblFormats.Text = "Formats:"
+        '
+        'btnClearFormats
+        '
+        Me.btnClearFormats.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.btnClearFormats.Location = New System.Drawing.Point(517, 209)
+        Me.btnClearFormats.Name = "btnClearFormats"
+        Me.btnClearFormats.Size = New System.Drawing.Size(75, 23)
+        Me.btnClearFormats.TabIndex = 339
+        Me.btnClearFormats.Tag = ""
+        Me.btnClearFormats.Text = "Clear"
+        Me.btnClearFormats.UseVisualStyleBackColor = True
+        '
+        'lblColumns
+        '
+        Me.lblColumns.AutoSize = True
+        Me.lblColumns.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblColumns.Location = New System.Drawing.Point(239, 58)
+        Me.lblColumns.Name = "lblColumns"
+        Me.lblColumns.Size = New System.Drawing.Size(56, 13)
+        Me.lblColumns.TabIndex = 338
+        Me.lblColumns.Text = "Column(s):"
+        '
+        'btnEnterFormat
+        '
+        Me.btnEnterFormat.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
+        Me.btnEnterFormat.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.btnEnterFormat.Location = New System.Drawing.Point(236, 186)
+        Me.btnEnterFormat.Name = "btnEnterFormat"
+        Me.btnEnterFormat.Size = New System.Drawing.Size(126, 23)
+        Me.btnEnterFormat.TabIndex = 337
+        Me.btnEnterFormat.Tag = ""
+        Me.btnEnterFormat.Text = "Enter Format"
+        Me.btnEnterFormat.UseVisualStyleBackColor = True
+        '
+        'ucrSelectorCols
+        '
+        Me.ucrSelectorCols.AutoSize = True
+        Me.ucrSelectorCols.bDropUnusedFilterLevels = False
+        Me.ucrSelectorCols.bShowHiddenColumns = False
+        Me.ucrSelectorCols.bUseCurrentFilter = True
+        Me.ucrSelectorCols.Location = New System.Drawing.Point(6, 4)
+        Me.ucrSelectorCols.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrSelectorCols.Name = "ucrSelectorCols"
+        Me.ucrSelectorCols.Size = New System.Drawing.Size(213, 183)
+        Me.ucrSelectorCols.TabIndex = 336
+        '
+        'dataGridFormats
+        '
+        Me.dataGridFormats.AllowUserToAddRows = False
+        Me.dataGridFormats.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
+        Me.dataGridFormats.Columns.AddRange(New System.Windows.Forms.DataGridViewColumn() {Me.colCodnition, Me.colLabel, Me.colRow})
+        Me.dataGridFormats.Location = New System.Drawing.Point(236, 235)
+        Me.dataGridFormats.Name = "dataGridFormats"
+        Me.dataGridFormats.ReadOnly = True
+        Me.dataGridFormats.RowHeadersWidth = 62
+        Me.dataGridFormats.Size = New System.Drawing.Size(361, 73)
+        Me.dataGridFormats.TabIndex = 335
+        '
+        'colCodnition
+        '
+        Me.colCodnition.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells
+        Me.colCodnition.HeaderText = "Format"
+        Me.colCodnition.MinimumWidth = 8
+        Me.colCodnition.Name = "colCodnition"
+        Me.colCodnition.ReadOnly = True
+        Me.colCodnition.Width = 64
+        '
+        'colLabel
+        '
+        Me.colLabel.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells
+        Me.colLabel.HeaderText = "Column(s)"
+        Me.colLabel.MinimumWidth = 8
+        Me.colLabel.Name = "colLabel"
+        Me.colLabel.ReadOnly = True
+        Me.colLabel.Width = 78
+        '
+        'colRow
+        '
+        Me.colRow.HeaderText = "Row Expression"
+        Me.colRow.Name = "colRow"
+        Me.colRow.ReadOnly = True
+        '
+        'ucrNewCellFormats
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.ucrRowExpression)
+        Me.Controls.Add(Me.Label1)
+        Me.Controls.Add(Me.Label2)
+        Me.Controls.Add(Me.cboSelectFormat)
+        Me.Controls.Add(Me.ucrReceiverMultipleCols)
+        Me.Controls.Add(Me.lblFormats)
+        Me.Controls.Add(Me.btnClearFormats)
+        Me.Controls.Add(Me.lblColumns)
+        Me.Controls.Add(Me.btnEnterFormat)
+        Me.Controls.Add(Me.ucrSelectorCols)
+        Me.Controls.Add(Me.dataGridFormats)
+        Me.Name = "ucrNewCellFormats"
+        Me.Size = New System.Drawing.Size(602, 312)
+        CType(Me.dataGridFormats, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents ucrRowExpression As ucrRowExpression
+    Friend WithEvents Label1 As Label
+    Friend WithEvents Label2 As Label
+    Friend WithEvents cboSelectFormat As ComboBox
+    Friend WithEvents ucrReceiverMultipleCols As ucrReceiverMultiple
+    Friend WithEvents lblFormats As Label
+    Friend WithEvents btnClearFormats As Button
+    Friend WithEvents lblColumns As Label
+    Friend WithEvents btnEnterFormat As Button
+    Friend WithEvents ucrSelectorCols As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents dataGridFormats As DataGridView
+    Friend WithEvents colCodnition As DataGridViewTextBoxColumn
+    Friend WithEvents colLabel As DataGridViewTextBoxColumn
+    Friend WithEvents colRow As DataGridViewTextBoxColumn
+End Class

--- a/instat/UserTables/Cells/Formats/ucrNewCellFormats.resx
+++ b/instat/UserTables/Cells/Formats/ucrNewCellFormats.resx
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="colCodnition.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="colLabel.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="colRow.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+</root>

--- a/instat/UserTables/Cells/Formats/ucrNewCellFormats.vb
+++ b/instat/UserTables/Cells/Formats/ucrNewCellFormats.vb
@@ -1,0 +1,146 @@
+﻿Public Class ucrNewCellFormats
+    Private clsOperator As New ROperator
+    Private bFirstload As Boolean = True
+
+
+    Private Sub InitialiseControl()
+        ucrReceiverMultipleCols.Selector = ucrSelectorCols
+        ucrReceiverMultipleCols.SetMeAsReceiver()
+
+        cboSelectFormat.SelectedIndex = 0
+
+    End Sub
+
+    Public Sub Setup(strDataFrameName As String, clsOperator As ROperator)
+        If bFirstload Then
+            InitialiseControl()
+            bFirstload = False
+        End If
+
+        Me.clsOperator = clsOperator
+
+        ' Set up the selector
+        ucrSelectorCols.SetDataframe(strDataFrameName, bEnableDataframe:=False)
+        ucrReceiverMultipleCols.SetMeAsReceiver()
+        ucrRowExpression.Setup(strDataFrameName)
+
+        ' Clear and Set up the data grid with contents
+        dataGridFormats.Rows.Clear()
+        SetupDataGrid(clsTablesUtils.FindRFunctionsParamsWithRCommand({"fmt", "fmt_units", "fmt_number", "fmt_currency"}, clsOperator))
+
+    End Sub
+
+    Private Sub SetupDataGrid(lstRParams As List(Of RParameter))
+
+        For Each clsRParam As RParameter In lstRParams
+
+            Dim clsFormatRFunction As RFunction = clsRParam.clsArgumentCodeStructure
+
+            ' Create a new row that represents the tab_row_group() parameters
+            Dim row As New DataGridViewRow
+            row.CreateCells(dataGridFormats)
+
+            ' Set the function name
+            row.Cells(0).Value = clsFormatRFunction.strRCommand
+
+            For Each clsRowGroupRParam As RParameter In clsFormatRFunction.clsParameters
+                If clsRowGroupRParam.strArgumentName = "columns" Then
+                    row.Cells(1).Value = clsTablesUtils.GetStringValue(clsRowGroupRParam.strArgumentValue, False)
+                ElseIf clsRowGroupRParam.strArgumentName = "rows" Then
+                    row.Cells(2).Value = clsTablesUtils.GetStringValue(clsRowGroupRParam.strArgumentValue, False)
+                End If
+            Next
+
+            ' Tag and add the  tab_row_group() parameter function contents as a row
+            row.Tag = clsRParam
+            dataGridFormats.Rows.Add(row)
+
+        Next
+    End Sub
+
+    Private Sub ucrReceiverMultipleCols_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverMultipleCols.ControlContentsChanged
+        btnEnterFormat.Enabled = Not ucrReceiverMultipleCols.IsEmpty
+    End Sub
+
+    Private Sub btnEnter_Click(sender As Object, e As EventArgs) Handles btnEnterFormat.Click
+        Dim clsFormatRFunction As RFunction = Nothing
+        If cboSelectFormat.Text = "Number" Then
+            sdgCellFormatNumberOptions.ShowDialog(Me.ParentForm)
+            clsFormatRFunction = sdgCellFormatNumberOptions.GetNewUserInputAsRFunction()
+        ElseIf cboSelectFormat.Text = "Date" Then
+            sdgCellFormatDateOptions.ShowDialog(Me.ParentForm)
+            clsFormatRFunction = sdgCellFormatDateOptions.GetNewUserInputAsRFunction()
+        ElseIf cboSelectFormat.Text = "Text" Then
+            sdgCellFormatTextOptions.ShowDialog(Me.ParentForm)
+            clsFormatRFunction = sdgCellFormatTextOptions.GetNewUserInputAsRFunction()
+        ElseIf cboSelectFormat.Text = "Missing" Then
+            ' TODO
+        End If
+
+        If clsFormatRFunction Is Nothing Then
+            Exit Sub
+        End If
+
+        AddFormatParameterToGrid(clsFormatRFunction)
+        ucrReceiverMultipleCols.Clear()
+        ucrRowExpression.Clear()
+
+    End Sub
+
+
+    Private Sub AddFormatParameterToGrid(clsFormatRFunction As RFunction)
+
+        Dim strColumnsExpression As String = ucrReceiverMultipleCols.GetVariableNames(bWithQuotes:=False)
+        Dim strRowsExpression As String = ucrRowExpression.GetText
+
+        ' Add columns parameter
+        clsFormatRFunction.AddParameter(New RParameter(strParameterName:="columns", strParamValue:=strColumnsExpression, iNewPosition:=0))
+
+        ' Add rows as paramater if present
+        If Not ucrRowExpression.IsEmpty Then
+            clsFormatRFunction.AddParameter(New RParameter(strParameterName:="rows", strParamValue:=strRowsExpression, iNewPosition:=1))
+        End If
+
+        ' Create parameter with unique name
+        Dim clsRParam As New RParameter(strParameterName:="fmt_param" & (dataGridFormats.Rows.Count + 1), strParamValue:=clsFormatRFunction, bNewIncludeArgumentName:=False)
+
+        ' Create row and its cells
+        Dim row As New DataGridViewRow
+        row.CreateCells(dataGridFormats)
+        row.Cells(0).Value = clsFormatRFunction.strRCommand
+        row.Cells(1).Value = strColumnsExpression
+        row.Cells(2).Value = strRowsExpression
+
+
+        ' Tag the row with the parameter 
+        row.Tag = clsRParam
+
+        ' Add it to grid
+        dataGridFormats.Rows.Add(row)
+
+    End Sub
+
+    Private Sub btnClearFormats_Click(sender As Object, e As EventArgs) Handles btnClearFormats.Click
+        dataGridFormats.Rows.Clear()
+    End Sub
+
+    Private Sub cboSelectFormat_SelectedIndexChanged(sender As Object, e As EventArgs) Handles cboSelectFormat.TextChanged
+        If cboSelectFormat.Text = "Number" Then
+            'ucrReceiverMultipleCols.SetIncludedDataTypes({})
+            ucrReceiverMultipleCols.strSelectorHeading = "Select Numerics"
+        ElseIf cboSelectFormat.Text = "Date" Then
+            'ucrReceiverMultipleCols.SetIncludedDataTypes({"numeric"})
+            ucrReceiverMultipleCols.strSelectorHeading = "Select Dates"
+        ElseIf cboSelectFormat.Text = "Text" OrElse cboSelectFormat.Text = "Missing" Then
+            'ucrReceiverMultipleCols.SetIncludedDataTypes({"date"})
+            ucrReceiverMultipleCols.strSelectorHeading = "Select Columns"
+        End If
+
+        ucrReceiverMultipleCols.SetMeAsReceiver()
+    End Sub
+
+    Public Sub SetValuesToOperator()
+        clsTablesUtils.RemoveRFunctionsParamsWithRCommand({"fmt", "fmt_units", "fmt_number", "fmt_currency"}, clsOperator)
+        clsTablesUtils.AddGridRowTagsRParamsToROperator(dataGridFormats, clsOperator)
+    End Sub
+End Class

--- a/instat/UserTables/Columns/ucrColumnNewMissingTexts.Designer.vb
+++ b/instat/UserTables/Columns/ucrColumnNewMissingTexts.Designer.vb
@@ -1,0 +1,177 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class ucrColumnNewMissingTexts
+    Inherits System.Windows.Forms.UserControl
+
+    'UserControl overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.lblMissingTexts = New System.Windows.Forms.Label()
+        Me.btnClear = New System.Windows.Forms.Button()
+        Me.ucrSelectorCols = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.dataGrid = New System.Windows.Forms.DataGridView()
+        Me.colMissingTexts = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.ucrReceiverMultipleCols = New instat.ucrReceiverMultiple()
+        Me.Label1 = New System.Windows.Forms.Label()
+        Me.lblMissingText = New System.Windows.Forms.Label()
+        Me.btnAdd = New System.Windows.Forms.Button()
+        Me.ucrTxtMissingText = New instat.ucrInputComboBox()
+        CType(Me.dataGrid, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.SuspendLayout()
+        '
+        'lblMissingTexts
+        '
+        Me.lblMissingTexts.AutoSize = True
+        Me.lblMissingTexts.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblMissingTexts.Location = New System.Drawing.Point(239, 199)
+        Me.lblMissingTexts.Name = "lblMissingTexts"
+        Me.lblMissingTexts.Size = New System.Drawing.Size(74, 13)
+        Me.lblMissingTexts.TabIndex = 368
+        Me.lblMissingTexts.Text = "Missing Texts:"
+        '
+        'btnClear
+        '
+        Me.btnClear.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.btnClear.Location = New System.Drawing.Point(520, 189)
+        Me.btnClear.Name = "btnClear"
+        Me.btnClear.Size = New System.Drawing.Size(75, 23)
+        Me.btnClear.TabIndex = 367
+        Me.btnClear.Tag = ""
+        Me.btnClear.Text = "Clear"
+        Me.btnClear.UseVisualStyleBackColor = True
+        '
+        'ucrSelectorCols
+        '
+        Me.ucrSelectorCols.AutoSize = True
+        Me.ucrSelectorCols.bDropUnusedFilterLevels = False
+        Me.ucrSelectorCols.bShowHiddenColumns = False
+        Me.ucrSelectorCols.bUseCurrentFilter = True
+        Me.ucrSelectorCols.Location = New System.Drawing.Point(7, 7)
+        Me.ucrSelectorCols.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrSelectorCols.Name = "ucrSelectorCols"
+        Me.ucrSelectorCols.Size = New System.Drawing.Size(213, 183)
+        Me.ucrSelectorCols.TabIndex = 365
+        '
+        'dataGrid
+        '
+        Me.dataGrid.AllowUserToAddRows = False
+        Me.dataGrid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
+        Me.dataGrid.Columns.AddRange(New System.Windows.Forms.DataGridViewColumn() {Me.colMissingTexts})
+        Me.dataGrid.Location = New System.Drawing.Point(240, 215)
+        Me.dataGrid.Name = "dataGrid"
+        Me.dataGrid.RowHeadersWidth = 62
+        Me.dataGrid.Size = New System.Drawing.Size(361, 73)
+        Me.dataGrid.TabIndex = 364
+        '
+        'colMissingTexts
+        '
+        Me.colMissingTexts.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill
+        Me.colMissingTexts.HeaderText = "Missing Text Expressions"
+        Me.colMissingTexts.MinimumWidth = 8
+        Me.colMissingTexts.Name = "colMissingTexts"
+        '
+        'ucrReceiverMultipleCols
+        '
+        Me.ucrReceiverMultipleCols.AutoSize = True
+        Me.ucrReceiverMultipleCols.frmParent = Nothing
+        Me.ucrReceiverMultipleCols.Location = New System.Drawing.Point(240, 26)
+        Me.ucrReceiverMultipleCols.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverMultipleCols.Name = "ucrReceiverMultipleCols"
+        Me.ucrReceiverMultipleCols.Selector = Nothing
+        Me.ucrReceiverMultipleCols.Size = New System.Drawing.Size(120, 80)
+        Me.ucrReceiverMultipleCols.strNcFilePath = ""
+        Me.ucrReceiverMultipleCols.TabIndex = 370
+        Me.ucrReceiverMultipleCols.ucrSelector = Nothing
+        '
+        'Label1
+        '
+        Me.Label1.AutoSize = True
+        Me.Label1.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.Label1.Location = New System.Drawing.Point(244, 9)
+        Me.Label1.Name = "Label1"
+        Me.Label1.Size = New System.Drawing.Size(56, 13)
+        Me.Label1.TabIndex = 371
+        Me.Label1.Text = "Column(s):"
+        '
+        'lblMissingText
+        '
+        Me.lblMissingText.AutoSize = True
+        Me.lblMissingText.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblMissingText.Location = New System.Drawing.Point(243, 120)
+        Me.lblMissingText.Name = "lblMissingText"
+        Me.lblMissingText.Size = New System.Drawing.Size(90, 13)
+        Me.lblMissingText.TabIndex = 369
+        Me.lblMissingText.Text = "Replace NA with:"
+        '
+        'btnAdd
+        '
+        Me.btnAdd.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
+        Me.btnAdd.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.btnAdd.Location = New System.Drawing.Point(240, 167)
+        Me.btnAdd.Name = "btnAdd"
+        Me.btnAdd.Size = New System.Drawing.Size(83, 23)
+        Me.btnAdd.TabIndex = 366
+        Me.btnAdd.Tag = ""
+        Me.btnAdd.Text = "Add"
+        Me.btnAdd.UseVisualStyleBackColor = True
+        '
+        'ucrTxtMissingText
+        '
+        Me.ucrTxtMissingText.AddQuotesIfUnrecognised = True
+        Me.ucrTxtMissingText.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrTxtMissingText.GetSetSelectedIndex = -1
+        Me.ucrTxtMissingText.IsReadOnly = False
+        Me.ucrTxtMissingText.Location = New System.Drawing.Point(240, 136)
+        Me.ucrTxtMissingText.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrTxtMissingText.Name = "ucrTxtMissingText"
+        Me.ucrTxtMissingText.Size = New System.Drawing.Size(120, 23)
+        Me.ucrTxtMissingText.TabIndex = 372
+        '
+        'ucrColumnNewMissingTexts
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.Controls.Add(Me.ucrTxtMissingText)
+        Me.Controls.Add(Me.lblMissingTexts)
+        Me.Controls.Add(Me.btnClear)
+        Me.Controls.Add(Me.ucrSelectorCols)
+        Me.Controls.Add(Me.dataGrid)
+        Me.Controls.Add(Me.ucrReceiverMultipleCols)
+        Me.Controls.Add(Me.Label1)
+        Me.Controls.Add(Me.lblMissingText)
+        Me.Controls.Add(Me.btnAdd)
+        Me.Name = "ucrColumnNewMissingTexts"
+        Me.Size = New System.Drawing.Size(602, 294)
+        CType(Me.dataGrid, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents lblMissingTexts As Label
+    Friend WithEvents btnClear As Button
+    Friend WithEvents ucrSelectorCols As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents dataGrid As DataGridView
+    Friend WithEvents colMissingTexts As DataGridViewTextBoxColumn
+    Friend WithEvents ucrReceiverMultipleCols As ucrReceiverMultiple
+    Friend WithEvents Label1 As Label
+    Friend WithEvents lblMissingText As Label
+    Friend WithEvents btnAdd As Button
+    Friend WithEvents ucrTxtMissingText As ucrInputComboBox
+End Class

--- a/instat/UserTables/Columns/ucrColumnNewMissingTexts.resx
+++ b/instat/UserTables/Columns/ucrColumnNewMissingTexts.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="colMissingTexts.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+</root>

--- a/instat/UserTables/Columns/ucrColumnNewMissingTexts.vb
+++ b/instat/UserTables/Columns/ucrColumnNewMissingTexts.vb
@@ -1,0 +1,90 @@
+﻿Public Class ucrColumnNewMissingTexts
+    Private clsOperator As New ROperator
+    Private bFirstload As Boolean = True
+    Private ReadOnly strZero As String = "0"
+    Private ReadOnly strMultipleDashes As String = "...."
+    Private ReadOnly strMissing As String = "missing"
+    Private ReadOnly strStar As String = "***"
+
+    Private Sub ucrColumnMissingTexts_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        If bFirstload Then
+            InitialiseControl()
+            bFirstload = False
+        End If
+    End Sub
+
+    Private Sub InitialiseControl()
+        ucrReceiverMultipleCols.Selector = ucrSelectorCols
+        ucrReceiverMultipleCols.SetMeAsReceiver()
+        ucrTxtMissingText.SetItems({strZero, strMultipleDashes, strMissing, strStar})
+    End Sub
+
+    Public Sub Setup(strDataFrameName As String, clsOperator As ROperator)
+        Me.clsOperator = clsOperator
+
+        ' Set up the selector
+        ucrSelectorCols.SetDataframe(strDataFrameName, bEnableDataframe:=False)
+
+        ' Clear and Set up the data grid with contents
+        dataGrid.Rows.Clear()
+        SetupDataGrid(clsTablesUtils.FindRFunctionsParamsWithRCommand({"sub_missing"}, clsOperator))
+    End Sub
+
+    Private Sub SetupDataGrid(lstRParams As List(Of RParameter))
+        For Each clsRParam As RParameter In lstRParams
+            ' Create a new row that represents the tab_style() parameters
+            Dim row As New DataGridViewRow
+            row.CreateCells(dataGrid)
+            row.Cells(0).Value = clsRParam.clsArgumentCodeStructure.Clone.ToScript
+
+            ' Tag and add the tab_style() parameter function contents as a row
+            row.Tag = clsRParam
+            dataGrid.Rows.Add(row)
+        Next
+    End Sub
+
+    Private Sub ucrInputControls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverMultipleCols.ControlContentsChanged
+        btnAdd.Enabled = Not ucrReceiverMultipleCols.IsEmpty
+    End Sub
+
+    Private Sub btnAdd_Click(sender As Object, e As EventArgs) Handles btnAdd.Click
+        Dim clsSubMissingRFunction As New RFunction
+
+        clsSubMissingRFunction.SetPackageName("gt")
+        clsSubMissingRFunction.SetRCommand("sub_missing")
+        clsSubMissingRFunction.AddParameter(strParameterName:="columns", strParameterValue:=ucrReceiverMultipleCols.GetVariableNames(bWithQuotes:=False), iPosition:=0)
+        clsSubMissingRFunction.AddParameter(strParameterName:="missing_text", strParameterValue:=Chr(34) & ucrTxtMissingText.GetText & Chr(34), iPosition:=1)
+
+        ' Create parameter with unique name
+        Dim clsRParam As New RParameter(strParameterName:="sub_missing_param" & (dataGrid.Rows.Count + 1), strParamValue:=clsSubMissingRFunction, bNewIncludeArgumentName:=False)
+
+        ' Create row and its cells
+        Dim row As New DataGridViewRow
+        row.CreateCells(dataGrid)
+        row.Cells(0).Value = clsSubMissingRFunction.Clone.ToScript
+
+        ' Tag the row with the parameter 
+        row.Tag = clsRParam
+
+        ' Add it to grid
+        dataGrid.Rows.Add(row)
+
+        ucrReceiverMultipleCols.Clear()
+        ucrTxtMissingText.SetName("")
+    End Sub
+
+    Private Sub btnClear_Click(sender As Object, e As EventArgs) Handles btnClear.Click
+        dataGrid.Rows.Clear()
+    End Sub
+
+    Public Sub SetValuesToOperator()
+        ' Remove any previous cell footers 
+        Dim lstRParams As List(Of RParameter) = clsTablesUtils.FindRFunctionsParamsWithRCommand({"sub_missing"}, clsOperator)
+        For Each clsRParam As RParameter In lstRParams
+            clsOperator.RemoveParameter(clsRParam)
+        Next
+
+        ' Add new changes
+        clsTablesUtils.AddGridRowTagsRParamsToROperator(dataGrid, clsOperator)
+    End Sub
+End Class

--- a/instat/UserTables/sdgBeforeTablesOption.Designer.vb
+++ b/instat/UserTables/sdgBeforeTablesOption.Designer.vb
@@ -34,12 +34,19 @@ Partial Class sdgBeforeTablesOption
         Me.btnManualTheme = New System.Windows.Forms.Button()
         Me.tbpOtherStyles = New System.Windows.Forms.TabPage()
         Me.ucrOtherStyles = New instat.ucrOtherStyles()
+        Me.tbpTables = New System.Windows.Forms.TabPage()
+        Me.ucrColumnNewMissingTexts = New instat.ucrColumnNewMissingTexts()
+        Me.rdoReplaceNa = New System.Windows.Forms.RadioButton()
+        Me.rdoDataFormat = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlCells = New instat.UcrPanel()
+        Me.ucrNewCellFormats = New instat.ucrNewCellFormats()
         Me.ucrSdgBaseButtons = New instat.ucrButtonsSubdialogue()
         Me.tbpFormatOptions.SuspendLayout()
         Me.tbpHeader.SuspendLayout()
         Me.tbpSourceNotes.SuspendLayout()
         Me.tbpThemes.SuspendLayout()
         Me.tbpOtherStyles.SuspendLayout()
+        Me.tbpTables.SuspendLayout()
         Me.SuspendLayout()
         '
         'tbpFormatOptions
@@ -48,6 +55,7 @@ Partial Class sdgBeforeTablesOption
         Me.tbpFormatOptions.Controls.Add(Me.tbpSourceNotes)
         Me.tbpFormatOptions.Controls.Add(Me.tbpThemes)
         Me.tbpFormatOptions.Controls.Add(Me.tbpOtherStyles)
+        Me.tbpFormatOptions.Controls.Add(Me.tbpTables)
         Me.tbpFormatOptions.Location = New System.Drawing.Point(2, 1)
         Me.tbpFormatOptions.Name = "tbpFormatOptions"
         Me.tbpFormatOptions.SelectedIndex = 0
@@ -166,6 +174,83 @@ Partial Class sdgBeforeTablesOption
         Me.ucrOtherStyles.Size = New System.Drawing.Size(326, 179)
         Me.ucrOtherStyles.TabIndex = 0
         '
+        'tbpTables
+        '
+        Me.tbpTables.Controls.Add(Me.ucrColumnNewMissingTexts)
+        Me.tbpTables.Controls.Add(Me.rdoReplaceNa)
+        Me.tbpTables.Controls.Add(Me.rdoDataFormat)
+        Me.tbpTables.Controls.Add(Me.ucrPnlCells)
+        Me.tbpTables.Controls.Add(Me.ucrNewCellFormats)
+        Me.tbpTables.Location = New System.Drawing.Point(4, 22)
+        Me.tbpTables.Name = "tbpTables"
+        Me.tbpTables.Padding = New System.Windows.Forms.Padding(3)
+        Me.tbpTables.Size = New System.Drawing.Size(637, 363)
+        Me.tbpTables.TabIndex = 11
+        Me.tbpTables.Text = "Tables"
+        Me.tbpTables.UseVisualStyleBackColor = True
+        '
+        'ucrColumnNewMissingTexts
+        '
+        Me.ucrColumnNewMissingTexts.Location = New System.Drawing.Point(12, 59)
+        Me.ucrColumnNewMissingTexts.Name = "ucrColumnNewMissingTexts"
+        Me.ucrColumnNewMissingTexts.Size = New System.Drawing.Size(602, 303)
+        Me.ucrColumnNewMissingTexts.TabIndex = 297
+        '
+        'rdoReplaceNa
+        '
+        Me.rdoReplaceNa.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoReplaceNa.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoReplaceNa.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None
+        Me.rdoReplaceNa.CheckAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoReplaceNa.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoReplaceNa.FlatAppearance.BorderSize = 2
+        Me.rdoReplaceNa.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoReplaceNa.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoReplaceNa.ForeColor = System.Drawing.SystemColors.ActiveCaptionText
+        Me.rdoReplaceNa.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoReplaceNa.Location = New System.Drawing.Point(288, 15)
+        Me.rdoReplaceNa.Name = "rdoReplaceNa"
+        Me.rdoReplaceNa.Size = New System.Drawing.Size(108, 29)
+        Me.rdoReplaceNa.TabIndex = 301
+        Me.rdoReplaceNa.Text = "Replace NA with"
+        Me.rdoReplaceNa.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoReplaceNa.UseVisualStyleBackColor = True
+        '
+        'rdoDataFormat
+        '
+        Me.rdoDataFormat.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoDataFormat.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoDataFormat.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None
+        Me.rdoDataFormat.CheckAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoDataFormat.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoDataFormat.FlatAppearance.BorderSize = 2
+        Me.rdoDataFormat.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoDataFormat.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoDataFormat.ForeColor = System.Drawing.SystemColors.ActiveCaptionText
+        Me.rdoDataFormat.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoDataFormat.Location = New System.Drawing.Point(179, 15)
+        Me.rdoDataFormat.Name = "rdoDataFormat"
+        Me.rdoDataFormat.Size = New System.Drawing.Size(109, 29)
+        Me.rdoDataFormat.TabIndex = 300
+        Me.rdoDataFormat.Text = "Data Format"
+        Me.rdoDataFormat.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoDataFormat.UseVisualStyleBackColor = True
+        '
+        'ucrPnlCells
+        '
+        Me.ucrPnlCells.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrPnlCells.Location = New System.Drawing.Point(163, 11)
+        Me.ucrPnlCells.Name = "ucrPnlCells"
+        Me.ucrPnlCells.Size = New System.Drawing.Size(247, 40)
+        Me.ucrPnlCells.TabIndex = 299
+        '
+        'ucrNewCellFormats
+        '
+        Me.ucrNewCellFormats.Location = New System.Drawing.Point(15, 50)
+        Me.ucrNewCellFormats.Name = "ucrNewCellFormats"
+        Me.ucrNewCellFormats.Size = New System.Drawing.Size(602, 312)
+        Me.ucrNewCellFormats.TabIndex = 298
+        '
         'ucrSdgBaseButtons
         '
         Me.ucrSdgBaseButtons.AutoSize = True
@@ -195,6 +280,7 @@ Partial Class sdgBeforeTablesOption
         Me.tbpThemes.ResumeLayout(False)
         Me.tbpThemes.PerformLayout()
         Me.tbpOtherStyles.ResumeLayout(False)
+        Me.tbpTables.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -213,4 +299,10 @@ Partial Class sdgBeforeTablesOption
     Friend WithEvents tbpOtherStyles As TabPage
     Friend WithEvents ucrOtherStyles As ucrOtherStyles
     Friend WithEvents ucrSdgBaseButtons As ucrButtonsSubdialogue
+    Friend WithEvents tbpTables As TabPage
+    Friend WithEvents ucrColumnNewMissingTexts As ucrColumnNewMissingTexts
+    Friend WithEvents ucrNewCellFormats As ucrNewCellFormats
+    Friend WithEvents rdoReplaceNa As RadioButton
+    Friend WithEvents rdoDataFormat As RadioButton
+    Friend WithEvents ucrPnlCells As UcrPanel
 End Class

--- a/instat/UserTables/sdgBeforeTablesOption.vb
+++ b/instat/UserTables/sdgBeforeTablesOption.vb
@@ -35,8 +35,14 @@ Public Class sdgBeforeTablesOption
     Private Sub InitialiseDialog()
         ucrSdgBaseButtons.iHelpTopicID = 146
         ucrChkSelectTheme.Checked = True
+        ucrNewCellFormats.Visible = False
+        ucrColumnNewMissingTexts.Visible = False
         ucrChkSelectTheme.SetText("Select Theme")
         ucrChkManualTheme.SetText("Manual Theme")
+
+        ucrPnlCells.AddRadioButton(rdoDataFormat)
+        ucrPnlCells.AddRadioButton(rdoReplaceNa)
+        rdoDataFormat.Checked = True
 
         ucrCboSelectThemes.SetItems({"None", "Dark Theme", "538 Theme", "Dot Matrix Theme", "Espn Theme", "Excel Theme", "Guardian Theme", "NY Times Theme", "PFF Theme"})
         ucrCboSelectThemes.SetDropDownStyleAsNonEditable()
@@ -54,6 +60,8 @@ Public Class sdgBeforeTablesOption
         ucrHeader.Setup(clsOperator)
         ucrSourceNotes.Setup(clsOperator)
         ucrOtherStyles.Setup(clsOperator)
+        ucrNewCellFormats.Setup(strDataFrameName, clsOperator)
+        ucrColumnNewMissingTexts.Setup(strDataFrameName, clsOperator)
 
         ucrHeader.ucrInputTitle.SetText(dlgGeneralTable.ucrInputTitle.GetText)
         ucrHeader.ucrInputTitleFooter.SetText(dlgGeneralTable.ucrInputTitleFooter.GetText)
@@ -67,6 +75,8 @@ Public Class sdgBeforeTablesOption
         ucrHeader.SetValuesToOperator()
         ucrSourceNotes.SetValuesToOperator()
         ucrOtherStyles.SetValuesToOperator()
+        ucrNewCellFormats.SetValuesToOperator()
+        ucrColumnNewMissingTexts.SetValuesToOperator()
         SetThemeValuesOnReturn(clsOperator)
     End Sub
 
@@ -152,5 +162,11 @@ Public Class sdgBeforeTablesOption
             clsOperator.RemoveParameterByName("theme_format")
         End If
     End Sub
+
+    Private Sub ucrPnlRows_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlCells.ControlValueChanged
+        ucrNewCellFormats.Visible = rdoDataFormat.Checked
+        ucrColumnNewMissingTexts.Visible = rdoReplaceNa.Checked
+    End Sub
+
     '-----------------------------------------
 End Class

--- a/instat/UserTables/sdgTableOptions.Designer.vb
+++ b/instat/UserTables/sdgTableOptions.Designer.vb
@@ -43,6 +43,12 @@ Partial Class sdgTableOptions
         Me.tbpOtherStyles = New System.Windows.Forms.TabPage()
         Me.ucrOtherStyles = New instat.ucrOtherStyles()
         Me.ucrSdgBaseButtons = New instat.ucrButtonsSubdialogue()
+        Me.tbpTables = New System.Windows.Forms.TabPage()
+        Me.ucrColumnNewMissingTexts = New instat.ucrColumnNewMissingTexts()
+        Me.rdoReplaceNa = New System.Windows.Forms.RadioButton()
+        Me.rdoDataFormat = New System.Windows.Forms.RadioButton()
+        Me.ucrPnlCells = New instat.UcrPanel()
+        Me.ucrNewCellFormats = New instat.ucrNewCellFormats()
         Me.tbpFormatOptions.SuspendLayout()
         Me.tbpHeader.SuspendLayout()
         Me.tbpStub.SuspendLayout()
@@ -52,6 +58,7 @@ Partial Class sdgTableOptions
         Me.tbpSourceNotes.SuspendLayout()
         Me.tbpThemes.SuspendLayout()
         Me.tbpOtherStyles.SuspendLayout()
+        Me.tbpTables.SuspendLayout()
         Me.SuspendLayout()
         '
         'tbpFormatOptions
@@ -64,6 +71,7 @@ Partial Class sdgTableOptions
         Me.tbpFormatOptions.Controls.Add(Me.tbpSourceNotes)
         Me.tbpFormatOptions.Controls.Add(Me.tbpThemes)
         Me.tbpFormatOptions.Controls.Add(Me.tbpOtherStyles)
+        Me.tbpFormatOptions.Controls.Add(Me.tbpTables)
         Me.tbpFormatOptions.Location = New System.Drawing.Point(3, 5)
         Me.tbpFormatOptions.Name = "tbpFormatOptions"
         Me.tbpFormatOptions.SelectedIndex = 0
@@ -263,6 +271,83 @@ Partial Class sdgTableOptions
         Me.ucrSdgBaseButtons.Size = New System.Drawing.Size(224, 30)
         Me.ucrSdgBaseButtons.TabIndex = 343
         '
+        'tbpTables
+        '
+        Me.tbpTables.Controls.Add(Me.ucrColumnNewMissingTexts)
+        Me.tbpTables.Controls.Add(Me.rdoReplaceNa)
+        Me.tbpTables.Controls.Add(Me.rdoDataFormat)
+        Me.tbpTables.Controls.Add(Me.ucrPnlCells)
+        Me.tbpTables.Controls.Add(Me.ucrNewCellFormats)
+        Me.tbpTables.Location = New System.Drawing.Point(4, 22)
+        Me.tbpTables.Name = "tbpTables"
+        Me.tbpTables.Padding = New System.Windows.Forms.Padding(3)
+        Me.tbpTables.Size = New System.Drawing.Size(765, 431)
+        Me.tbpTables.TabIndex = 11
+        Me.tbpTables.Text = "Tables"
+        Me.tbpTables.UseVisualStyleBackColor = True
+        '
+        'ucrColumnNewMissingTexts
+        '
+        Me.ucrColumnNewMissingTexts.Location = New System.Drawing.Point(12, 56)
+        Me.ucrColumnNewMissingTexts.Name = "ucrColumnNewMissingTexts"
+        Me.ucrColumnNewMissingTexts.Size = New System.Drawing.Size(602, 303)
+        Me.ucrColumnNewMissingTexts.TabIndex = 302
+        '
+        'rdoReplaceNa
+        '
+        Me.rdoReplaceNa.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoReplaceNa.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoReplaceNa.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None
+        Me.rdoReplaceNa.CheckAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoReplaceNa.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoReplaceNa.FlatAppearance.BorderSize = 2
+        Me.rdoReplaceNa.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoReplaceNa.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoReplaceNa.ForeColor = System.Drawing.SystemColors.ActiveCaptionText
+        Me.rdoReplaceNa.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoReplaceNa.Location = New System.Drawing.Point(288, 12)
+        Me.rdoReplaceNa.Name = "rdoReplaceNa"
+        Me.rdoReplaceNa.Size = New System.Drawing.Size(108, 29)
+        Me.rdoReplaceNa.TabIndex = 306
+        Me.rdoReplaceNa.Text = "Replace NA with"
+        Me.rdoReplaceNa.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoReplaceNa.UseVisualStyleBackColor = True
+        '
+        'rdoDataFormat
+        '
+        Me.rdoDataFormat.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoDataFormat.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoDataFormat.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None
+        Me.rdoDataFormat.CheckAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoDataFormat.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoDataFormat.FlatAppearance.BorderSize = 2
+        Me.rdoDataFormat.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoDataFormat.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoDataFormat.ForeColor = System.Drawing.SystemColors.ActiveCaptionText
+        Me.rdoDataFormat.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoDataFormat.Location = New System.Drawing.Point(179, 12)
+        Me.rdoDataFormat.Name = "rdoDataFormat"
+        Me.rdoDataFormat.Size = New System.Drawing.Size(109, 29)
+        Me.rdoDataFormat.TabIndex = 305
+        Me.rdoDataFormat.Text = "Data Format"
+        Me.rdoDataFormat.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoDataFormat.UseVisualStyleBackColor = True
+        '
+        'ucrPnlCells
+        '
+        Me.ucrPnlCells.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrPnlCells.Location = New System.Drawing.Point(163, 8)
+        Me.ucrPnlCells.Name = "ucrPnlCells"
+        Me.ucrPnlCells.Size = New System.Drawing.Size(247, 40)
+        Me.ucrPnlCells.TabIndex = 304
+        '
+        'ucrNewCellFormats
+        '
+        Me.ucrNewCellFormats.Location = New System.Drawing.Point(15, 47)
+        Me.ucrNewCellFormats.Name = "ucrNewCellFormats"
+        Me.ucrNewCellFormats.Size = New System.Drawing.Size(602, 312)
+        Me.ucrNewCellFormats.TabIndex = 303
+        '
         'sdgTableOptions
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -284,6 +369,7 @@ Partial Class sdgTableOptions
         Me.tbpThemes.ResumeLayout(False)
         Me.tbpThemes.PerformLayout()
         Me.tbpOtherStyles.ResumeLayout(False)
+        Me.tbpTables.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -310,4 +396,10 @@ Partial Class sdgTableOptions
     Friend WithEvents ucrOtherStyles As ucrOtherStyles
     Friend WithEvents ucrChkSelectTheme As ucrCheck
     Friend WithEvents ucrChkManualTheme As ucrCheck
+    Friend WithEvents tbpTables As TabPage
+    Friend WithEvents ucrColumnNewMissingTexts As ucrColumnNewMissingTexts
+    Friend WithEvents rdoReplaceNa As RadioButton
+    Friend WithEvents rdoDataFormat As RadioButton
+    Friend WithEvents ucrPnlCells As UcrPanel
+    Friend WithEvents ucrNewCellFormats As ucrNewCellFormats
 End Class

--- a/instat/UserTables/sdgTableOptions.vb
+++ b/instat/UserTables/sdgTableOptions.vb
@@ -34,9 +34,15 @@ Public Class sdgTableOptions
 
     Private Sub InitialiseDialog()
         ucrSdgBaseButtons.iHelpTopicID = 146
+        ucrNewCellFormats.Visible = False
+        ucrColumnNewMissingTexts.Visible = False
         ucrChkSelectTheme.Checked = True
         ucrChkSelectTheme.SetText("Select Theme")
         ucrChkManualTheme.SetText("Manual Theme")
+
+        ucrPnlCells.AddRadioButton(rdoDataFormat)
+        ucrPnlCells.AddRadioButton(rdoReplaceNa)
+        rdoDataFormat.Checked = True
 
         ucrCboSelectThemes.SetItems({"None", "Dark Theme", "538 Theme", "Dot Matrix Theme", "Espn Theme", "Excel Theme", "Guardian Theme", "NY Times Theme", "PFF Theme"})
         ucrCboSelectThemes.SetDropDownStyleAsNonEditable()
@@ -56,6 +62,8 @@ Public Class sdgTableOptions
         ucrRows.Setup(strDataFrameName, clsOperator)
         ucrColumns.Setup(strDataFrameName, clsOperator)
         ucrCells.Setup(strDataFrameName, clsOperator)
+        ucrNewCellFormats.Setup(strDataFrameName, clsOperator)
+        ucrColumnNewMissingTexts.Setup(strDataFrameName, clsOperator)
         ucrSourceNotes.Setup(clsOperator)
         ucrOtherStyles.Setup(clsOperator)
 
@@ -75,6 +83,8 @@ Public Class sdgTableOptions
         ucrCells.SetValuesToOperator()
         ucrSourceNotes.SetValuesToOperator()
         ucrOtherStyles.SetValuesToOperator()
+        ucrNewCellFormats.SetValuesToOperator()
+        ucrColumnNewMissingTexts.SetValuesToOperator()
         SetThemeValuesOnReturn(clsOperator)
     End Sub
 
@@ -162,6 +172,9 @@ Public Class sdgTableOptions
         End If
     End Sub
     '-----------------------------------------
-
+    Private Sub ucrPnlRows_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlCells.ControlValueChanged
+        ucrNewCellFormats.Visible = rdoDataFormat.Checked
+        ucrColumnNewMissingTexts.Visible = rdoReplaceNa.Checked
+    End Sub
 
 End Class

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -535,6 +535,12 @@
     <Compile Include="UserTables\Cells\Formats\ucrCellFormats.vb">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Include="UserTables\Cells\Formats\ucrNewCellFormats.Designer.vb">
+      <DependentUpon>ucrNewCellFormats.vb</DependentUpon>
+    </Compile>
+    <Compile Include="UserTables\Cells\Formats\ucrNewCellFormats.vb">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="UserTables\Cells\Styles\ucrCellStyles.Designer.vb">
       <DependentUpon>ucrCellStyles.vb</DependentUpon>
     </Compile>
@@ -564,6 +570,12 @@
       <DependentUpon>ucrColumnNanoPlots.vb</DependentUpon>
     </Compile>
     <Compile Include="UserTables\Columns\ucrColumnNanoPlots.vb">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UserTables\Columns\ucrColumnNewMissingTexts.Designer.vb">
+      <DependentUpon>ucrColumnNewMissingTexts.vb</DependentUpon>
+    </Compile>
+    <Compile Include="UserTables\Columns\ucrColumnNewMissingTexts.vb">
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="UserTables\Columns\ucrColumnStyles.Designer.vb">
@@ -3646,6 +3658,9 @@
     <EmbeddedResource Include="UserTables\Cells\Formats\ucrCellFormats.resx">
       <DependentUpon>ucrCellFormats.vb</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="UserTables\Cells\Formats\ucrNewCellFormats.resx">
+      <DependentUpon>ucrNewCellFormats.vb</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="UserTables\Cells\Styles\ucrCellStyles.resx">
       <DependentUpon>ucrCellStyles.vb</DependentUpon>
     </EmbeddedResource>
@@ -3660,6 +3675,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="UserTables\Columns\ucrColumnNanoPlots.resx">
       <DependentUpon>ucrColumnNanoPlots.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UserTables\Columns\ucrColumnNewMissingTexts.resx">
+      <DependentUpon>ucrColumnNewMissingTexts.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="UserTables\Columns\ucrColumnStyles.resx">
       <DependentUpon>ucrColumnStyles.vb</DependentUpon>


### PR DESCRIPTION
Fixes #9632
This adds the New Tables tab option to the Tables sub-dialog (Before and Same, After was supposed to be implemented by Patrick)
While working this, i realized the options were added as a whole (each option having it own selector, receiver etc) so to have them as group boxes would not be ideal. So i followed the structure and made them separately with radio button assigned to the two options.
I believe this will make it simpler for the user to be able to use them and also for any developer when there are changes to be made would find them easy to do
@rdstern , @lilyclements can you review this
Thanks