### PR TITLE
Added the save checkbox to the display options sub-dialog for the modelling dialog (no covariates)

### DIFF
--- a/instat/dlgModellingTree.vb
+++ b/instat/dlgModellingTree.vb
@@ -298,7 +298,7 @@ Public Class dlgModellingTree
         clsEstimatesFunction.SetRCommand("map")
         clsEstimatesFunction.AddParameter(".x", "mod_list", iPosition:=0)
         clsEstimatesFunction.AddParameter(".f", clsROperatorParameter:=clsCoefOperator, iPosition:=1)
-        'clsEstimatesFunction.iCallType = 2
+        clsEstimatesFunction.iCallType = 2
 
         clsAICFunction.SetRCommand("AIC")
         clsAICFunction.AddParameter("x", ".x", bIncludeArgumentName:=False, iPosition:=0)

--- a/instat/dlgModellingTree.vb
+++ b/instat/dlgModellingTree.vb
@@ -37,11 +37,11 @@ Public Class dlgModellingTree
     Private clsDevianceFunction, clsDevianceMainFunction, clsSecondEstimatesFunction As New RFunction
     Private clsRegretFunction, clsNodeLabelsFunction, clsNodeRulesFunction, clsTopItemsFunction As New RFunction
     Private clsPairwiseProbFunction, clsPairwiseProbMainFunction, clsReliabilityFunction, clsItemsParFunction As New RFunction
-    Private clsCoefOperator, clsAICOperator, clsDevianceOperator, clsPairwiseProbOperator, clsStatsOperator, clsModelOperator As New ROperator
+    Private clsCoefOperator, clsAICOperator, clsDevianceOperator, clsPairwiseProbOperator, clsStatsOperator, clsModelOperator, clsPipeOperator As New ROperator
     Private clsAnnovaFunction, clsConfidenLimFunction, clsStatsFunction, clsQuasivarianceFunction, clsVarianCovaMatrixFunction As New RFunction
     Private clsWrapBarFunction, clsWrapPlotFunction, clsPlacketFunction As New RFunction
 
-    Private clsAddObjectHeatFunction, clsHeatFunction, clsTreeFunction As New RFunction
+    Private clsAddObjectHeatFunction, clsHeatFunction, clsTreeFunction, clsImportDataFunction As New RFunction
     Private clsPlotFunction, clsBarfunction As New RFunction
 
     Public bResetSubDialog As Boolean = False
@@ -298,7 +298,7 @@ Public Class dlgModellingTree
         clsEstimatesFunction.SetRCommand("map")
         clsEstimatesFunction.AddParameter(".x", "mod_list", iPosition:=0)
         clsEstimatesFunction.AddParameter(".f", clsROperatorParameter:=clsCoefOperator, iPosition:=1)
-        clsEstimatesFunction.iCallType = 2
+        'clsEstimatesFunction.iCallType = 2
 
         clsAICFunction.SetRCommand("AIC")
         clsAICFunction.AddParameter("x", ".x", bIncludeArgumentName:=False, iPosition:=0)
@@ -474,15 +474,15 @@ Public Class dlgModellingTree
 
         ucrBase.clsRsyntax.ClearCodes()
 
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsGetDataFrameFunction)
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsGetSecondDataFrameFunction)
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsGetVariablesFromMetaDataFunction)
+        ucrBase.clsRsyntax.AddToBeforeCodes(clsGetDataFrameFunction, iPosition:=1)
+        ucrBase.clsRsyntax.AddToBeforeCodes(clsGetSecondDataFrameFunction, iPosition:=2)
+        ucrBase.clsRsyntax.AddToBeforeCodes(clsGetVariablesFromMetaDataFunction, iPosition:=3)
 
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsLibraryFunction)
+        ucrBase.clsRsyntax.AddToBeforeCodes(clsLibraryFunction, iPosition:=4)
 
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsMappingFunction)
+        ucrBase.clsRsyntax.AddToBeforeCodes(clsMappingFunction, iPosition:=5)
 
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsAssignOperator)
+        ucrBase.clsRsyntax.AddToBeforeCodes(clsAssignOperator, iPosition:=6)
 
         ucrBase.clsRsyntax.SetBaseROperator(clsModelOperator)
 
