### PR TITLE
Extended the One Covariate and Modelling General dialogs

### DIFF
--- a/instat/dlgTricotModelOneVarCov.vb
+++ b/instat/dlgTricotModelOneVarCov.vb
@@ -21,22 +21,25 @@ Public Class dlgTricotModelOneVarCov
     Private bReset As Boolean = True
     Public bResetSubDialog As Boolean = False
     Private bIsUnique As Boolean = True
+    Private bCheck7Passed As Boolean = False
     Private clsGetVariablesMetadataFunction As New RFunction
     Private clsWrapBarFunction, clsWrapPlotFunction,
         clsHeatFunction, clsPlotFunction, clsBarfunction, clsAnnovaFunction, clsSummaryFunction, clsAICFunction,
         clsCoefFunction, clsConfidenLimFunction, clsDevianceFunction, clsEstimatesFunction, clsItemsFunction,
         clsPariPropFunction, clsQuasivarianceFunction, clsReliabilityFunction, clsSecondEstimatesFunction,
         clsStatsFunction, clsRegretFunction, clsTopItemFunction, clsNodeRuleFunction, clsNodeLabFuction,
-        clsTreeFunction, clsVarianCovaMatrixFunction, clsImportDataFunction, clsWrapTrees As New RFunction
+        clsTreeFunction, clsVarianCovaMatrixFunction, clsImportDataFunction, clsWrapTrees,
+        clsGetVarFromMetaData, clsGetColumnFromData, clsDataUnstackedFunction, clsPullFunction, clsLevels2Function,
+        clsFactor2Function, clsPladmm2Function, clsMap2Function, clsNames2Function, clsDataFunction, clsGetDataFrame As New RFunction
 
     Private clsMapFunction As New RFunction
-    Private clsCoefOperator, clsStatsOperator, clsSpaceOpreator, clsAssignOperator, clsPipeOperator As New ROperator
+    Private clsCoefOperator, clsStatsOperator, clsSpaceOpreator, clsAssignOperator, clsPipeOperator, clsPipe2Operator, clsNames2Operator As New ROperator
 
     Private clsGetObjectFunction, clsGetRankingItemsFunction, clsGetColumn,
         clsLevelsFunction, clsFactorsFunction, clsMappingFunction, clsPladmmFunction, clsNamesFunction,
         clsCheckUniqueFunction As New RFunction
-    Private clsObjectOperator, clsTildeOperator, clsTilde2Operator, clsBracketOperator,
-        clsNamesOperator, clsModelOperator, clsSpaceOperator, clsTilde3Operator As New ROperator
+    Private clsObjectOperator, clsTildeOperator, clsTilde2Operator, clsBracketOperator, clsTilde5Operator, clsTilde6Operator,
+        clsNamesOperator, clsModelOperator, clsSpaceOperator, clsTilde3Operator, clsBracket2Operator As New ROperator
 
 
     Private Sub dlgTricotModelOneVarCov_Load(sender As Object, e As EventArgs) Handles MyBase.Load
@@ -47,7 +50,7 @@ Public Class dlgTricotModelOneVarCov
         If bReset Then
             setDefaults()
         End If
-
+        bCheck7Passed = False
         SetRcodeForControls(bReset)
         bReset = False
         autoTranslate(Me)
@@ -67,13 +70,15 @@ Public Class dlgTricotModelOneVarCov
         ucrTraitsReceiver.strSelectorHeading = "Traits"
         ucrTraitsReceiver.SetTricotType({"traits"})
 
-        ucrSelectorVarietyLevel.SetParameter(New RParameter("data", 3))
+        ucrSelectorVarietyLevel.SetParameter(New RParameter("data", 0))
         ucrSelectorVarietyLevel.SetParameterIsrfunction()
 
         ucrVarietyLevelReceiver.SetParameter(New RParameter("c", 0))
         ucrVarietyLevelReceiver.Selector = ucrSelectorVarietyLevel
         ucrVarietyLevelReceiver.SetParameterIsRFunction()
         ucrVarietyLevelReceiver.SetMeAsReceiver()
+
+        bCheck7Passed = False
 
         ucrTricOneVarSave.SetDataFrameSelector(ucrSelectorVarietyLevel.ucrAvailableDataFrames)
         ucrTricOneVarSave.SetSaveTypeAsModel()
@@ -120,6 +125,22 @@ Public Class dlgTricotModelOneVarCov
         clsTreeFunction = New RFunction
         clsVarianCovaMatrixFunction = New RFunction
 
