### PR TITLE
Use date instead of doy in climatic summary dialog

### DIFF
--- a/instat/dlgEndOfRainsSeason.vb
+++ b/instat/dlgEndOfRainsSeason.vb
@@ -1331,8 +1331,9 @@ Public Class dlgEndOfRainsSeason
     End Sub
 
     Private Sub cmdDoyRange_Click(sender As Object, e As EventArgs) Handles cmdDoyRange.Click
-        sdgDoyRange.Setup(clsNewDoyFilterCalc:=clsDoyFilterCalc, clsNewDayFromOperator:=clsDayFromOperator, clsNewIfElseFirstDoyFilledFunction:=clsIfElseFirstDoyFilledFunction, clsNewDayToOperator:=clsDayToOperator, clsNewCalcFromList:=clsDoyFilterCalcFromList, strNewMainDataFrame:=ucrSelectorForWaterBalance.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strNewDoyColumn:=ucrReceiverDOY.GetVariableNames(False))
+        sdgDoyRange.Setup(clsNewDoyFilterCalc:=clsDoyFilterCalc, clsNewDayFromOperator:=clsDayFromOperator, clsNewIfElseFirstDoyFilledFunction:=clsIfElseFirstDoyFilledFunction, clsNewDayToOperator:=clsDayToOperator, clsNewCalcFromList:=clsDoyFilterCalcFromList, strNewMainDataFrame:=ucrSelectorForWaterBalance.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strNewDoyColumn:=ucrReceiverDOY.GetVariableNames(False), bSetUseDateVisible:=False)
         sdgDoyRange.ShowDialog()
+        sdgDoyRange.SetUseDateVisibility(False)
         UpdateDayFilterPreview()
     End Sub
 

--- a/instat/dlgExtremesClimatic.vb
+++ b/instat/dlgExtremesClimatic.vb
@@ -665,8 +665,9 @@ Public Class dlgExtremesClimatic
     End Sub
 
     Private Sub cmdDoyRange_Click(sender As Object, e As EventArgs) Handles cmdDoyRange.Click
-        sdgDoyRange.Setup(clsNewDoyFilterCalc:=clsDayFromAndTo, clsNewIfElseFirstDoyFilledFunction:=clsIfElseFirstDoyFilledFunction, clsNewDayFromOperator:=clsDayFromOperator, clsNewDayToOperator:=clsDayToOperator, clsNewCalcFromList:=clsDayFilterCalcFromList, strNewMainDataFrame:=ucrSelectorClimaticExtremes.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strNewDoyColumn:=ucrReceiverDOY.GetVariableNames(False))
+        sdgDoyRange.Setup(clsNewDoyFilterCalc:=clsDayFromAndTo, clsNewIfElseFirstDoyFilledFunction:=clsIfElseFirstDoyFilledFunction, clsNewDayFromOperator:=clsDayFromOperator, clsNewDayToOperator:=clsDayToOperator, clsNewCalcFromList:=clsDayFilterCalcFromList, strNewMainDataFrame:=ucrSelectorClimaticExtremes.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strNewDoyColumn:=ucrReceiverDOY.GetVariableNames(False), bSetUseDateVisible:=False)
         sdgDoyRange.ShowDialog()
+        sdgDoyRange.SetUseDateVisibility(False)
         UpdateDayFilterPreview()
         AddDayRange()
     End Sub

--- a/instat/dlgSpells.vb
+++ b/instat/dlgSpells.vb
@@ -365,7 +365,8 @@ Public Class dlgSpells
     End Sub
 
     Private Sub cmdDoyRange_Click(sender As Object, e As EventArgs) Handles cmdDoyRange.Click
