### PR TITLE
Autofilling in the Traits Multiple Receivers

### DIFF
--- a/instat/dlgModellingTree.vb
+++ b/instat/dlgModellingTree.vb
@@ -78,7 +78,8 @@ Public Class dlgModellingTree
         ucrReceiverModellingTree.SetParameterIsRFunction()
         ucrReceiverModellingTree.Selector = ucrSelectorByDataFrameAddRemoveForModellingTree
         ucrReceiverModellingTree.strSelectorHeading = "Traits"
-        ucrReceiverModellingTree.SetTricotType({"traits"})
+        ucrReceiverModellingTree.SetTricotType("traits")
+        ucrReceiverModellingTree.bAutoFill = True
 
         ucrReceiverExpressionModellingTree.SetParameter(New RParameter("y", 2))
         ucrReceiverExpressionModellingTree.SetParameterIsString()

--- a/instat/dlgPlacketLuceModel.vb
+++ b/instat/dlgPlacketLuceModel.vb
@@ -52,7 +52,8 @@ Public Class dlgPlacketLuceModel
         ucrReceiverMultipleTraits.Selector = ucrSelectorTraitsPL
         ucrReceiverMultipleTraits.strSelectorHeading = "Traits"
         ucrReceiverMultipleTraits.SetMeAsReceiver()
-        ucrReceiverMultipleTraits.SetTricotType({"traits"})
+        ucrReceiverMultipleTraits.SetTricotType("traits")
+        ucrReceiverMultipleTraits.bAutoFill = True
         ucrReceiverMultipleTraits.SetLinkedDisplayControl(lblTraits)
 
         ucrSaveResult.SetPrefix("model")
@@ -123,7 +124,7 @@ Public Class dlgPlacketLuceModel
         clsGetVarMetadataFunction.SetAssignTo("get_index_names")
 
         clsGetObjectRFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_object")
-       clsGetObjectRFunction.AddParameter("data_name", Chr(34) & ucrSelectorTraitsPL.strCurrentDataFrame & Chr(34), iPosition:=0)
+        clsGetObjectRFunction.AddParameter("data_name", Chr(34) & ucrSelectorTraitsPL.strCurrentDataFrame & Chr(34), iPosition:=0)
         clsGetObjectRFunction.AddParameter("object_name", Chr(34) & "rankings_list" & Chr(34), iPosition:=1)
 
         clsGetRankingOperator.SetOperation("$")

--- a/instat/dlgTraitCorrelations.vb
+++ b/instat/dlgTraitCorrelations.vb
@@ -44,6 +44,9 @@ Public Class dlgTraitCorrelations
 
         ucrReceiverTraitsToCompare.SetParameterIsRFunction()
         ucrReceiverTraitsToCompare.Selector = ucrSelecetorTraits
+        ucrReceiverTraitsToCompare.strSelectorHeading = "Traits"
+        ucrReceiverTraitsToCompare.SetTricotType("traits")
+        ucrReceiverTraitsToCompare.bAutoFill = True
 
         ucrSelecetorTraits.SetParameterIsrfunction()
 

--- a/instat/dlgTraits.vb
+++ b/instat/dlgTraits.vb
@@ -48,10 +48,11 @@ Public Class dlgTraits
         ucrReceiverTrait.SetParameter(New RParameter("column", 1, bNewIncludeArgumentName:=False))
         ucrReceiverTrait.Selector = ucrTraitGraphSelector
         ucrReceiverTrait.SetParameterIsString()
-        ucrReceiverTrait.bAutoFill = True
         ucrReceiverTrait.strSelectorHeading = "Traits"
+        ucrReceiverTrait.SetIncludedDataTypes({"numeric"})
         ucrReceiverTrait.SetMeAsReceiver()
-        ucrReceiverTrait.SetTricotType({"traits"})
+        ucrReceiverTrait.SetTricotType("traits")
+        ucrReceiverTrait.bAutoFill = True
 
         ucrSaveTraits.SetPrefix("trait_plot")
         ucrSaveTraits.SetIsComboBox()

--- a/instat/dlgTricotModelOneVarCov.vb
+++ b/instat/dlgTricotModelOneVarCov.vb
@@ -65,7 +65,8 @@ Public Class dlgTricotModelOneVarCov
         ucrTraitsReceiver.SetParameterIsString()
         ucrTraitsReceiver.SetMeAsReceiver()
         ucrTraitsReceiver.strSelectorHeading = "Traits"
-        ucrTraitsReceiver.SetTricotType({"traits"})
+        ucrTraitsReceiver.SetTricotType("traits")
+        ucrTraitsReceiver.bAutoFill = True
 
         ucrSelectorVarietyLevel.SetParameter(New RParameter("data", 3))
         ucrSelectorVarietyLevel.SetParameterIsrfunction()

--- a/instat/dlgTricotModellingGeneral.vb
+++ b/instat/dlgTricotModellingGeneral.vb
@@ -48,7 +48,8 @@ Public Class dlgTricotModellingGeneral
         ucrTraitsReceiver.SetParameterIsString()
         ucrTraitsReceiver.SetMeAsReceiver()
         ucrTraitsReceiver.strSelectorHeading = "Traits"
-        ucrTraitsReceiver.SetTricotType({"traits"})
+        ucrTraitsReceiver.SetTricotType("traits")
+        ucrTraitsReceiver.bAutoFill = True
 
         ucrSelectorVarietyLevel.SetParameter(New RParameter("data", 3))
         ucrSelectorVarietyLevel.SetParameterIsrfunction()


### PR DESCRIPTION
Fixes partially #7306 for Tricot cases

@rdstern and @lilyclements following the discussion in the issue above, the multiple receivers in the modelling dialogs and correlation dialog are now able to autofill.

This took time because I started with implemeting the Traits dialog with a single receiver and after spending time on it, I realized the ucrReceiver only autofills when there is only one valid item. So in our case with multiple traits, it doesn't autofill.

I am thinking, what if, when we have multiple items, it could take the first one in the list, but that would be a @Patowhiz problem in the ucrReceiver.

In the meantime, I have set the receiver in Traits dialog to include numerics in the selector, to make it easier for the users.