+        clsGetVarFromMetaData = New RFunction
+        clsGetColumnFromData = New RFunction
+        clsDataFunction = New RFunction
+        clsDataUnstackedFunction = New RFunction
+        clsPullFunction = New RFunction
+        clsLevels2Function = New RFunction
+        clsFactor2Function = New RFunction
+        clsPladmm2Function = New RFunction
+        clsMap2Function = New RFunction
+        clsNames2Function = New RFunction
+        clsNames2Operator = New ROperator
+        clsTilde5Operator = New ROperator
+        clsBracket2Operator = New ROperator
+        clsPipe2Operator = New ROperator
+        clsTilde6Operator = New ROperator
+
         clsMapFunction = New RFunction
         clsCoefOperator = New ROperator
         clsStatsOperator = New ROperator
@@ -131,12 +152,14 @@ Public Class dlgTricotModelOneVarCov
         ucrSelectorVarietyLevel.Reset()
 
         bResetSubDialog = True
+        bCheck7Passed = False
 
         ucrInputCheckVariety.SetName("")
         ucrInputCheckVariety.txtInput.BackColor = Color.White
         ucrInputCheckVariety.IsReadOnly = True
 
         clsCheckUniqueFunction.SetRCommand("check_variety_data_level")
+        clsCheckUniqueFunction.AddParameter("col", Chr(34) & ucrVarietyLevelReceiver.GetVariableNames(bWithQuotes:=False) & Chr(34), iPosition:=1)
 
         clsGetVariablesMetadataFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_variables_metadata")
         clsGetVariablesMetadataFunction.SetAssignTo("get_index_names")
@@ -163,6 +186,79 @@ Public Class dlgTricotModelOneVarCov
         clsGetColumn.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_columns_from_data")
         clsGetColumn.SetAssignTo("column")
 
+        clsGetVarFromMetaData.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_variables_from_metadata")
+        clsGetVarFromMetaData.AddParameter("x", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0, bIncludeArgumentName:=False)
+        clsGetVarFromMetaData.AddParameter("second", Chr(34) & "Tricot_Type" & Chr(34), iPosition:=1, bIncludeArgumentName:=False)
+        clsGetVarFromMetaData.AddParameter("third", Chr(34) & "variety" & Chr(34), iPosition:=2, bIncludeArgumentName:=False)
+        clsGetVarFromMetaData.SetAssignTo("variety_level_var")
+
+        clsGetColumnFromData.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_columns_from_data")
+        clsGetColumnFromData.AddParameter("x", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0, bIncludeArgumentName:=False)
+        clsGetColumnFromData.AddParameter("y", clsRFunctionParameter:=clsGetVarFromMetaData, iPosition:=1, bIncludeArgumentName:=False)
+        clsGetColumnFromData.SetAssignTo("variety_level_var")
+
+        clsGetDataFrame.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_data_frame")
+        clsGetDataFrame.AddParameter("data_name", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0)
+        clsGetDataFrame.SetAssignTo(ucrSelectorVarietyLevel.strCurrentDataFrame)
+
+        clsDataFunction.SetPackageName("data.table")
+        clsDataFunction.SetRCommand("as.data.table")
+        clsDataFunction.AddParameter("x", ucrSelectorVarietyLevel.strCurrentDataFrame, iPosition:=0, bIncludeArgumentName:=False)
+
+        clsDataUnstackedFunction.SetPackageName("data.table")
+        clsDataUnstackedFunction.SetRCommand("dcast")
+        clsDataUnstackedFunction.AddParameter("data", clsRFunctionParameter:=clsDataFunction, iPosition:=0)
+        clsDataUnstackedFunction.AddParameter("formula", "variety_level_var" & " + " & ucrVarietyLevelReceiver.GetVariableNames(bWithQuotes:=False) & " ~ " & Chr(34) & "X" & Chr(34), iPosition:=1)
+        clsDataUnstackedFunction.SetAssignTo("cochran.bib_unstacked")
+
+        clsPullFunction.SetPackageName("dplyr")
+        clsPullFunction.SetRCommand("pull")
+        clsPullFunction.AddParameter("x", ucrVarietyLevelReceiver.GetVariableNames(bWithQuotes:=False), iPosition:=0, bIncludeArgumentName:=False)
+
+        clsPipe2Operator.SetOperation("%>%")
+        clsPipe2Operator.AddParameter("left", "cochran.bib_unstacked", iPosition:=0, bIncludeArgumentName:=False)
+        clsPipe2Operator.AddParameter("right", clsRFunctionParameter:=clsPullFunction, iPosition:=1, bIncludeArgumentName:=False)
+        clsPipe2Operator.SetAssignTo(ucrVarietyLevelReceiver.GetVariableNames(bWithQuotes:=False))
+
+        clsFactor2Function.SetRCommand("factor")
+        clsFactor2Function.AddParameter("x", clsROperatorParameter:=clsPipe2Operator, iPosition:=0, bIncludeArgumentName:=False)
+
+        clsLevels2Function.SetRCommand("levels")
+        clsLevels2Function.AddParameter("x", clsRFunctionParameter:=clsFactor2Function, iPosition:=0, bIncludeArgumentName:=False)
+
+        clsBracket2Operator.SetOperation("[")
+        clsBracket2Operator.AddParameter("left", clsRFunctionParameter:=clsLevels2Function, iPosition:=0, bIncludeArgumentName:=False)
+        clsBracket2Operator.AddParameter("right", "1]", iPosition:=1, bIncludeArgumentName:=False)
+        clsBracket2Operator.SetAssignTo("variety_baseline")
+        clsBracket2Operator.bSpaceAroundOperation = False
+
+        clsTilde5Operator.SetOperation("~")
+        clsTilde5Operator.AddParameter("left", "", iPosition:=0, bIncludeArgumentName:=False)
+        clsTilde5Operator.AddParameter("right", ucrVarietyLevelReceiver.GetVariableNames(bWithQuotes:=False), iPosition:=1, bIncludeArgumentName:=False)
+
+        clsPladmm2Function.SetPackageName("PlackettLuce")
+        clsPladmm2Function.SetRCommand("pladmm")
+        clsPladmm2Function.AddParameter("x", ".x", iPosition:=0, bIncludeArgumentName:=False)
+        clsPladmm2Function.AddParameter("y", clsROperatorParameter:=clsTilde5Operator, iPosition:=1, bIncludeArgumentName:=False)
+        clsPladmm2Function.AddParameter("data", "cochran.bib_unstacked", iPosition:=2)
+
+        clsTilde6Operator.SetOperation("~")
+        clsTilde6Operator.AddParameter("left", "", iPosition:=0, bIncludeArgumentName:=False)
+        clsTilde6Operator.AddParameter("right", clsRFunctionParameter:=clsPladmm2Function, iPosition:=1, bIncludeArgumentName:=False)
+
+        clsMap2Function.SetPackageName("purrr")
+        clsMap2Function.SetRCommand("map")
+        clsMap2Function.AddParameter(".x", "rankings_object", iPosition:=0)
+        clsMap2Function.AddParameter(".f", clsROperatorParameter:=clsTilde6Operator, iPosition:=1)
+        clsMap2Function.SetAssignTo("mod_list")
+
+        clsNames2Function.SetRCommand("names")
+        clsNames2Function.AddParameter("x", clsRFunctionParameter:=clsMap2Function, iPosition:=0, bIncludeArgumentName:=False)
+
+        clsNames2Operator.SetOperation("<-")
+        clsNames2Operator.AddParameter("left", clsRFunctionParameter:=clsNames2Function, iPosition:=0, bIncludeArgumentName:=False)
+        clsNames2Operator.AddParameter("right", "vars", iPosition:=1, bIncludeArgumentName:=False)
+
         clsLevelsFunction.SetRCommand("levels")
         clsLevelsFunction.AddParameter("x", clsRFunctionParameter:=clsFactorsFunction, iPosition:=0, bIncludeArgumentName:=False)
 