@@ -595,7 +595,7 @@ Public Class dlgModellingTree
     End Sub
     Private Sub cmdDisplayOptions_Click(sender As Object, e As EventArgs) Handles cmdDisplayOptions.Click
         sdgDisplayModelOptions.SetRCode(clsNewSummaryFunction:=clsSummaryFunction, clsNewCoefFunction:=clscoefFunction, clsNewSecondEstimatesFunction:=clsSecondEstimatesFunction,
-            clsNewEstimatesFunction:=clsEstimatesFunction, clsNewDevianceFunction:=clsDevianceMainFunction,
+            clsNewEstimatesFunction:=clsEstimatesFunction, clsNewImportDataFunction:=clsImportDataFunction, clsNewPipeOperator:=clsPipeOperator, clsNewDevianceFunction:=clsDevianceMainFunction,
             clsNewPariPropFunction:=clsPairwiseProbMainFunction, clsNewReliabilityFunction:=clsReliabilityFunction,
             clsNewItemsFunction:=clsItemsParFunction, clsNewRegretFunction:=clsRegretFunction, clsNewNodeLabFuction:=clsNodeLabelsFunction,
             clsNewNodeRuleFunction:=clsNodeRulesFunction, clsNewTopItemFunction:=clsTopItemsFunction, clsNewRSyntax:=ucrBase.clsRsyntax, clsNewAICFunction:=clsUnListAICFunction,
@@ -616,6 +616,9 @@ Public Class dlgModellingTree
         sdgDisplayModelOptions.ucrChkParProp.Enabled = True
         sdgDisplayModelOptions.ucrChkReability.Enabled = True
         sdgDisplayModelOptions.ucrChkItemPara.Enabled = True
+        sdgDisplayModelOptions.ucrChkSave.Checked = False
+        sdgDisplayModelOptions.ucrChkSave.Enabled = False
+        sdgDisplayModelOptions.ucrChkSave.Visible = False
         sdgDisplayModelOptions.rdoPlot.Enabled = False
         sdgDisplayModelOptions.rdoTree.Enabled = False
         sdgDisplayModelOptions.rdoNoPlot.Enabled = True

--- a/instat/dlgModellingTree.vb
+++ b/instat/dlgModellingTree.vb
@@ -617,7 +617,6 @@ Public Class dlgModellingTree
         sdgDisplayModelOptions.ucrChkReability.Enabled = True
         sdgDisplayModelOptions.ucrChkItemPara.Enabled = True
         sdgDisplayModelOptions.ucrChkSave.Checked = False
-        sdgDisplayModelOptions.ucrChkSave.Enabled = False
         sdgDisplayModelOptions.ucrChkSave.Visible = False
         sdgDisplayModelOptions.rdoPlot.Enabled = False
         sdgDisplayModelOptions.rdoTree.Enabled = False

--- a/instat/dlgPlacketLuceModel.vb
+++ b/instat/dlgPlacketLuceModel.vb
@@ -22,8 +22,8 @@ Public Class dlgPlacketLuceModel
     Private bResetSubdialog As Boolean = True
     Private clsGetDataFrameFunction, clsSndgetVarmataFunction, clsLevelFunction, clsFactorFunction, clsNamesFunction, clsGetVarMetadataFunction, clsGetObjectRFunction, clsRankingsItemsFunction, clsVarFunction, clsMapFunction, clsPlacketFunction As RFunction
     Private clsPlotFunction, clsWrapPlotFunction, clsWrapBarFunction, clsHeatFunction, clsBarfunction, clsTreeFunction, clsNodeLabFuction, clsNodeRuleFunction, clsTopItemFunction, clsRegretFunction, clsSummaryFunction, clsAnnovaFunction, clsEstimatesFunction, clsConfidenLimFunction, clsAICFunction, clsDevianceFunction, clsSecondEstimatesFunction, clsPariPropFunction, clsReliabilityFunction, clsItemsFunction, clsVarianCovaMatrixFunction, clsQuasivarianceFunction As RFunction
-    Private clsCoefFunction, clsStatsFunction As RFunction
-    Private clsStatsOperator, clsCoefOperator As ROperator
+    Private clsCoefFunction, clsStatsFunction, clsLdplyFunction, clsPivotLongerFunction, clsPivotWiderFunction, clsListFunction, clsImportDataFunction As RFunction
+    Private clsStatsOperator, clsCoefOperator, clsPipeOperator As ROperator
     Private clsAssignOperator, clsSpaceOpreator As ROperator
     Private clsGetRankingOperator, clsModelOperator, clsPlacketOperator, clsNamesOperator As ROperator
 
@@ -74,6 +74,15 @@ Public Class dlgPlacketLuceModel
         clsAnnovaFunction = New RFunction
         clsSummaryFunction = New RFunction
         clsEstimatesFunction = New RFunction
+
+
+        clsLdplyFunction = New RFunction
+        clsPivotLongerFunction = New RFunction
+        clsPivotWiderFunction = New RFunction
+        clsListFunction = New RFunction
+        clsImportDataFunction = New RFunction
+
+
         clsConfidenLimFunction = New RFunction
         clsAICFunction = New RFunction
         clsDevianceFunction = New RFunction
@@ -96,6 +105,7 @@ Public Class dlgPlacketLuceModel
         clsWrapBarFunction = New RFunction
         clsWrapPlotFunction = New RFunction
 
+        clsPipeOperator = New ROperator
         clsSpaceOpreator = New ROperator
         clsAssignOperator = New ROperator
         clsGetRankingOperator = New ROperator
@@ -179,6 +189,36 @@ Public Class dlgPlacketLuceModel
 
         clsCoefFunction.SetRCommand("coef")
         clsCoefFunction.AddParameter("x", ".x", iPosition:=0, bIncludeArgumentName:=False)
+
+        ' Adding the function for the save checkbox
+        clsLdplyFunction.SetPackageName("plyr")
+        clsLdplyFunction.SetRCommand("ldply")
+        clsLdplyFunction.AddParameter("left", "coefficients_data", bIncludeArgumentName:=False, iPosition:=0)
+
+        clsPivotLongerFunction.SetPackageName("tidyr")
+        clsPivotLongerFunction.SetRCommand("pivot_longer")
+        clsPivotLongerFunction.AddParameter("cols", "-`.id`")
+
+        clsPivotWiderFunction.SetPackageName("tidyr")
+        clsPivotWiderFunction.SetRCommand("pivot_wider")
+        clsPivotWiderFunction.AddParameter("names_from", "`.id`")
+        clsPivotWiderFunction.AddParameter("values_from", "value")
+
+        clsPipeOperator.SetOperation("%>%")
+        clsPipeOperator.AddParameter("first", clsRFunctionParameter:=clsLdplyFunction, bIncludeArgumentName:=False)
+        clsPipeOperator.AddParameter("second", clsRFunctionParameter:=clsPivotLongerFunction, bIncludeArgumentName:=False)
+        clsPipeOperator.AddParameter("third", clsRFunctionParameter:=clsPivotWiderFunction, bIncludeArgumentName:=False)
+        clsPipeOperator.SetAssignTo("coefficients_data")
+
+        clsListFunction.SetRCommand("list")
+        clsListFunction.AddParameter("coefficients_data", "coefficients_data")
+
+        clsImportDataFunction.SetRCommand("data_book$import_data")
+        clsImportDataFunction.AddParameter("left", clsRFunctionParameter:=clsListFunction, bIncludeArgumentName:=False)
+
+
+
+
 
         clsConfidenLimFunction.SetPackageName("purrr")
         clsConfidenLimFunction.SetRCommand("map")
@@ -340,12 +380,14 @@ Public Class dlgPlacketLuceModel
     End Sub
 
     Private Sub cmdDisplayOptions_Click(sender As Object, e As EventArgs) Handles cmdDisplayOptions.Click
-        sdgDisplayModelOptions.SetRCode(clsNewWrapBarFunction:=clsWrapBarFunction, clsNewWrapPlotFunction:=clsWrapPlotFunction, clsNewHeatFunction:=clsHeatFunction, clsNewPlotFunction:=clsPlotFunction, clsNewBarfunction:=clsBarfunction, clsNewAnnovaFunction:=clsAnnovaFunction, clsNewSummaryFunction:=clsSummaryFunction, clsNewAICFunction:=clsAICFunction, clsNewCoefFunction:=clsCoefFunction, clsNewConfidenLimFunction:=clsConfidenLimFunction, clsNewDevianceFunction:=clsDevianceFunction, clsNewEstimatesFunction:=clsEstimatesFunction, clsNewItemsFunction:=clsItemsFunction, clsNewPariPropFunction:=clsPariPropFunction, clsNewQuasivarianceFunction:=clsQuasivarianceFunction, clsNewReliabilityFunction:=clsReliabilityFunction, clsNewRSyntax:=ucrBase.clsRsyntax, clsNewSecondEstimatesFunction:=clsSecondEstimatesFunction, clsNewStatsFunction:=clsStatsFunction, clsNewRegretFunction:=clsRegretFunction, clsNewTopItemFunction:=clsTopItemFunction, clsNewNodeRuleFunction:=clsNodeRuleFunction, clsNewNodeLabFuction:=clsNodeLabFuction, clsNewVarianCovaMatrixFunction:=clsVarianCovaMatrixFunction, clsNewTreeFunction:=clsTreeFunction, bReset:=bResetSubdialog)
+        sdgDisplayModelOptions.SetRCode(clsNewWrapBarFunction:=clsWrapBarFunction, clsNewWrapPlotFunction:=clsWrapPlotFunction, clsNewHeatFunction:=clsHeatFunction, clsNewPlotFunction:=clsPlotFunction, clsNewBarfunction:=clsBarfunction, clsNewAnnovaFunction:=clsAnnovaFunction, clsNewSummaryFunction:=clsSummaryFunction, clsNewAICFunction:=clsAICFunction, clsNewCoefFunction:=clsCoefFunction, clsNewConfidenLimFunction:=clsConfidenLimFunction, clsNewDevianceFunction:=clsDevianceFunction, clsNewEstimatesFunction:=clsEstimatesFunction, clsNewImportDataFunction:=clsImportDataFunction, clsNewPipeOperator:=clsPipeOperator, clsNewItemsFunction:=clsItemsFunction, clsNewPariPropFunction:=clsPariPropFunction, clsNewQuasivarianceFunction:=clsQuasivarianceFunction, clsNewReliabilityFunction:=clsReliabilityFunction, clsNewRSyntax:=ucrBase.clsRsyntax, clsNewSecondEstimatesFunction:=clsSecondEstimatesFunction, clsNewStatsFunction:=clsStatsFunction, clsNewRegretFunction:=clsRegretFunction, clsNewTopItemFunction:=clsTopItemFunction, clsNewNodeRuleFunction:=clsNodeRuleFunction, clsNewNodeLabFuction:=clsNodeLabFuction, clsNewVarianCovaMatrixFunction:=clsVarianCovaMatrixFunction, clsNewTreeFunction:=clsTreeFunction, bReset:=bResetSubdialog)
         sdgDisplayModelOptions.grpTrees.Enabled = False
         sdgDisplayModelOptions.rdoTree.Enabled = False
         sdgDisplayModelOptions.ucrChkANOVA.Enabled = True
         sdgDisplayModelOptions.ucrChkReability.Enabled = True
         sdgDisplayModelOptions.ucrChkQuasiVa.Enabled = True
+        sdgDisplayModelOptions.ucrChkSave.Enabled = True
+        sdgDisplayModelOptions.ucrChkSave.Visible = True
         sdgDisplayModelOptions.rdoPlot.Enabled = True
         sdgDisplayModelOptions.rdoBar.Enabled = True
         sdgDisplayModelOptions.rdoMap.Enabled = True

--- a/instat/dlgPlacketLuceModel.vb
+++ b/instat/dlgPlacketLuceModel.vb
@@ -74,15 +74,11 @@ Public Class dlgPlacketLuceModel
         clsAnnovaFunction = New RFunction
         clsSummaryFunction = New RFunction
         clsEstimatesFunction = New RFunction
-
-
         clsLdplyFunction = New RFunction
         clsPivotLongerFunction = New RFunction
         clsPivotWiderFunction = New RFunction
         clsListFunction = New RFunction
         clsImportDataFunction = New RFunction
-
-
         clsConfidenLimFunction = New RFunction
         clsAICFunction = New RFunction
         clsDevianceFunction = New RFunction
@@ -386,7 +382,6 @@ Public Class dlgPlacketLuceModel
         sdgDisplayModelOptions.ucrChkANOVA.Enabled = True
         sdgDisplayModelOptions.ucrChkReability.Enabled = True
         sdgDisplayModelOptions.ucrChkQuasiVa.Enabled = True
-        sdgDisplayModelOptions.ucrChkSave.Enabled = True
         sdgDisplayModelOptions.ucrChkSave.Visible = True
         sdgDisplayModelOptions.rdoPlot.Enabled = True
         sdgDisplayModelOptions.rdoBar.Enabled = True

--- a/instat/dlgTricotModelOneVarCov.Designer.vb
+++ b/instat/dlgTricotModelOneVarCov.Designer.vb
@@ -148,7 +148,7 @@ Partial Class dlgTricotModelOneVarCov
         Me.ucrInputCheckVariety.IsMultiline = False
         Me.ucrInputCheckVariety.IsReadOnly = False
         Me.ucrInputCheckVariety.Location = New System.Drawing.Point(144, 592)
-        Me.ucrInputCheckVariety.Margin = New System.Windows.Forms.Padding(14, 14, 14, 14)
+        Me.ucrInputCheckVariety.Margin = New System.Windows.Forms.Padding(14)
         Me.ucrInputCheckVariety.Name = "ucrInputCheckVariety"
         Me.ucrInputCheckVariety.Size = New System.Drawing.Size(484, 32)
         Me.ucrInputCheckVariety.TabIndex = 13
@@ -165,8 +165,9 @@ Partial Class dlgTricotModelOneVarCov
         '
         'dlgTricotModelOneVarCov
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(9.0!, 20.0!)
-        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
+        Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(674, 774)
         Me.Controls.Add(Me.lblCheckVariety)
         Me.Controls.Add(Me.ucrInputCheckVariety)
@@ -180,6 +181,9 @@ Partial Class dlgTricotModelOneVarCov
         Me.Controls.Add(Me.ucrTraitsReceiver)
         Me.Controls.Add(Me.ucrSelectorVarietyLevel)
         Me.Controls.Add(Me.ucrSelectorTraitsRanking)
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.MaximizeBox = False
+        Me.MinimizeBox = False
         Me.Name = "dlgTricotModelOneVarCov"
         Me.ShowIcon = False
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen

--- a/instat/dlgTricotModelOneVarCov.vb
+++ b/instat/dlgTricotModelOneVarCov.vb
@@ -396,7 +396,6 @@ Public Class dlgTricotModelOneVarCov
         sdgDisplayModelOptions.rdoTree.Enabled = False
         sdgDisplayModelOptions.rdoMap.Enabled = True
         sdgDisplayModelOptions.ucrChkSave.Checked = False
-        sdgDisplayModelOptions.ucrChkSave.Enabled = False
         sdgDisplayModelOptions.ucrChkSave.Visible = False
         sdgDisplayModelOptions.ucrChkConfLimits.Enabled = True
         sdgDisplayModelOptions.ucrChkVaCoMa.Enabled = True

--- a/instat/dlgTricotModelOneVarCov.vb
+++ b/instat/dlgTricotModelOneVarCov.vb
@@ -27,10 +27,10 @@ Public Class dlgTricotModelOneVarCov
         clsCoefFunction, clsConfidenLimFunction, clsDevianceFunction, clsEstimatesFunction, clsItemsFunction,
         clsPariPropFunction, clsQuasivarianceFunction, clsReliabilityFunction, clsSecondEstimatesFunction,
         clsStatsFunction, clsRegretFunction, clsTopItemFunction, clsNodeRuleFunction, clsNodeLabFuction,
-        clsTreeFunction, clsVarianCovaMatrixFunction As New RFunction
+        clsTreeFunction, clsVarianCovaMatrixFunction, clsImportDataFunction As New RFunction
 
     Private clsMapFunction As New RFunction
-    Private clsCoefOperator, clsStatsOperator, clsSpaceOpreator, clsAssignOperator As New ROperator
+    Private clsCoefOperator, clsStatsOperator, clsSpaceOpreator, clsAssignOperator, clsPipeOperator As New ROperator
 
     Private clsGetObjectFunction, clsGetRankingItemsFunction, clsGetColumn,
         clsLevelsFunction, clsFactorsFunction, clsMappingFunction, clsPladmmFunction, clsNamesFunction,
@@ -382,7 +382,7 @@ Public Class dlgTricotModelOneVarCov
                                         clsNewHeatFunction:=clsHeatFunction, clsNewPlotFunction:=clsPlotFunction, clsNewBarfunction:=clsBarfunction,
                                         clsNewAnnovaFunction:=clsAnnovaFunction, clsNewSummaryFunction:=clsSummaryFunction, clsNewAICFunction:=clsAICFunction,
                                         clsNewCoefFunction:=clsCoefFunction, clsNewConfidenLimFunction:=clsConfidenLimFunction,
-                                        clsNewDevianceFunction:=clsDevianceFunction, clsNewEstimatesFunction:=clsEstimatesFunction, clsNewItemsFunction:=clsItemsFunction,
+                                        clsNewDevianceFunction:=clsDevianceFunction, clsNewEstimatesFunction:=clsEstimatesFunction, clsNewImportDataFunction:=clsImportDataFunction, clsNewPipeOperator:=clsPipeOperator, clsNewItemsFunction:=clsItemsFunction,
                                         clsNewPariPropFunction:=clsPariPropFunction, clsNewQuasivarianceFunction:=clsQuasivarianceFunction, clsNewReliabilityFunction:=clsReliabilityFunction,
                                         clsNewRSyntax:=ucrBase.clsRsyntax, clsNewSecondEstimatesFunction:=clsSecondEstimatesFunction, clsNewStatsFunction:=clsStatsFunction, clsNewRegretFunction:=clsRegretFunction,
                                         clsNewTopItemFunction:=clsTopItemFunction, clsNewNodeRuleFunction:=clsNodeRuleFunction, clsNewNodeLabFuction:=clsNodeLabFuction,
@@ -395,7 +395,9 @@ Public Class dlgTricotModelOneVarCov
         sdgDisplayModelOptions.rdoBar.Enabled = False
         sdgDisplayModelOptions.rdoTree.Enabled = False
         sdgDisplayModelOptions.rdoMap.Enabled = True
-
+        sdgDisplayModelOptions.ucrChkSave.Checked = False
+        sdgDisplayModelOptions.ucrChkSave.Enabled = False
+        sdgDisplayModelOptions.ucrChkSave.Visible = False
         sdgDisplayModelOptions.ucrChkConfLimits.Enabled = True
         sdgDisplayModelOptions.ucrChkVaCoMa.Enabled = True
         sdgDisplayModelOptions.ucrChkEstimates.Enabled = True

--- a/instat/dlgTricotModellingGeneral.vb
+++ b/instat/dlgTricotModellingGeneral.vb
@@ -469,7 +469,6 @@ Public Class dlgTricotModellingGeneral
         sdgDisplayModelOptions.rdoTree.Enabled = False
         sdgDisplayModelOptions.rdoMap.Enabled = True
         sdgDisplayModelOptions.ucrChkSave.Checked = False
-        sdgDisplayModelOptions.ucrChkSave.Enabled = False
         sdgDisplayModelOptions.ucrChkSave.Visible = False
         sdgDisplayModelOptions.ucrChkConfLimits.Enabled = True
         sdgDisplayModelOptions.ucrChkVaCoMa.Enabled = True

--- a/instat/dlgTricotModellingGeneral.vb
+++ b/instat/dlgTricotModellingGeneral.vb
@@ -14,11 +14,11 @@ Public Class dlgTricotModellingGeneral
             clsPairwiseProbMainFunction, clsReliabilityFunction, clsItemsParFunction, clsRegretFunction, clsNodeLabelsFunction,
             clsNodeRulesFunction, clsTopItemsFunction, clsAICFunction, clsUnListAICFunction, clsAICMainFunction, clsAnnovaFunction,
             clsConfidenLimFunction, clsStatsFunction, clsQuasivarianceFunction, clsVarianCovaMatrixFunction, clsHeatFunction,
-            clsPlotFunction, clsBarfunction, clsWrapPlotFunction, clsWrapBarFunction, clsTreeFunction As New RFunction
+            clsPlotFunction, clsBarfunction, clsWrapPlotFunction, clsWrapBarFunction, clsTreeFunction, clsImportDataFunction As New RFunction
 
     Private clsObjectOperator, clsTildeOperator, clsTilde2Operator, clsBracketOperator, clsDevianceOperator, clsPairwiseProbOperator,
             clsNamesOperator, clsModelOperator, clsSpaceOperator, clsEmptySpaceOperator, clsCoefOperator,
-            clsAICOperator, clsStatsOperator As New ROperator
+            clsAICOperator, clsStatsOperator, clsPipeOperator As New ROperator
 
     Private Sub dlgTricotModellingGeneral_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
@@ -449,7 +449,7 @@ Public Class dlgTricotModellingGeneral
     Private Sub btnDisplayOptions_Click(sender As Object, e As EventArgs) Handles btnDisplayOptions.Click
         sdgDisplayModelOptions.SetRCode(clsNewSummaryFunction:=clsSummaryFunction,
             clsNewCoefFunction:=clscoefFunction, clsNewSecondEstimatesFunction:=clsSecondEstimatesFunction,
-            clsNewEstimatesFunction:=clsEstimatesFunction, clsNewDevianceFunction:=clsDevianceMainFunction,
+            clsNewEstimatesFunction:=clsEstimatesFunction, clsNewImportDataFunction:=clsImportDataFunction, clsNewPipeOperator:=clsPipeOperator, clsNewDevianceFunction:=clsDevianceMainFunction,
             clsNewPariPropFunction:=clsPairwiseProbMainFunction, clsNewReliabilityFunction:=clsReliabilityFunction,
             clsNewItemsFunction:=clsItemsParFunction, clsNewRegretFunction:=clsRegretFunction, clsNewNodeLabFuction:=clsNodeLabelsFunction,
             clsNewNodeRuleFunction:=clsNodeRulesFunction, clsNewTopItemFunction:=clsTopItemsFunction, clsNewRSyntax:=ucrBase.clsRsyntax, clsNewAICFunction:=clsUnListAICFunction,
@@ -468,7 +468,9 @@ Public Class dlgTricotModellingGeneral
         sdgDisplayModelOptions.rdoBar.Enabled = False
         sdgDisplayModelOptions.rdoTree.Enabled = False
         sdgDisplayModelOptions.rdoMap.Enabled = True
-
+        sdgDisplayModelOptions.ucrChkSave.Checked = False
+        sdgDisplayModelOptions.ucrChkSave.Enabled = False
+        sdgDisplayModelOptions.ucrChkSave.Visible = False
         sdgDisplayModelOptions.ucrChkConfLimits.Enabled = True
         sdgDisplayModelOptions.ucrChkVaCoMa.Enabled = True
         sdgDisplayModelOptions.ucrChkEstimates.Enabled = True

--- a/instat/sdgDisplayModelOptions.Designer.vb
+++ b/instat/sdgDisplayModelOptions.Designer.vb
@@ -34,11 +34,12 @@ Partial Class sdgDisplayModelOptions
         Me.ucrPnlPlots = New instat.UcrPanel()
         Me.ucrSavePlots = New instat.ucrSave()
         Me.tpDisplay = New System.Windows.Forms.TabPage()
+        Me.grpTrees = New System.Windows.Forms.GroupBox()
+        Me.ucrChkRegret = New instat.ucrCheck()
         Me.ucrNudNumber = New instat.ucrNud()
-        Me.ucrChkTopItem = New instat.ucrCheck()
         Me.ucrChkNodeLabel = New instat.ucrCheck()
         Me.ucrChkNodeRules = New instat.ucrCheck()
-        Me.ucrChkRegret = New instat.ucrCheck()
+        Me.ucrChkTopItem = New instat.ucrCheck()
         Me.ucrChkQuasiVa = New instat.ucrCheck()
         Me.ucrChkItemPara = New instat.ucrCheck()
         Me.ucrChkVaCoMa = New instat.ucrCheck()
@@ -55,11 +56,11 @@ Partial Class sdgDisplayModelOptions
         Me.ucrChkModel = New instat.ucrCheck()
         Me.tbpDisplayOptions = New System.Windows.Forms.TabControl()
         Me.ucrSdgButtons = New instat.ucrButtonsSubdialogue()
-        Me.grpTrees = New System.Windows.Forms.GroupBox()
+        Me.ucrChkSave = New instat.ucrCheck()
         Me.tpGraphics.SuspendLayout()
         Me.tpDisplay.SuspendLayout()
-        Me.tbpDisplayOptions.SuspendLayout()
         Me.grpTrees.SuspendLayout()
+        Me.tbpDisplayOptions.SuspendLayout()
         Me.SuspendLayout()
         '
         'lblNumber
@@ -76,7 +77,7 @@ Partial Class sdgDisplayModelOptions
         'lblConfLevel
         '
         Me.lblConfLevel.AutoSize = True
-        Me.lblConfLevel.Location = New System.Drawing.Point(106, 169)
+        Me.lblConfLevel.Location = New System.Drawing.Point(106, 189)
         Me.lblConfLevel.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblConfLevel.Name = "lblConfLevel"
         Me.lblConfLevel.Size = New System.Drawing.Size(135, 20)
@@ -205,6 +206,7 @@ Partial Class sdgDisplayModelOptions
         Me.tpDisplay.Controls.Add(Me.ucrChkANOVA)
         Me.tpDisplay.Controls.Add(Me.ucrChkModel)
         Me.tpDisplay.Controls.Add(Me.lblConfLevel)
+        Me.tpDisplay.Controls.Add(Me.ucrChkSave)
         Me.tpDisplay.Location = New System.Drawing.Point(4, 29)
         Me.tpDisplay.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.tpDisplay.Name = "tpDisplay"
@@ -214,6 +216,31 @@ Partial Class sdgDisplayModelOptions
         Me.tpDisplay.Tag = "Display"
         Me.tpDisplay.Text = "Display"
         Me.tpDisplay.UseVisualStyleBackColor = True
+        '
+        'grpTrees
+        '
+        Me.grpTrees.Controls.Add(Me.ucrChkRegret)
+        Me.grpTrees.Controls.Add(Me.ucrNudNumber)
+        Me.grpTrees.Controls.Add(Me.ucrChkNodeLabel)
+        Me.grpTrees.Controls.Add(Me.lblNumber)
+        Me.grpTrees.Controls.Add(Me.ucrChkNodeRules)
+        Me.grpTrees.Controls.Add(Me.ucrChkTopItem)
+        Me.grpTrees.Location = New System.Drawing.Point(20, 215)
+        Me.grpTrees.Name = "grpTrees"
+        Me.grpTrees.Size = New System.Drawing.Size(360, 247)
+        Me.grpTrees.TabIndex = 12
+        Me.grpTrees.TabStop = False
+        Me.grpTrees.Text = "Tree Options"
+        '
+        'ucrChkRegret
+        '
+        Me.ucrChkRegret.AutoSize = True
+        Me.ucrChkRegret.Checked = False
+        Me.ucrChkRegret.Location = New System.Drawing.Point(12, 40)
+        Me.ucrChkRegret.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrChkRegret.Name = "ucrChkRegret"
+        Me.ucrChkRegret.Size = New System.Drawing.Size(348, 34)
+        Me.ucrChkRegret.TabIndex = 25
         '
         'ucrNudNumber
         '
@@ -228,16 +255,6 @@ Partial Class sdgDisplayModelOptions
         Me.ucrNudNumber.Size = New System.Drawing.Size(75, 31)
         Me.ucrNudNumber.TabIndex = 30
         Me.ucrNudNumber.Value = New Decimal(New Integer() {0, 0, 0, 0})
-        '
-        'ucrChkTopItem
-        '
-        Me.ucrChkTopItem.AutoSize = True
-        Me.ucrChkTopItem.Checked = False
-        Me.ucrChkTopItem.Location = New System.Drawing.Point(12, 167)
-        Me.ucrChkTopItem.Margin = New System.Windows.Forms.Padding(9)
-        Me.ucrChkTopItem.Name = "ucrChkTopItem"
-        Me.ucrChkTopItem.Size = New System.Drawing.Size(348, 34)
-        Me.ucrChkTopItem.TabIndex = 28
         '
         'ucrChkNodeLabel
         '
@@ -259,15 +276,15 @@ Partial Class sdgDisplayModelOptions
         Me.ucrChkNodeRules.Size = New System.Drawing.Size(348, 34)
         Me.ucrChkNodeRules.TabIndex = 26
         '
-        'ucrChkRegret
+        'ucrChkTopItem
         '
-        Me.ucrChkRegret.AutoSize = True
-        Me.ucrChkRegret.Checked = False
-        Me.ucrChkRegret.Location = New System.Drawing.Point(12, 40)
-        Me.ucrChkRegret.Margin = New System.Windows.Forms.Padding(9)
-        Me.ucrChkRegret.Name = "ucrChkRegret"
-        Me.ucrChkRegret.Size = New System.Drawing.Size(348, 34)
-        Me.ucrChkRegret.TabIndex = 25
+        Me.ucrChkTopItem.AutoSize = True
+        Me.ucrChkTopItem.Checked = False
+        Me.ucrChkTopItem.Location = New System.Drawing.Point(12, 167)
+        Me.ucrChkTopItem.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrChkTopItem.Name = "ucrChkTopItem"
+        Me.ucrChkTopItem.Size = New System.Drawing.Size(348, 34)
+        Me.ucrChkTopItem.TabIndex = 28
         '
         'ucrChkQuasiVa
         '
@@ -364,7 +381,7 @@ Partial Class sdgDisplayModelOptions
         Me.ucrNudConfLevel.AutoSize = True
         Me.ucrNudConfLevel.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudConfLevel.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudConfLevel.Location = New System.Drawing.Point(253, 167)
+        Me.ucrNudConfLevel.Location = New System.Drawing.Point(253, 187)
         Me.ucrNudConfLevel.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrNudConfLevel.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
         Me.ucrNudConfLevel.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
@@ -387,7 +404,7 @@ Partial Class sdgDisplayModelOptions
         '
         Me.ucrChkConfLimits.AutoSize = True
         Me.ucrChkConfLimits.Checked = False
-        Me.ucrChkConfLimits.Location = New System.Drawing.Point(18, 135)
+        Me.ucrChkConfLimits.Location = New System.Drawing.Point(18, 155)
         Me.ucrChkConfLimits.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkConfLimits.Name = "ucrChkConfLimits"
         Me.ucrChkConfLimits.Size = New System.Drawing.Size(348, 34)
@@ -433,20 +450,15 @@ Partial Class sdgDisplayModelOptions
         Me.ucrSdgButtons.Size = New System.Drawing.Size(336, 46)
         Me.ucrSdgButtons.TabIndex = 11
         '
-        'grpTrees
+        'ucrChkSave
         '
-        Me.grpTrees.Controls.Add(Me.ucrChkRegret)
-        Me.grpTrees.Controls.Add(Me.ucrNudNumber)
-        Me.grpTrees.Controls.Add(Me.ucrChkNodeLabel)
-        Me.grpTrees.Controls.Add(Me.lblNumber)
-        Me.grpTrees.Controls.Add(Me.ucrChkNodeRules)
-        Me.grpTrees.Controls.Add(Me.ucrChkTopItem)
-        Me.grpTrees.Location = New System.Drawing.Point(20, 215)
-        Me.grpTrees.Name = "grpTrees"
-        Me.grpTrees.Size = New System.Drawing.Size(360, 247)
-        Me.grpTrees.TabIndex = 12
-        Me.grpTrees.TabStop = False
-        Me.grpTrees.Text = "Tree Options"
+        Me.ucrChkSave.AutoSize = True
+        Me.ucrChkSave.Checked = False
+        Me.ucrChkSave.Location = New System.Drawing.Point(250, 128)
+        Me.ucrChkSave.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrChkSave.Name = "ucrChkSave"
+        Me.ucrChkSave.Size = New System.Drawing.Size(348, 34)
+        Me.ucrChkSave.TabIndex = 25
         '
         'sdgDisplayModelOptions
         '
@@ -466,9 +478,9 @@ Partial Class sdgDisplayModelOptions
         Me.tpGraphics.PerformLayout()
         Me.tpDisplay.ResumeLayout(False)
         Me.tpDisplay.PerformLayout()
-        Me.tbpDisplayOptions.ResumeLayout(False)
         Me.grpTrees.ResumeLayout(False)
         Me.grpTrees.PerformLayout()
+        Me.tbpDisplayOptions.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -508,4 +520,5 @@ Partial Class sdgDisplayModelOptions
     Friend WithEvents ucrPnlPlots As UcrPanel
     Friend WithEvents rdoTree As RadioButton
     Friend WithEvents grpTrees As GroupBox
+    Friend WithEvents ucrChkSave As ucrCheck
 End Class

--- a/instat/sdgDisplayModelOptions.vb
+++ b/instat/sdgDisplayModelOptions.vb
@@ -18,8 +18,9 @@ Imports instat.Translations
 
 Public Class sdgDisplayModelOptions
     Private clsSummaryFunction, clsNodeLabFuction, clsNodeRuleFunction, clsTopItemFunction, clsRegretFunction, clsAnnovaFunction, clsEstimatesFunction, clsConfidenLimFunction, clsAICFunction, clsDevianceFunction, clsSecondEstimatesFunction, clsPariPropFunction, clsReliabilityFunction, clsItemsFunction, clsVarianCovaMatrixFunction, clsQuasivarianceFunction As RFunction
-    Private clsCoefFunction, clsStatsFunction As RFunction
+    Private clsCoefFunction, clsStatsFunction, clsImportDataFunction As RFunction
     Private clsDummyFunction, clsPlotFunction, clsHeatFunction, clsWrapBarFunction, clsWrapPlotFunction, clsBarfunction, clsTreeFunction As RFunction
+    Private clsPipeOperator As New ROperator
     Private bControlsInitialised As Boolean = False
     Private bInitialised As Boolean = False
 
@@ -41,11 +42,15 @@ Public Class sdgDisplayModelOptions
         ucrChkEstimates.SetText("Coefficients")
         ucrChkEstimates.AddRSyntaxContainsFunctionNamesCondition(True, {"coef"}, True)
         ucrChkEstimates.AddRSyntaxContainsFunctionNamesCondition(False, {"coef"}, False)
-        ucrChkEstimates.AddToLinkedControls(ucrChkLog, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrChkEstimates.AddToLinkedControls({ucrChkLog, ucrChkSave}, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
 
         ucrChkLog.SetText("Log")
         ucrChkLog.AddRSyntaxContainsFunctionNamesCondition(True, {"log"}, True)
         ucrChkLog.AddRSyntaxContainsFunctionNamesCondition(False, {"log"}, False)
+
+        ucrChkSave.SetText("Save")
+        ucrChkSave.AddRSyntaxContainsFunctionNamesCondition(True, {"save"}, True)
+        ucrChkSave.AddRSyntaxContainsFunctionNamesCondition(False, {"save"}, False)
 
         ucrChkConfLimits.SetText("Confidence Limits")
         ucrChkConfLimits.AddRSyntaxContainsFunctionNamesCondition(True, {"confint"}, True)
@@ -141,7 +146,7 @@ Public Class sdgDisplayModelOptions
         bControlsInitialised = False
     End Sub
 
-    Public Sub SetRCode(clsNewRSyntax As RSyntax, clsNewWrapPlotFunction As RFunction, clsNewWrapBarFunction As RFunction, clsNewSummaryFunction As RFunction, clsNewAnnovaFunction As RFunction, clsNewEstimatesFunction As RFunction, clsNewConfidenLimFunction As RFunction, clsNewAICFunction As RFunction, clsNewDevianceFunction As RFunction, clsNewSecondEstimatesFunction As RFunction, clsNewPariPropFunction As RFunction, clsNewReliabilityFunction As RFunction, clsNewItemsFunction As RFunction, clsNewVarianCovaMatrixFunction As RFunction, clsNewQuasivarianceFunction As RFunction, clsNewCoefFunction As RFunction, clsNewStatsFunction As RFunction, clsNewNodeLabFuction As RFunction, clsNewNodeRuleFunction As RFunction, clsNewTopItemFunction As RFunction, clsNewRegretFunction As RFunction, clsNewPlotFunction As RFunction, clsNewHeatFunction As RFunction, clsNewBarfunction As RFunction, clsNewTreeFunction As RFunction, Optional bReset As Boolean = False)
+    Public Sub SetRCode(clsNewRSyntax As RSyntax, clsNewWrapPlotFunction As RFunction, clsNewWrapBarFunction As RFunction, clsNewSummaryFunction As RFunction, clsNewAnnovaFunction As RFunction, clsNewEstimatesFunction As RFunction, clsNewImportDataFunction As RFunction, clsNewPipeOperator As ROperator, clsNewConfidenLimFunction As RFunction, clsNewAICFunction As RFunction, clsNewDevianceFunction As RFunction, clsNewSecondEstimatesFunction As RFunction, clsNewPariPropFunction As RFunction, clsNewReliabilityFunction As RFunction, clsNewItemsFunction As RFunction, clsNewVarianCovaMatrixFunction As RFunction, clsNewQuasivarianceFunction As RFunction, clsNewCoefFunction As RFunction, clsNewStatsFunction As RFunction, clsNewNodeLabFuction As RFunction, clsNewNodeRuleFunction As RFunction, clsNewTopItemFunction As RFunction, clsNewRegretFunction As RFunction, clsNewPlotFunction As RFunction, clsNewHeatFunction As RFunction, clsNewBarfunction As RFunction, clsNewTreeFunction As RFunction, Optional bReset As Boolean = False)
         ucrNudConfLevel.SetText("0.95")
         If Not bControlsInitialised Then
             InitialiseDialog()
@@ -154,6 +159,8 @@ Public Class sdgDisplayModelOptions
         clsAnnovaFunction = clsNewAnnovaFunction
         clsSummaryFunction = clsNewSummaryFunction
         clsEstimatesFunction = clsNewEstimatesFunction
+        clsImportDataFunction = clsNewImportDataFunction
+        clsPipeOperator = clsNewPipeOperator
         clsConfidenLimFunction = clsNewConfidenLimFunction
         clsAICFunction = clsNewAICFunction
         clsDevianceFunction = clsNewDevianceFunction
@@ -180,6 +187,7 @@ Public Class sdgDisplayModelOptions
             ucrChkANOVA.SetRSyntax(clsRSyntax, bReset, bCloneIfNeeded:=True)
             ucrChkModel.SetRCode(clsDummyFunction, bReset)
             ucrChkEstimates.SetRSyntax(clsRSyntax, bReset, bCloneIfNeeded:=True)
+            ucrChkSave.SetRSyntax(clsRSyntax, bReset, bCloneIfNeeded:=True)
             ucrChkLog.SetRCode(clsCoefFunction, bReset, bCloneIfNeeded:=True)
             ucrChkAIC.SetRSyntax(clsRSyntax, bReset, bCloneIfNeeded:=True)
             ucrChkConfLimits.SetRSyntax(clsRSyntax, bReset, bCloneIfNeeded:=True)
@@ -239,9 +247,10 @@ Public Class sdgDisplayModelOptions
 
     Private Sub ucrChkEstimates_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkEstimates.ControlValueChanged
         If ucrChkEstimates.Checked Then
-            clsRSyntax.AddToBeforeCodes(clsEstimatesFunction)
+            clsRSyntax.AddToBeforeCodes(clsEstimatesFunction, iPosition:=11)
         Else
             clsRSyntax.RemoveFromBeforeCodes(clsEstimatesFunction)
+            ucrChkSave.Checked = False
         End If
     End Sub
 
@@ -260,6 +269,21 @@ Public Class sdgDisplayModelOptions
             clsCoefFunction.RemoveParameterByName("log")
         End If
     End Sub
+
+    Private Sub ucrChkSave_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkSave.ControlValueChanged
+
+
+        If ucrChkSave.Checked Then
+            clsEstimatesFunction.SetAssignTo("coefficients_data")
+            clsRSyntax.AddToBeforeCodes(clsPipeOperator, iPosition:=12)
+            clsRSyntax.AddToBeforeCodes(clsImportDataFunction, iPosition:=13)
+        Else
+            clsEstimatesFunction.RemoveAssignTo()
+            clsRSyntax.RemoveFromBeforeCodes(clsPipeOperator)
+            clsRSyntax.RemoveFromBeforeCodes(clsImportDataFunction)
+        End If
+    End Sub
+
 
     Private Sub ucrChkModel_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkModel.ControlValueChanged
         AddRemoveSummary()

--- a/instat/sdgDisplayModelOptions.vb
+++ b/instat/sdgDisplayModelOptions.vb
@@ -48,7 +48,7 @@ Public Class sdgDisplayModelOptions
         ucrChkLog.AddRSyntaxContainsFunctionNamesCondition(True, {"log"}, True)
         ucrChkLog.AddRSyntaxContainsFunctionNamesCondition(False, {"log"}, False)
 
-        ucrChkSave.SetText("Save")
+        ucrChkSave.SetText("Store")
         ucrChkSave.AddRSyntaxContainsFunctionNamesCondition(True, {"save"}, True)
         ucrChkSave.AddRSyntaxContainsFunctionNamesCondition(False, {"save"}, False)
 

--- a/instat/sdgDisplayModelOptions.vb
+++ b/instat/sdgDisplayModelOptions.vb
@@ -48,7 +48,7 @@ Public Class sdgDisplayModelOptions
         ucrChkLog.AddRSyntaxContainsFunctionNamesCondition(True, {"log"}, True)
         ucrChkLog.AddRSyntaxContainsFunctionNamesCondition(False, {"log"}, False)
 
-        ucrChkSave.SetText("Store")
+        ucrChkSave.SetText("Store as Data Frame")
         ucrChkSave.AddRSyntaxContainsFunctionNamesCondition(True, {"save"}, True)
         ucrChkSave.AddRSyntaxContainsFunctionNamesCondition(False, {"save"}, False)
 


### PR DESCRIPTION
Fixed #9688 
@lilyclements @rdstern 
I have added the save checkbox that is visible when the coefficients checkbox is checked. This is only available for the modelling (no covariate) dialog as specified in the issue. I added some snippets to the other modelling dialog to ensure that the save option is not available there. Kindly check and let me know if there are any more required changes. Thank you.

Also, I realized the one covariate dialog had the maximize and minimize buttons on the dialog, so I change it to disable those options (as we have for the other dialogs).