### PR TITLE
Ensured that R script parameter name correctly updated in `Trait Correlations XP` dialog

### DIFF
--- a/instat/clsTransformationRModel.vb
+++ b/instat/clsTransformationRModel.vb
@@ -48,6 +48,11 @@ Public Class clsTransformationRModel
     Public strParameterName As String
 
     ''' <summary>
+    ''' The dictionary key to use to find the name of the parameter to update in the R model.
+    ''' </summary>
+    Public strParameterNameKey As String
+
+    ''' <summary>
     ''' A valid R script to update the R model with.
     ''' </summary>
     Public strScript As String
@@ -56,6 +61,10 @@ Public Class clsTransformationRModel
     ''' Used as part of the condition in some transformations.
     ''' </summary>
     Public strValueDefault As String = "TRUE"
+
+    ''' <summary>
+    ''' The dictionary key to use to find the value to update in the R model.
+    ''' </summary>
     Public strValueKey As String
 
     ''' <summary>
@@ -87,8 +96,9 @@ Public Class clsTransformationRModel
     ''' <param name="dctConfigurableValues"> The dictionary of configurable values to reference 
     '''                                      when performing the transformation</param>
     Public Sub updateRModel(rScript As RScript, dctConfigurableValues As Dictionary(Of String, String))
-
+        'todo remove strValue, just use strScript
         Dim strValue As String = If(String.IsNullOrEmpty(strValueKey), strScript, dctConfigurableValues(strValueKey))
+        strParameterName = If(String.IsNullOrEmpty(strParameterNameKey), strParameterName, dctConfigurableValues(strParameterNameKey))
 
         Select Case enumTransformationType
             Case TransformationType.functionAddParam

--- a/instat/static/DialogDefinitions/DlgTraitCorrelations/dlgTraitCorrelations.json
+++ b/instat/static/DialogDefinitions/DlgTraitCorrelations/dlgTraitCorrelations.json
@@ -222,11 +222,17 @@
                                 "strValueKey": "storeTableOrDataFrame"
                             },
                             {
-                                "enumTransformationType": "functionUpdateParamValue",
+                                "enumTransformationType": "functionRemoveParamByName",
                                 "iStatementNumber": 11,
                                 "strFunctionName": "list",
-                                "iParameterNumber": 0,
-                                "strValueKey": "storeTableOrDataFrame",
+                                "strParameterName": "last_dataframe"
+                            },
+                            {
+                                "enumTransformationType": "functionAddParam",
+                                "iStatementNumber": 11,
+                                "strFunctionName": "list",
+                                "strParameterNameKey": "storeTableOrDataFrame",
+                                "strValueKey": "storeTableOrDataFrame"
                             },
                             {
                                 "enumTransformationType": "functionUpdateParamValue",


### PR DESCRIPTION
As mentioned in PR #9671, in the `Trait Correlations XP` dialog, if `Display Options`, `Save As Data Frame` and `Store Data Frame` were selected, then the parameter name was not correctly updated in the script.

This PR fixes this (sorry, there is no corresponding GitHub issue).

@rdstern Please could you test? Thanks

![image](https://github.com/user-attachments/assets/ab34f727-9edd-4a9c-a53e-8a8a57aeb2cc)

Before fix

![image](https://github.com/user-attachments/assets/ec1c76df-e7aa-4f59-952f-b71f0534f507)

After fix:

![image](https://github.com/user-attachments/assets/5dc62cb6-9266-4d41-ab7b-76031aa2eb74)