@@ -173,6 +269,7 @@ Public Class dlgTricotModelOneVarCov
         clsBracketOperator.AddParameter("left", clsRFunctionParameter:=clsLevelsFunction, iPosition:=0)
         clsBracketOperator.AddParameter("right", "1]", iPosition:=1)
         clsBracketOperator.SetAssignTo("variety_baseline")
+        clsBracketOperator.bSpaceAroundOperation = False
 
         clsTildeOperator.SetOperation("~")
         clsTildeOperator.AddParameter("left", "", iPosition:=0, bIncludeArgumentName:=False)
@@ -198,7 +295,7 @@ Public Class dlgTricotModelOneVarCov
 
         clsNamesOperator.SetOperation("<-")
         clsNamesOperator.AddParameter("left", clsRFunctionParameter:=clsNamesFunction, iPosition:=0)
-        clsNamesOperator.AddParameter("right", clsROperatorParameter:=clsSpaceOperator, iPosition:=1)
+        clsNamesOperator.AddParameter("right", "vars", iPosition:=1)
 
         clsSummaryFunction.SetPackageName("purrr")
         clsSummaryFunction.SetRCommand("map")
@@ -291,8 +388,6 @@ Public Class dlgTricotModelOneVarCov
 
         ucrBase.clsRsyntax.ClearCodes()
         ucrBase.clsRsyntax.AddToBeforeCodes(clsGetRankingItemsFunction, iPosition:=3)
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsBracketOperator, iPosition:=4)
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsNamesOperator, iPosition:=5)
         ucrBase.clsRsyntax.SetBaseROperator(clsModelOperator)
 
     End Sub
@@ -329,7 +424,14 @@ Public Class dlgTricotModelOneVarCov
     Private Sub ucrVarietyLevelReceiver_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrVarietyLevelReceiver.ControlValueChanged
         clsTilde2Operator.AddParameter("right", ucrVarietyLevelReceiver.GetVariableNames(bWithQuotes:=False), iPosition:=1, bIncludeArgumentName:=False)
         clsGetColumn.AddParameter("col_name", ucrVarietyLevelReceiver.GetVariableNames(), iPosition:=1, bIncludeArgumentName:=False)