-        sdgDoyRange.Setup(clsNewDoyFilterCalc:=clsDayFilter, clsNewIfElseFirstDoyFilledFunction:=clsIfElseFirstDoyFilledFunction, clsNewDayFromOperator:=clsDayFromOperator, clsNewDayToOperator:=clsDayToOperator, clsNewCalcFromList:=clsDayFilterCalcFromList, strNewMainDataFrame:=ucrSelectorForSpells.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strNewDoyColumn:=ucrReceiverDOY.GetVariableNames(False))
+        sdgDoyRange.Setup(clsNewDoyFilterCalc:=clsDayFilter, clsNewIfElseFirstDoyFilledFunction:=clsIfElseFirstDoyFilledFunction, clsNewDayFromOperator:=clsDayFromOperator, clsNewDayToOperator:=clsDayToOperator, clsNewCalcFromList:=clsDayFilterCalcFromList, strNewMainDataFrame:=ucrSelectorForSpells.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strNewDoyColumn:=ucrReceiverDOY.GetVariableNames(False), bSetUseDateVisible:=False)
+        sdgDoyRange.SetUseDateVisibility(False)
         sdgDoyRange.ShowDialog()
         UpdateDayFilterPreview()
         AddDayRange()

--- a/instat/dlgStartofRains.vb
+++ b/instat/dlgStartofRains.vb
@@ -974,8 +974,9 @@ Public Class dlgStartofRains
     End Sub
 
     Private Sub cmdDoyRange_Click(sender As Object, e As EventArgs) Handles cmdDoyRange.Click
-        sdgDoyRange.Setup(clsNewDoyFilterCalc:=clsDayFromAndTo, clsNewIfElseFirstDoyFilledFunction:=clsIfElseFirstDoyFilledFunction, clsNewDayFromOperator:=clsDayFromOperator, clsNewDayToOperator:=clsDayToOperator, clsNewCalcFromList:=clsDayFilterCalcFromList, strNewMainDataFrame:=ucrSelectorForStartofRains.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strNewDoyColumn:=ucrReceiverDOY.GetVariableNames(False))
+        sdgDoyRange.Setup(clsNewDoyFilterCalc:=clsDayFromAndTo, clsNewIfElseFirstDoyFilledFunction:=clsIfElseFirstDoyFilledFunction, clsNewDayFromOperator:=clsDayFromOperator, clsNewDayToOperator:=clsDayToOperator, clsNewCalcFromList:=clsDayFilterCalcFromList, strNewMainDataFrame:=ucrSelectorForStartofRains.ucrAvailableDataFrames.cboAvailableDataFrames.Text, strNewDoyColumn:=ucrReceiverDOY.GetVariableNames(False), bSetUseDateVisible:=False)
         sdgDoyRange.ShowDialog()
+        sdgDoyRange.SetUseDateVisibility(False)
         UpdateDayFilterPreview()
     End Sub
 

--- a/instat/sdgDoyRange.Designer.vb
+++ b/instat/sdgDoyRange.Designer.vb
@@ -40,6 +40,7 @@ Partial Class sdgDoyRange
         Me.ucrPnlTo = New instat.UcrPanel()
         Me.ucrSelectorDoy = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBaseSub = New instat.ucrButtonsSubdialogue()
+        Me.ucrChkUseDate = New instat.ucrCheck()
         Me.grpFrom.SuspendLayout()
         Me.grpTo.SuspendLayout()
         Me.SuspendLayout()
@@ -242,12 +243,22 @@ Partial Class sdgDoyRange
         Me.ucrBaseSub.Size = New System.Drawing.Size(224, 30)
         Me.ucrBaseSub.TabIndex = 3
         '
+        'ucrChkUseDate
+        '
+        Me.ucrChkUseDate.AutoSize = True
+        Me.ucrChkUseDate.Checked = False
+        Me.ucrChkUseDate.Location = New System.Drawing.Point(257, 169)
+        Me.ucrChkUseDate.Name = "ucrChkUseDate"
+        Me.ucrChkUseDate.Size = New System.Drawing.Size(100, 23)
+        Me.ucrChkUseDate.TabIndex = 4
+        '
         'sdgDoyRange
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
         Me.ClientSize = New System.Drawing.Size(587, 357)
+        Me.Controls.Add(Me.ucrChkUseDate)
         Me.Controls.Add(Me.grpTo)
         Me.Controls.Add(Me.ucrSelectorDoy)
         Me.Controls.Add(Me.grpFrom)
@@ -285,4 +296,5 @@ Partial Class sdgDoyRange
     Friend WithEvents ucrSelectorDoy As ucrSelectorByDataFrameAddRemove
     Friend WithEvents ucrDoyFrom As ucrDayOfYear
     Friend WithEvents lblToDays As Label
+    Friend WithEvents ucrChkUseDate As ucrCheck
 End Class

