### PR TITLE
Removed unused dialog definition folder

### DIFF
--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -5848,8 +5848,6 @@
     <Content Include="Resources\upward-arrow1.png" />
     <Content Include="translations\translateDynamic.txt" />
     <Content Include="translations\translateIgnore.txt" />
-    <None Include="DialogDefinitions\DlgTraits\dlgTraits.json" />
-    <None Include="DialogDefinitions\DlgTraits\dlgTraits.R" />
     <None Include="instat.licenseheader" />
     <None Include="My Project\Application.myapp">
       <Generator>MyApplicationCodeGenerator</Generator>


### PR DESCRIPTION
@rdstern This is a very small PR. It just removes an unused folder and file. These were related to the `Tricot XP` menu. I don't think there's anything you can test. These files were not used in the code and I checked that there was no regression after I removed then.

This PR changes the `instat.vbproj` file so it would be great if it could be merged quickly to reduce the risk of future merge conflicts.

Thanks