+        clsPullFunction.AddParameter("x", ucrVarietyLevelReceiver.GetVariableNames(bWithQuotes:=False), iPosition:=0, bIncludeArgumentName:=False)
+        clsDataUnstackedFunction.AddParameter("formula", "variety_level_var" & " + " & ucrVarietyLevelReceiver.GetVariableNames(bWithQuotes:=False) & " ~ " & Chr(34) & "X" & Chr(34), iPosition:=1)
+        clsTilde5Operator.AddParameter("right", ucrVarietyLevelReceiver.GetVariableNames(bWithQuotes:=False), iPosition:=1, bIncludeArgumentName:=False)
+        clsPipe2Operator.SetAssignTo(ucrVarietyLevelReceiver.GetVariableNames(bWithQuotes:=False))
+        clsFactor2Function.AddParameter("x", ucrVarietyLevelReceiver.GetVariableNames(bWithQuotes:=False), iPosition:=0, bIncludeArgumentName:=False)
+        clsCheckUniqueFunction.AddParameter("col", Chr(34) & ucrVarietyLevelReceiver.GetVariableNames(bWithQuotes:=False) & Chr(34), iPosition:=1)
         CheckVarietyUnique()
+        CheckAddCodesToBefore()
     End Sub
 
     Private Sub CheckVarietyUnique()
@@ -354,6 +456,15 @@ Public Class dlgTricotModelOneVarCov
                 ucrInputCheckVariety.SetName("Model fails. Only variety level data can be used for this data. This is data where there is a unique row for each variety given.")
                 ucrInputCheckVariety.txtInput.BackColor = Color.Coral
                 bIsUnique = False
+            ElseIf iAnyDuplicated = 7 Then
+                ucrInputCheckVariety.SetName("Success. This data is at the plot level, but it can be used.")
+                ucrInputCheckVariety.txtInput.BackColor = Color.LightGreen
+                bIsUnique = True
+                bCheck7Passed = True
+            ElseIf iAnyDuplicated = 8 Then
+                ucrInputCheckVariety.SetName("This data is at the plot level. Either use variety-level data, or use data where there is only one level of 'col' for each variety level.")
+                ucrInputCheckVariety.txtInput.BackColor = Color.Coral
+                bIsUnique = False
             Else
                 ucrInputCheckVariety.SetName("Model runs OK.")
                 ucrInputCheckVariety.txtInput.BackColor = Color.LightGreen
@@ -366,8 +477,37 @@ Public Class dlgTricotModelOneVarCov
         End If
     End Sub
 
+    Private Sub CheckAddCodesToBefore()
+        If bCheck7Passed Then
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsBracketOperator)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsNamesOperator)
+
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsGetColumnFromData, iPosition:=4)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsGetDataFrame, iPosition:=5)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsDataUnstackedFunction, iPosition:=6)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsPipe2Operator, iPosition:=7)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsBracket2Operator, iPosition:=8)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsNames2Operator, iPosition:=9)
+        Else
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsGetColumnFromData)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsGetDataFrame)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsDataUnstackedFunction)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsPipe2Operator)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsBracket2Operator)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsNames2Operator)
+
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsBracketOperator, iPosition:=4)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsNamesOperator, iPosition:=5)
+        End If
+    End Sub
+
     Private Sub ucrSelectorVarietyLevel_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorVarietyLevel.ControlValueChanged
         clsGetColumn.AddParameter("x", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0, bIncludeArgumentName:=False)
+        clsGetVarFromMetaData.AddParameter("x", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0, bIncludeArgumentName:=False)
+        clsGetColumnFromData.AddParameter("x", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0, bIncludeArgumentName:=False)
+        clsDataFunction.AddParameter("x", ucrSelectorVarietyLevel.strCurrentDataFrame, iPosition:=0, bIncludeArgumentName:=False)
+        clsGetDataFrame.AddParameter("data_name", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0)
+        clsGetDataFrame.SetAssignTo(ucrSelectorVarietyLevel.strCurrentDataFrame)
         clsCheckUniqueFunction.AddParameter("x", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0, bIncludeArgumentName:=False)
     End Sub
 

--- a/instat/dlgTricotModellingGeneral.vb
+++ b/instat/dlgTricotModellingGeneral.vb
@@ -5,7 +5,7 @@ Public Class dlgTricotModellingGeneral
     Public bFirstLoad As Boolean = True
     Private bReset As Boolean = True
     Private bResetSubDialog As Boolean = True
-
+    Private bCheck7Passed As Boolean = False
     Private bIsUnique As Boolean = True
     Private clsGetVariablesMetadataFunction As New RFunction
     Private clsGetObjectFunction, clsGetRankingItemsFunction, clsGetDataFrameFunction, clsLevelsFunction, clsMappingFunction, clsPladmmFunction,