--- a/instat/sdgDoyRange.vb
+++ b/instat/sdgDoyRange.vb
@@ -28,12 +28,15 @@ Public Class sdgDoyRange
     Private strMainDataFrame As String
     Private strDoyColumn As String
     Private bUpdate As Boolean = True
+    Private bReset As Boolean = True
+    Private bUseDateVisibility As Boolean = False ' Default to False or set as needed
+
 
     Private Sub sdgDoyRange_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         autoTranslate(Me)
     End Sub
 
-    Public Sub Setup(clsNewDoyFilterCalc As RFunction, clsNewDayFromOperator As ROperator, clsNewDayToOperator As ROperator, clsNewCalcFromList As RFunction, strNewMainDataFrame As String, strNewDoyColumn As String, Optional clsNewIfElseFirstDoyFilledFunction As RFunction = Nothing)
+    Public Sub Setup(clsNewDoyFilterCalc As RFunction, clsNewDayFromOperator As ROperator, clsNewDayToOperator As ROperator, clsNewCalcFromList As RFunction, strNewMainDataFrame As String, strNewDoyColumn As String, Optional clsNewIfElseFirstDoyFilledFunction As RFunction = Nothing, Optional bReset As Boolean = False, Optional bSetUseDateVisible As Boolean = False)
         Dim iFrom As Integer
         Dim iTo As Integer
         Dim iDiff As Integer
@@ -50,15 +53,22 @@ Public Class sdgDoyRange
         Dim iNewStartDay As Integer
 
         If Not bControlsInitialised Then
+            bUseDateVisibility = bSetUseDateVisible
             bUpdate = False
             InitialiseControls()
             bUpdate = True
         End If
+
+        If bReset Then
+            ucrChkUseDate.Checked = False
+        End If
+
         clsDoyFilterCalc = clsNewDoyFilterCalc
         clsCalcFromList = clsNewCalcFromList
         clsIfElseFirstDoyFilledFunction = clsNewIfElseFirstDoyFilledFunction
         strMainDataFrame = strNewMainDataFrame
         strDoyColumn = strNewDoyColumn
+
 
         ucrSelectorDoy.SetPrimaryDataFrameOptions(strMainDataFrame, True, True)
 
@@ -167,8 +177,8 @@ Public Class sdgDoyRange
         ucrPnlTo.AddToLinkedControls(ucrNudToDiff, {rdoLength}, bNewLinkedHideIfParameterMissing:=True)
 
         ucrReceiverFrom.Selector = ucrSelectorDoy
-        'Strict because we only want numeric/integer, not Dates etc.
-        ucrReceiverFrom.SetIncludedDataTypes({"numeric"}, bStrict:=True)
+        'Strict because we only want numeric/integer, Dates etc.
+        ucrReceiverFrom.SetIncludedDataTypes({"numeric", "Date"}, bStrict:=True)
         ucrReceiverFrom.strSelectorHeading = "Numerics"
 
         ucrReceiverTo.Selector = ucrSelectorDoy
@@ -177,6 +187,9 @@ Public Class sdgDoyRange
 
         ucrDoyFrom.SetParameterIsNumber()
         ucrDoyTo.SetParameterIsNumber()
+
+        ucrChkUseDate.SetText("Use Date")
+        ucrChkUseDate.Visible = bUseDateVisibility
 
         bControlsInitialised = True
         ucrSelectorDoy.Reset()
@@ -265,4 +278,23 @@ Public Class sdgDoyRange
         UpdateFromValues()
         UpdateToValues()
     End Sub
+
+    Private Sub ucrChkUseDate_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkUseDate.ControlValueChanged
+        dlgClimaticSummary.AddDateDoy()
+    End Sub
+
+    Public ReadOnly Property UseDateChecked As Boolean
+        Get
+            Return ucrChkUseDate.Checked
+        End Get
+    End Property
+
+    Public Sub SetUseDateVisibility(bVisible As Boolean)
+        bUseDateVisibility = bVisible
+        If bControlsInitialised Then
+            ucrChkUseDate.Visible = bVisible
+        End If
+    End Sub
+
+
 End Class


### PR DESCRIPTION
Fixes #9622 
@rdstern @lilyclements , it uses date instead of doy in climatic summary dialog when Use date checkbox is checked 