### PR TITLE
Fixed Bug in Describe two variable summarise

### DIFF
--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -74,7 +74,6 @@ Public Class dlgDescribeTwoVariable
         ucrBase.clsRsyntax.iCallType = 2
         ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
 
-
         iUcrBaseXLocation = ucrBase.Location.X
         iDialogueXsize = Me.Size.Width
 

--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -74,6 +74,7 @@ Public Class dlgDescribeTwoVariable
         ucrBase.clsRsyntax.iCallType = 2
         ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
 
+
         iUcrBaseXLocation = ucrBase.Location.X
         iDialogueXsize = Me.Size.Width
 
@@ -1142,6 +1143,7 @@ Public Class dlgDescribeTwoVariable
         ElseIf rdoTwoVariable.Checked Then
             clsMapSummaryFunction.AddParameter(".f", clsROperatorParameter:=clsMapOperator, iPosition:=1)
             clsSummaryOperator.AddParameter("tableFun", clsRFunctionParameter:=clsMapSummaryFunction, iPosition:=2)
+            clsGtTableROperator.AddParameter(strParameterName:="gt_tbl", clsRFunctionParameter:=clsgtFunction, iPosition:=0, bIncludeArgumentName:=False)
         End If
     End Sub
 


### PR DESCRIPTION
Fixes #9712 
Added` instatExtras::generate_summary_tables` which was missing in the two variable option of the Two variable summarise dialog.
@lilyclements , @rdstern can review this 
Thanks