@@ -13,12 +13,14 @@ Public Class dlgTricotModellingGeneral
             clsEstimatesFunction, clsSecondEstimatesFunction, clsDevianceFunction, clsDevianceMainFunction, clsPairwiseProbFunction,
             clsPairwiseProbMainFunction, clsReliabilityFunction, clsItemsParFunction, clsRegretFunction, clsNodeLabelsFunction,
             clsNodeRulesFunction, clsTopItemsFunction, clsAICFunction, clsUnListAICFunction, clsAICMainFunction, clsAnnovaFunction,
-            clsConfidenLimFunction, clsStatsFunction, clsQuasivarianceFunction, clsVarianCovaMatrixFunction, clsHeatFunction,
-            clsPlotFunction, clsBarfunction, clsWrapPlotFunction, clsWrapBarFunction, clsTreeFunction, clsImportDataFunction, clsWrapTrees As New RFunction
+            clsConfidenLimFunction, clsStatsFunction, clsQuasivarianceFunction, clsVarianCovaMatrixFunction, clsHeatFunction, clsPackageCheck,
+            clsPlotFunction, clsBarfunction, clsWrapPlotFunction, clsWrapBarFunction, clsTreeFunction, clsImportDataFunction, clsWrapTrees,
+            clsGetVarFromMetaData, clsGetColumnFromData, clsDataUnstackedFunction, clsPullFunction, clsFactor2Function, clsLevels2Function,
+            clsPladmm2Function, clsMappings2Function, clsNames2Function, clsDataFunction, clsGetDataframe2function As New RFunction
 
     Private clsObjectOperator, clsTildeOperator, clsTilde2Operator, clsBracketOperator, clsDevianceOperator, clsPairwiseProbOperator,
-            clsNamesOperator, clsModelOperator, clsSpaceOperator, clsEmptySpaceOperator, clsCoefOperator,
-            clsAICOperator, clsStatsOperator, clsPipeOperator As New ROperator
+            clsNamesOperator, clsModelOperator, clsSpaceOperator, clsEmptySpaceOperator, clsCoefOperator, clsPipe2Operator, clsBracket2Operator,
+            clsAICOperator, clsStatsOperator, clsPipeOperator, clsTilde3Operator, clsTilde4Operator, clsNames2Operator As New ROperator
 
     Private Sub dlgTricotModellingGeneral_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
@@ -28,7 +30,7 @@ Public Class dlgTricotModellingGeneral
         If bReset Then
             setDefaults()
         End If
-
+        bCheck7Passed = False
         SetRcodeForControls(bReset)
         bReset = False
         ' autoTranslate(Me)
@@ -50,7 +52,7 @@ Public Class dlgTricotModellingGeneral
         ucrTraitsReceiver.strSelectorHeading = "Traits"
         ucrTraitsReceiver.SetTricotType({"traits"})
 
-        ucrSelectorVarietyLevel.SetParameter(New RParameter("data", 3))
+        ucrSelectorVarietyLevel.SetParameter(New RParameter("data", 0))
         ucrSelectorVarietyLevel.SetParameterIsrfunction()
 
         ucrReceiverExpressionModellingGeneral.SetParameter(New RParameter("y", 2))
@@ -66,6 +68,8 @@ Public Class dlgTricotModellingGeneral
         ucrSaveModellingGeneral.SetIsComboBox()
         ucrSaveModellingGeneral.SetPrefix("gen_model")
         ucrSaveModellingGeneral.SetAssignToIfUncheckedValue("last_model")
+
+        bCheck7Passed = False
 
         btnModelOptions.Enabled = True
         btnDisplayOptions.Enabled = True
@@ -83,6 +87,7 @@ Public Class dlgTricotModellingGeneral
         clsGetVariablesFromMetaDataFunction = New RFunction
         clsGetDataFrameFunction = New RFunction
         clscoefFunction = New RFunction
+        clsPackageCheck = New RFunction
         clsTildeOperator = New ROperator
         clsTilde2Operator = New ROperator
         clsEmptySpaceOperator = New ROperator
@@ -92,6 +97,22 @@ Public Class dlgTricotModellingGeneral
         clsNamesFunction = New RFunction
         clsNamesOperator = New ROperator
         clsModelOperator = New ROperator
+
+        clsGetVarFromMetaData = New RFunction
+        clsDataUnstackedFunction = New RFunction
+        clsGetDataframe2function = New RFunction
+        clsPullFunction = New RFunction
+        clsDataFunction = New RFunction
+        clsFactor2Function = New RFunction
+        clsLevels2Function = New RFunction
+        clsPladmm2Function = New RFunction
+        clsMappings2Function = New RFunction
+        clsNames2Function = New RFunction
+        clsNames2Operator = New ROperator
+        clsTilde4Operator = New ROperator
+        clsBracket2Operator = New ROperator
+        clsPipe2Operator = New ROperator
+        clsTilde3Operator = New ROperator
 
         ' Sub Dialogs
         '-----------------------------------------------------------------------------------------------------
@@ -127,6 +148,7 @@ Public Class dlgTricotModellingGeneral
         clsWrapBarFunction = New RFunction
 
         bResetSubDialog = True
+        bCheck7Passed = False
 
         ucrSaveModellingGeneral.Reset()
         ucrSelectorTraitsRanking.Reset()
@@ -137,6 +159,11 @@ Public Class dlgTricotModellingGeneral
         ucrInputCheckVariety.IsReadOnly = True
 
         ucrTraitsReceiver.SetMeAsReceiver()
+
+        clsPackageCheck.SetPackageName("databook")
+        clsPackageCheck.SetRCommand("check_variety_data_level")
+        clsPackageCheck.AddParameter("data", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34))
+        clsPackageCheck.AddParameter("col", Chr(34) & ucrReceiverExpressionModellingGeneral.GetVariableNames(bWithQuotes:=False) & Chr(34))
 
         clsGetVariablesMetadataFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_variables_metadata")
         clsGetVariablesMetadataFunction.SetAssignTo("get_index_names")
@@ -155,6 +182,84 @@ Public Class dlgTricotModellingGeneral
         clsObjectOperator.AddParameter("right", "object", iPosition:=1)
         clsObjectOperator.SetAssignTo("rankings_object")
         clsObjectOperator.bSpaceAroundOperation = False
+
+
+        clsGetVarFromMetaData.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_variables_from_metadata")
+        clsGetVarFromMetaData.AddParameter("data", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0, bIncludeArgumentName:=False)
+        clsGetVarFromMetaData.AddParameter("tricot_type", Chr(34) & "Tricot_Type" & Chr(34), iPosition:=1, bIncludeArgumentName:=False)
+        clsGetVarFromMetaData.AddParameter("variety", Chr(34) & "variety" & Chr(34), iPosition:=2, bIncludeArgumentName:=False)
+        clsGetVarFromMetaData.SetAssignTo("variety_level_var")
+
+        clsGetColumnFromData.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_columns_from_data")
+        clsGetColumnFromData.AddParameter("data", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0, bIncludeArgumentName:=False)
+        clsGetColumnFromData.AddParameter("x", clsRFunctionParameter:=clsGetVarFromMetaData, iPosition:=1, bIncludeArgumentName:=False)
+        clsGetColumnFromData.SetAssignTo("variety_level_var")
+
+        clsGetDataframe2function.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_data_frame")
+        clsGetDataframe2function.AddParameter("data_name", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0)
+        clsGetDataframe2function.SetAssignTo(ucrSelectorVarietyLevel.strCurrentDataFrame)
+
+        clsDataFunction.SetPackageName("data.table")
+        clsDataFunction.SetRCommand("as.data.table")
+        clsDataFunction.AddParameter("x", ucrSelectorVarietyLevel.strCurrentDataFrame, iPosition:=0, bIncludeArgumentName:=False)
+
+        clsDataUnstackedFunction.SetPackageName("data.table")
+        clsDataUnstackedFunction.SetRCommand("dcast")
+        clsDataUnstackedFunction.AddParameter("data", clsRFunctionParameter:=clsDataFunction, iPosition:=0)
+        clsDataUnstackedFunction.AddParameter("formula", "variety_level_var" & " + " & ucrReceiverExpressionModellingGeneral.GetVariableNames(bWithQuotes:=False) & " ~ " & Chr(34) & "X" & Chr(34), iPosition:=1)
+        clsDataUnstackedFunction.SetAssignTo("cochran.bib_unstacked")
+
+        clsPullFunction.SetPackageName("dplyr")
+        clsPullFunction.SetRCommand("pull")
+        clsPullFunction.AddParameter("x", ucrReceiverExpressionModellingGeneral.GetVariableNames(bWithQuotes:=False), iPosition:=0, bIncludeArgumentName:=False)
+
+        clsPipe2Operator.SetOperation("%>%")
+        clsPipe2Operator.AddParameter("left", "cochran.bib_unstacked", iPosition:=0, bIncludeArgumentName:=False)
+        clsPipe2Operator.AddParameter("right", clsRFunctionParameter:=clsPullFunction, iPosition:=1, bIncludeArgumentName:=False)
+        clsPipe2Operator.SetAssignTo(ucrReceiverExpressionModellingGeneral.GetVariableNames(bWithQuotes:=False))
+
+        clsFactor2Function.SetRCommand("factor")
+        clsFactor2Function.AddParameter("x", ucrReceiverExpressionModellingGeneral.GetVariableNames(bWithQuotes:=False), iPosition:=0, bIncludeArgumentName:=False)
+
+        clsLevels2Function.SetRCommand("levels")
+        clsLevels2Function.AddParameter("x", clsRFunctionParameter:=clsFactor2Function, iPosition:=0, bIncludeArgumentName:=False)
+
+        clsBracket2Operator.SetOperation("[")
+        clsBracket2Operator.AddParameter("left", clsRFunctionParameter:=clsLevels2Function, iPosition:=0, bIncludeArgumentName:=False)
+        clsBracket2Operator.AddParameter("right", "1]", iPosition:=1, bIncludeArgumentName:=False)
+        clsBracket2Operator.bSpaceAroundOperation = False
+        clsBracket2Operator.SetAssignTo("variety_baseline")
+
+        clsTilde3Operator.SetOperation("~")
+        clsTilde3Operator.AddParameter("left", "", iPosition:=0, bIncludeArgumentName:=False)
+        clsTilde3Operator.AddParameter("right", ucrReceiverExpressionModellingGeneral.GetVariableNames(bWithQuotes:=False), iPosition:=1, bIncludeArgumentName:=False)
+
+        clsPladmm2Function.SetPackageName("PlackettLuce")
+        clsPladmm2Function.SetRCommand("pladmm")
+        clsPladmm2Function.AddParameter("x", ".x", iPosition:=0, bIncludeArgumentName:=False)
+        clsPladmm2Function.AddParameter("y", clsROperatorParameter:=clsTilde3Operator, iPosition:=1, bIncludeArgumentName:=False)
+        clsPladmm2Function.AddParameter("data", "cochran.bib_unstacked", iPosition:=2)
+
+        clsTilde4Operator.SetOperation("~")
+        clsTilde4Operator.AddParameter("left", "", iPosition:=0, bIncludeArgumentName:=False)
+        clsTilde4Operator.AddParameter("right", clsRFunctionParameter:=clsPladmm2Function, iPosition:=1, bIncludeArgumentName:=False)
+
+        clsMappings2Function.SetPackageName("purrr")
+        clsMappings2Function.SetRCommand("map")
+        clsMappings2Function.AddParameter(".x", "rankings_object", iPosition:=0)
+        clsMappings2Function.AddParameter(".f", clsROperatorParameter:=clsTilde4Operator, iPosition:=1)
+        clsMappings2Function.SetAssignTo("mod_list")
+
+        clsNames2Function.SetRCommand("names")
+        clsNames2Function.AddParameter("x", clsRFunctionParameter:=clsMappings2Function, iPosition:=0, bIncludeArgumentName:=False)
+
+        clsNames2Operator.SetOperation("<-")
+        clsNames2Operator.AddParameter("left", clsRFunctionParameter:=clsNames2Function, iPosition:=0, bIncludeArgumentName:=False)
+        clsNames2Operator.AddParameter("right", "vars", iPosition:=1, bIncludeArgumentName:=False)
+
+
+
+
 
         clsSpaceOperator.SetOperation("")
         clsSpaceOperator.AddParameter("x", ucrTraitsReceiver.GetVariableNames(), iPosition:=0, bIncludeArgumentName:=False)
@@ -352,10 +457,6 @@ Public Class dlgTricotModellingGeneral
 
         ucrBase.clsRsyntax.ClearCodes()
         ucrBase.clsRsyntax.AddToBeforeCodes(clsGetRankingItemsFunction, iPosition:=3)
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsGetDataFrameFunction, iPosition:=4)
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsGetVariablesFromMetaDataFunction, iPosition:=5)
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsBracketOperator, iPosition:=6)
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsNamesOperator, iPosition:=7)
 
         ucrBase.clsRsyntax.SetBaseROperator(clsModelOperator)
     End Sub
@@ -505,12 +606,16 @@ Public Class dlgTricotModellingGeneral
         TestOkEnabled()
     End Sub
 
-
-    '----------------------------------------------------------------------------------------------'
-    'REVIEW THIS FUNCTION
-    Private Sub ucrVarietyLevelReceiver_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverExpressionModellingGeneral.ControlValueChanged
+    Private Sub ucrReceiverExpressionModellingGeneral_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverExpressionModellingGeneral.ControlValueChanged
+        clsDataUnstackedFunction.AddParameter("formula", "variety_level_var" & " + " & ucrReceiverExpressionModellingGeneral.GetVariableNames(bWithQuotes:=False) & " ~ " & Chr(34) & "X" & Chr(34), iPosition:=1)
         clsTilde2Operator.AddParameter("right", ucrReceiverExpressionModellingGeneral.GetVariableNames(bWithQuotes:=False), iPosition:=1, bIncludeArgumentName:=False)
+        clsPackageCheck.AddParameter("col", Chr(34) & ucrReceiverExpressionModellingGeneral.GetVariableNames(bWithQuotes:=False) & Chr(34))
+        clsPullFunction.AddParameter("x", ucrReceiverExpressionModellingGeneral.GetVariableNames(bWithQuotes:=False), iPosition:=0, bIncludeArgumentName:=False)
+        clsPipe2Operator.SetAssignTo(ucrReceiverExpressionModellingGeneral.GetVariableNames(bWithQuotes:=False))
+        clsFactor2Function.AddParameter("x", ucrReceiverExpressionModellingGeneral.GetVariableNames(bWithQuotes:=False), iPosition:=0, bIncludeArgumentName:=False)
+        clsTilde3Operator.AddParameter("right", ucrReceiverExpressionModellingGeneral.GetVariableNames(bWithQuotes:=False), iPosition:=1, bIncludeArgumentName:=False)
         Check()
+        CheckAddCodesToBefore()
     End Sub
 
 
@@ -527,19 +632,51 @@ Public Class dlgTricotModellingGeneral
         clsGetDataFrameFunction.SetAssignTo(ucrSelectorTraitsRanking.strCurrentDataFrame)
     End Sub
 
+    Private Sub ucrSelectorVarietyLevel_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorVarietyLevel.ControlValueChanged
+        clsGetVarFromMetaData.AddParameter("data", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0, bIncludeArgumentName:=False)
+        clsGetColumnFromData.AddParameter("data", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0, bIncludeArgumentName:=False)
+        clsGetDataframe2function.AddParameter("data_name", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34), iPosition:=0)
+        clsGetDataframe2function.SetAssignTo(ucrSelectorVarietyLevel.strCurrentDataFrame)
+        clsDataFunction.AddParameter("x", ucrSelectorVarietyLevel.strCurrentDataFrame, iPosition:=0, bIncludeArgumentName:=False)
+        clsPackageCheck.AddParameter("data", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34))
+    End Sub
+
+    Private Sub CheckAddCodesToBefore()
+        If bCheck7Passed Then
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsGetDataFrameFunction)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsGetVariablesFromMetaDataFunction)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsBracketOperator)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsNamesOperator)
+
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsGetColumnFromData, iPosition:=4)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsGetDataframe2function, iPosition:=5)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsDataUnstackedFunction, iPosition:=6)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsPipe2Operator, iPosition:=7)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsBracket2Operator, iPosition:=8)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsNames2Operator, iPosition:=9)
+
+        Else
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsGetColumnFromData)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsGetDataframe2function)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsDataUnstackedFunction)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsPipe2Operator)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsBracket2Operator)
+            ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsNames2Operator)
+
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsGetDataFrameFunction, iPosition:=4)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsGetVariablesFromMetaDataFunction, iPosition:=5)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsBracketOperator, iPosition:=6)
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsNamesOperator, iPosition:=7)
+        End If
+    End Sub
+
     Private Sub Check()
         Dim chrOutput As CharacterVector
-        Dim clsPackageCheck As New RFunction
         Dim expOutput As SymbolicExpression
 
         If Not ucrReceiverExpressionModellingGeneral.IsEmpty AndAlso Not ucrTraitsReceiver.IsEmpty Then
 
-            clsPackageCheck.SetPackageName("databook")
-            clsPackageCheck.SetRCommand("check_variety_data_level")
-            clsPackageCheck.AddParameter("data", Chr(34) & ucrSelectorVarietyLevel.strCurrentDataFrame & Chr(34))
-
             expOutput = frmMain.clsRLink.RunInternalScriptGetValue(clsPackageCheck.ToScript())
-
 
             If expOutput Is Nothing OrElse expOutput.Type = RDotNet.Internals.SymbolicExpressionType.Null Then
                 ucrInputCheckVariety.SetName("Model fails. There is no variety variable that is Tricot-Defined in this data.")
@@ -569,6 +706,15 @@ Public Class dlgTricotModellingGeneral
                     bIsUnique = True
                     ucrInputCheckVariety.SetName("Model runs OK.")
                     ucrInputCheckVariety.txtInput.BackColor = Color.LightGreen
+                Case "7"
+                    bIsUnique = True
+                    bCheck7Passed = True
+                    ucrInputCheckVariety.SetName("Success. This data is at the plot level, but it can be used.")
+                    ucrInputCheckVariety.txtInput.BackColor = Color.LightGreen
+                Case "8"
+                    bIsUnique = False
+                    ucrInputCheckVariety.SetName("This data is at the plot level. Either use variety-level data, or use data where there is only one level of 'col' for each variety level.")
+                    ucrInputCheckVariety.txtInput.BackColor = Color.Coral
             End Select
 
         Else


### PR DESCRIPTION
Fixes #9627
@lilyclements @rdstern 
I have added a new check and modified the code generated depending on which check passed for both the modelling general and one covariate dialogs. 

@lilyclements the changes you proposed worked and it doesn't result in an error anymore. Kindly review the changes and see if everything is as you wanted it.