### PR TITLE
Create user interface specification from list of transformations

### DIFF
--- a/instat/static/DialogDefinitions/DlgTraitCorrelations/dlgTraitCorrelations.json
+++ b/instat/static/DialogDefinitions/DlgTraitCorrelations/dlgTraitCorrelations.json
@@ -44,8 +44,8 @@
         "strValueKey": "traitsToCompareTo"
     },
     {
-        "enumTransformationType": "ifTrueExecuteChildTransformations",
-        "strValueKey": "isSaveAsTable",
+        "enumTransformationType": "ifFalseExecuteChildTransformations",
+        "strValueKey": "isStoreTableOrDataFrame",
         "lstTransformations": [
             {
                 "enumTransformationType": "scriptInsert",
@@ -67,48 +67,13 @@
                 "iParameterNumber": 0,
                 "strValueKey": "dataFrame",
                 "bIsQuoted": true
-            },
-            {
-                "enumTransformationType": "ifTrueExecuteChildTransformations",
-                "strValueKey": "isDisplayOptions",
-                "lstTransformations": [
-                    {
-                        "enumTransformationType": "ifTrueExecuteChildTransformations",
-                        "strValueKey": "isIncludePValues",
-                        "lstTransformations": [
-                            {
-                                "enumTransformationType": "operatorUpdateParam",
-                                "iStatementNumber": 9,
-                                "strFunctionName": "<-",
-                                "iParameterNumber": 1,
-                                "strScript": "kendall_rankings"
-                            }
-                        ]
-                    },
-                    {
-                        "enumTransformationType": "functionAddParam",
-                        "iStatementNumber": 10,
-                        "strFunctionName": "fashion",
-                        "iParameterNumber": 1,
-                        "strParameterName": "decimals",
-                        "strValueKey": "decimalPlaces"
-                    },
-                    {
-                        "enumTransformationType": "ifTrueExecuteChildTransformations",
-                        "strValueKey": "isLeadingZeros",
-                        "lstTransformations": [
-                            {
-                                "enumTransformationType": "functionAddParam",
-                                "iStatementNumber": 10,
-                                "strFunctionName": "fashion",
-                                "iParameterNumber": 1,
-                                "strParameterName": "leading_zeros",
-                                "strScript": "TRUE"
-                            }
-                        ]
-                    }
-                ]
-            },
+            }
+        ]
+    },
+    {
+        "enumTransformationType": "ifFalseExecuteChildTransformations",
+        "strValueKey": "isDisplayOptions",
+        "lstTransformations": [
             {
                 "enumTransformationType": "ifTrueExecuteChildTransformations",
                 "strValueKey": "isStoreTableOrDataFrame",
@@ -160,60 +125,117 @@
         "strValueKey": "isDisplayOptions",
         "lstTransformations": [
             {
-                "enumTransformationType": "ifFalseExecuteChildTransformations",
-                "strValueKey": "isSaveAsTable",
+                "enumTransformationType": "ifTrueExecuteChildTransformations",
+                "strValueKey": "isIncludePValues",
                 "lstTransformations": [
                     {
-                        "enumTransformationType": "scriptInsert",
-                        "iStatementNumber": 10,
-                        "strScript": "\nlast_dataframe <- corrr::fashion(kendall_rankings, decimals=2)\ndata_book$import_data(data_tables=list(last_dataframe=last_dataframe))\n"
-                    },
+                        "enumTransformationType": "operatorUpdateParam",
+                        "iStatementNumber": 9,
+                        "strFunctionName": "<-",
+                        "iParameterNumber": 1,
+                        "strScript": "kendall_rankings"
+                    }
+                ]
+            },
+            {
+                "enumTransformationType": "ifTrueExecuteChildTransformations",
+                "strValueKey": "isStoreTableOrDataFrame",
+                "lstTransformations": [
                     {
                         "enumTransformationType": "ifTrueExecuteChildTransformations",
-                        "strValueKey": "isIncludePValues",
+                        "strValueKey": "isSaveAsTable",
                         "lstTransformations": [
                             {
                                 "enumTransformationType": "operatorUpdateParam",
-                                "iStatementNumber": 9,
+                                "iStatementNumber": 10,
                                 "strFunctionName": "<-",
+                                "iParameterNumber": 0,
+                                "strValueKey": "storeTableOrDataFrame"
+                            },
+                            {
+                                "enumTransformationType": "functionUpdateParamValue",
+                                "iStatementNumber": 11,
+                                "strFunctionName": "add_object",
                                 "iParameterNumber": 1,
-                                "strScript": "kendall_rankings"
+                                "strValueKey": "storeTableOrDataFrame",
+                                "bIsQuoted": true
+                            },
+                            {
+                                "enumTransformationType": "functionUpdateParamValue",
+                                "iStatementNumber": 11,
+                                "strFunctionName": "add_object",
+                                "iParameterNumber": 4,
+                                "strValueKey": "storeTableOrDataFrame"
+                            },
+                            {
+                                "enumTransformationType": "functionUpdateParamValue",
+                                "iStatementNumber": 12,
+                                "strFunctionName": "get_object_data",
+                                "iParameterNumber": 1,
+                                "strValueKey": "storeTableOrDataFrame",
+                                "bIsQuoted": true
+                            },
+                            {
+                                "enumTransformationType": "functionUpdateParamValue",
+                                "iStatementNumber": 13,
+                                "strFunctionName": "c",
+                                "iParameterNumber": 0,
+                                "strValueKey": "storeTableOrDataFrame",
+                                "bIsQuoted": true
                             }
                         ]
                     },
                     {
-                        "enumTransformationType": "functionUpdateParamValue",
-                        "iStatementNumber": 10,
-                        "strFunctionName": "fashion",
-                        "iParameterNumber": 1,
-                        "strValueKey": "decimalPlaces"
-                    },
-                    {
-                        "enumTransformationType": "ifTrueExecuteChildTransformations",
-                        "strValueKey": "isLeadingZeros",
+                        "enumTransformationType": "ifFalseExecuteChildTransformations",
+                        "strValueKey": "isSaveAsTable",
                         "lstTransformations": [
                             {
-                                "enumTransformationType": "functionAddParam",
+                                "enumTransformationType": "scriptInsert",
+                                "iStatementNumber": 10,
+                                "strScript": "\nlast_dataframe <- corrr::fashion(kendall_rankings, decimals=2)\ndata_book$import_data(data_tables=list(last_dataframe=last_dataframe))\n"
+                            },
+                            {
+                                "enumTransformationType": "ifTrueExecuteChildTransformations",
+                                "strValueKey": "isIncludePValues",
+                                "lstTransformations": [
+                                    {
+                                        "enumTransformationType": "operatorUpdateParam",
+                                        "iStatementNumber": 9,
+                                        "strFunctionName": "<-",
+                                        "iParameterNumber": 1,
+                                        "strScript": "kendall_rankings"
+                                    }
+                                ]
+                            },
+                            {
+                                "enumTransformationType": "functionUpdateParamValue",
                                 "iStatementNumber": 10,
                                 "strFunctionName": "fashion",
                                 "iParameterNumber": 1,
-                                "strParameterName": "leading_zeros",
-                                "strScript": "TRUE"
-                            }
-                        ]
-                    },
-                    {
-                        "enumTransformationType": "functionUpdateParamValue",
-                        "iStatementNumber": 12,
-                        "strFunctionName": "c",
-                        "iParameterNumber": 0,
-                        "strScript": "last_dataframe",
-                        "bIsQuoted": true
-                    },
-                    {
-                        "enumTransformationType": "ifTrueExecuteChildTransformations",
-                        "strValueKey": "isStoreTableOrDataFrame",
-                        "lstTransformations": [
+                                "strValueKey": "decimalPlaces"
+                            },
+                            {
+                                "enumTransformationType": "ifTrueExecuteChildTransformations",
+                                "strValueKey": "isLeadingZeros",
+                                "lstTransformations": [
+                                    {
+                                        "enumTransformationType": "functionAddParam",
+                                        "iStatementNumber": 10,
+                                        "strFunctionName": "fashion",
+                                        "iParameterNumber": 1,
+                                        "strParameterName": "leading_zeros",
+                                        "strScript": "TRUE"
+                                    }
+                                ]
+                            },
+                            {
+                                "enumTransformationType": "functionUpdateParamValue",
+                                "iStatementNumber": 12,
+                                "strFunctionName": "c",
+                                "iParameterNumber": 0,
+                                "strScript": "last_dataframe",
+                                "bIsQuoted": true
+                            },
                             {
                                 "enumTransformationType": "operatorUpdateParam",
                                 "iStatementNumber": 10,
@@ -244,7 +266,6 @@
                             }
                         ]
                     }
-
                 ]
             }
         ]

--- a/instat/static/DialogDefinitions/DlgTraitCorrelations/dlgTraitCorrelations.json
+++ b/instat/static/DialogDefinitions/DlgTraitCorrelations/dlgTraitCorrelations.json
@@ -32,12 +32,6 @@
     },
     {
         "enumTransformationType": "ifFalseExecuteChildTransformations",
-        "strValueKey": "isStoreTableOrDataFrame",
-        "lstTransformations": [
-        ]
-    },
-    {
-        "enumTransformationType": "ifFalseExecuteChildTransformations",
         "strValueKey": "isDisplayOptions",
         "lstTransformations": [
             {
@@ -169,16 +163,10 @@
                         "iParameterNumber": 0,
                         "strValueKey": "dataFrame",
                         "bIsQuoted": true
-                    }
-                ]
-            },
-            {
-                "enumTransformationType": "ifTrueExecuteChildTransformations",
-                "strValueKey": "isStoreTableOrDataFrame",
-                "lstTransformations": [
+                    },
                     {
                         "enumTransformationType": "ifTrueExecuteChildTransformations",
-                        "strValueKey": "isSaveAsTable",
+                        "strValueKey": "isStoreTableOrDataFrame",
                         "lstTransformations": [
                             {
                                 "enumTransformationType": "operatorUpdateParam",

--- a/instat/static/DialogDefinitions/DlgTraitCorrelations/dlgTraitCorrelations.json
+++ b/instat/static/DialogDefinitions/DlgTraitCorrelations/dlgTraitCorrelations.json
@@ -1,18 +1,5 @@
 [
     {
-        "enumTransformationType": "ifTrueExecuteChildTransformations",
-        "strValueKey": "isComment",
-        "lstTransformations": [
-            {
-                "enumTransformationType": "operatorUpdateParamPresentation",
-                "iStatementNumber": 0,
-                "strFunctionName": "<-",
-                "iParameterNumber": 0,
-                "strValueKey": "comment"
-            }
-        ]
-    },
-    {
         "enumTransformationType": "functionUpdateParamValue",
         "iStatementNumber": 0,
         "strFunctionName": "get_variables_metadata",
@@ -47,6 +34,12 @@
         "enumTransformationType": "ifFalseExecuteChildTransformations",
         "strValueKey": "isStoreTableOrDataFrame",
         "lstTransformations": [
+        ]
+    },
+    {
+        "enumTransformationType": "ifFalseExecuteChildTransformations",
+        "strValueKey": "isDisplayOptions",
+        "lstTransformations": [
             {
                 "enumTransformationType": "scriptInsert",
                 "iStatementNumber": 10,
@@ -67,13 +60,7 @@
                 "iParameterNumber": 0,
                 "strValueKey": "dataFrame",
                 "bIsQuoted": true
-            }
-        ]
-    },
-    {
-        "enumTransformationType": "ifFalseExecuteChildTransformations",
-        "strValueKey": "isDisplayOptions",
-        "lstTransformations": [
+            },
             {
                 "enumTransformationType": "ifTrueExecuteChildTransformations",
                 "strValueKey": "isStoreTableOrDataFrame",
@@ -139,6 +126,54 @@
             },
             {
                 "enumTransformationType": "ifTrueExecuteChildTransformations",
+                "strValueKey": "isSaveAsTable",
+                "lstTransformations": [
+                    {
+                        "enumTransformationType": "scriptInsert",
+                        "iStatementNumber": 10,
+                        "strScript": "\nlast_table <- corrr::fashion(kendall_rankings, decimals=_decimalPlaces)\ndata_book$add_object(data_name=\"_dataFrame\", object_name=\"last_table\", object_type_label=\"table\", object_format=\"text\", object=last_table)\n\ndata_book$get_object_data(data_name=\"_dataFrame\", object_name=\"last_table\", as_file=TRUE)"
+                    },
+                    {
+                        "enumTransformationType": "functionUpdateParamValue",
+                        "iStatementNumber": 10,
+                        "strFunctionName": "fashion",
+                        "iParameterNumber": 1,
+                        "strValueKey": "decimalPlaces"
+                    },
+                    {
+                        "enumTransformationType": "ifTrueExecuteChildTransformations",
+                        "strValueKey": "isLeadingZeros",
+                        "lstTransformations": [
+                            {
+                                "enumTransformationType": "functionAddParam",
+                                "iStatementNumber": 10,
+                                "strFunctionName": "fashion",
+                                "iParameterNumber": 1,
+                                "strParameterName": "leading_zeros",
+                                "strScript": "TRUE"
+                            }
+                        ]
+                    },
+                    {
+                        "enumTransformationType": "functionUpdateParamValue",
+                        "iStatementNumber": 11,
+                        "strFunctionName": "add_object",
+                        "iParameterNumber": 0,
+                        "strValueKey": "dataFrame",
+                        "bIsQuoted": true
+                    },
+                    {
+                        "enumTransformationType": "functionUpdateParamValue",
+                        "iStatementNumber": 12,
+                        "strFunctionName": "get_object_data",
+                        "iParameterNumber": 0,
+                        "strValueKey": "dataFrame",
+                        "bIsQuoted": true
+                    }
+                ]
+            },
+            {
+                "enumTransformationType": "ifTrueExecuteChildTransformations",
                 "strValueKey": "isStoreTableOrDataFrame",
                 "lstTransformations": [
                     {
@@ -184,50 +219,56 @@
                                 "bIsQuoted": true
                             }
                         ]
+                    }
+                ]
+            },
+            {
+                "enumTransformationType": "ifFalseExecuteChildTransformations",
+                "strValueKey": "isSaveAsTable",
+                "lstTransformations": [
+                    {
+                        "enumTransformationType": "scriptInsert",
+                        "iStatementNumber": 10,
+                        "strScript": "\nlast_dataframe <- corrr::fashion(kendall_rankings, decimals=_decimalPlaces)\ndata_book$import_data(data_tables=list(last_dataframe=last_dataframe))\n"
                     },
                     {
-                        "enumTransformationType": "ifFalseExecuteChildTransformations",
-                        "strValueKey": "isSaveAsTable",
+                        "enumTransformationType": "ifTrueExecuteChildTransformations",
+                        "strValueKey": "isIncludePValues",
                         "lstTransformations": [
                             {
-                                "enumTransformationType": "scriptInsert",
-                                "iStatementNumber": 10,
-                                "strScript": "\nlast_dataframe <- corrr::fashion(kendall_rankings, decimals=2)\ndata_book$import_data(data_tables=list(last_dataframe=last_dataframe))\n"
-                            },
+                                "enumTransformationType": "operatorUpdateParam",
+                                "iStatementNumber": 9,
+                                "strFunctionName": "<-",
+                                "iParameterNumber": 1,
+                                "strScript": "kendall_rankings"
+                            }
+                        ]
+                    },
+                    {
+                        "enumTransformationType": "functionUpdateParamValue",
+                        "iStatementNumber": 10,
+                        "strFunctionName": "fashion",
+                        "iParameterNumber": 1,
+                        "strValueKey": "decimalPlaces"
+                    },
+                    {
+                        "enumTransformationType": "ifTrueExecuteChildTransformations",
+                        "strValueKey": "isLeadingZeros",
+                        "lstTransformations": [
                             {
-                                "enumTransformationType": "ifTrueExecuteChildTransformations",
-                                "strValueKey": "isIncludePValues",
-                                "lstTransformations": [
-                                    {
-                                        "enumTransformationType": "operatorUpdateParam",
-                                        "iStatementNumber": 9,
-                                        "strFunctionName": "<-",
-                                        "iParameterNumber": 1,
-                                        "strScript": "kendall_rankings"
-                                    }
-                                ]
-                            },
-                            {
-                                "enumTransformationType": "functionUpdateParamValue",
+                                "enumTransformationType": "functionAddParam",
                                 "iStatementNumber": 10,
                                 "strFunctionName": "fashion",
                                 "iParameterNumber": 1,
-                                "strValueKey": "decimalPlaces"
-                            },
-                            {
-                                "enumTransformationType": "ifTrueExecuteChildTransformations",
-                                "strValueKey": "isLeadingZeros",
-                                "lstTransformations": [
-                                    {
-                                        "enumTransformationType": "functionAddParam",
-                                        "iStatementNumber": 10,
-                                        "strFunctionName": "fashion",
-                                        "iParameterNumber": 1,
-                                        "strParameterName": "leading_zeros",
-                                        "strScript": "TRUE"
-                                    }
-                                ]
-                            },
+                                "strParameterName": "leading_zeros",
+                                "strScript": "TRUE"
+                            }
+                        ]
+                    },
+                    {
+                        "enumTransformationType": "ifFalseExecuteChildTransformations",
+                        "strValueKey": "isStoreTableOrDataFrame",
+                        "lstTransformations": [
                             {
                                 "enumTransformationType": "functionUpdateParamValue",
                                 "iStatementNumber": 12,
@@ -235,7 +276,13 @@
                                 "iParameterNumber": 0,
                                 "strScript": "last_dataframe",
                                 "bIsQuoted": true
-                            },
+                            }
+                        ]
+                    },
+                    {
+                        "enumTransformationType": "ifTrueExecuteChildTransformations",
+                        "strValueKey": "isStoreTableOrDataFrame",
+                        "lstTransformations": [
                             {
                                 "enumTransformationType": "operatorUpdateParam",
                                 "iStatementNumber": 10,
@@ -267,6 +314,19 @@
                         ]
                     }
                 ]
+            }
+        ]
+    },
+    {
+        "enumTransformationType": "ifTrueExecuteChildTransformations",
+        "strValueKey": "isComment",
+        "lstTransformations": [
+            {
+                "enumTransformationType": "operatorUpdateParamPresentation",
+                "iStatementNumber": 0,
+                "strFunctionName": "<-",
+                "iParameterNumber": 0,
+                "strValueKey": "comment"
             }
         ]
     }

--- a/instat/ucrButtons.vb
+++ b/instat/ucrButtons.vb
@@ -527,16 +527,20 @@ Public Class ucrButtons
         strElementTree += vbLf & vbLf & "After duplicate ancestor removal:" & vbLf & vbLf
         strElementTree += OutputUIElementTree(rootElementNoDuplicateAncestors, 0)
 
-        ' If there are duplicates in different branches, then find the largest duplicate tree and
-        '   add add it to the LCA (Lowest Common Ancestor)
-        Dim rootElementDuplicatesInLca As UIElement = GetUIElementAddDuplicatesToLca(rootElementNoDuplicateAncestors) ' updated variable name here
-        strElementTree += vbLf & vbLf & "After adding longest duplicate to Lowest Common Ancestor (LCA):" & vbLf & vbLf
-        strElementTree += OutputUIElementTree(rootElementDuplicatesInLca, 0)
+        Dim rootElementDuplicatesInLca As UIElement
+        Do
+            ' If there are duplicates in different branches, then find the largest duplicate tree and
+            '   add add it to the LCA (Lowest Common Ancestor)
+            rootElementDuplicatesInLca = GetUIElementAddDuplicatesToLca(rootElementNoDuplicateAncestors) ' updated variable name here
+            strElementTree += vbLf & vbLf & "After adding longest duplicate to Lowest Common Ancestor (LCA):" & vbLf & vbLf
+            strElementTree += OutputUIElementTree(rootElementDuplicatesInLca, 0)
 
-        ' Remove nodes that are duplicates of their ancestors, or siblings of their ancestors
-        Dim rootElementDuplicatesInLcaCleaned = GetUIElementNoDuplicateAncestors(rootElementDuplicatesInLca, Nothing, Nothing)
-        strElementTree += vbLf & vbLf & "After cleaning LCA tree:" & vbLf & vbLf
-        strElementTree += OutputUIElementTree(rootElementDuplicatesInLcaCleaned, 0)
+            ' Remove nodes that are duplicates of their ancestors, or siblings of their ancestors
+            rootElementNoDuplicateAncestors = GetUIElementNoDuplicateAncestors(rootElementDuplicatesInLca, Nothing, Nothing)
+            strElementTree += vbLf & vbLf & "After cleaning LCA tree:" & vbLf & vbLf
+            strElementTree += OutputUIElementTree(rootElementNoDuplicateAncestors, 0)
+
+        Loop Until rootElementDuplicatesInLca Is Nothing
 
         ' Write the element tree to a file on the desktop
         Dim strDesktopPath As String = Environment.GetFolderPath(Environment.SpecialFolder.Desktop)

--- a/instat/ucrButtons.vb
+++ b/instat/ucrButtons.vb
@@ -851,15 +851,16 @@ Public Class ucrButtons
 End Class
 
 Public Class UIElement
-    Public Property strElementName As String
-    Public Property strLabel As String
+    Public ReadOnly Property strElementName As String
+    Public ReadOnly Property strLabel As String
     Public Property lstChildren As New List(Of UIElement)
 
-    Private ReadOnly resetDefault As String
+    Private ReadOnly strResetDefault As String
 
-    Public Sub New(strName As String, Optional defaultValue As String = "")
+    Public Sub New(strName As String, Optional defaultValue As String = "", Optional labelValue As String = "")
         strElementName = strName
-        resetDefault = defaultValue
+        strResetDefault = defaultValue
+        strLabel = labelValue
     End Sub
 
     ''' <summary>
@@ -878,7 +879,7 @@ Public Class UIElement
     ''' </summary>
     Public Overridable ReadOnly Property defaultAsString As String
         Get
-            Return resetDefault
+            Return strResetDefault
         End Get
     End Property
 
@@ -913,20 +914,20 @@ Public Class UIElementBoolean
     ''' <summary>
     ''' The default boolean value for this element.
     ''' </summary>
-    Public Property resetdefault As Boolean
+    Private ReadOnly bResetDefault As Boolean
 
     ''' <summary>
     ''' Returns "True" if default is True, otherwise "False".
     ''' </summary>
     Public Overrides ReadOnly Property DefaultAsString As String
         Get
-            Return If(resetdefault, "True", "False")
+            Return If(bResetDefault, "True", "False")
         End Get
     End Property
 
     Public Sub New(strName As String, Optional defaultValue As Boolean = False)
         MyBase.New(strName)
-        Me.resetdefault = defaultValue
+        bResetDefault = defaultValue
     End Sub
 End Class
 

--- a/instat/ucrButtons.vb
+++ b/instat/ucrButtons.vb
@@ -808,7 +808,8 @@ Public Class ucrButtons
         Dim lca As UIElement = Nothing
         For i = 0 To minLen - 1
             Dim thisNode = paths(0)(i)
-            If paths.All(Function(p) p(i) Is thisNode) Then
+            Dim iIndex = i 'needed to prevent warning in line below
+            If paths.All(Function(p) p(iIndex) Is thisNode) Then
                 lca = thisNode
             Else
                 Exit For
@@ -849,13 +850,16 @@ Public Class ucrButtons
 
 End Class
 
-' todo Define the UIElement class (place this outside of ucrButtons, e.g., at the end of the file or in a separate file if preferred)
 Public Class UIElement
     Public Property strElementName As String
+    Public Property strLabel As String
     Public Property lstChildren As New List(Of UIElement)
 
-    Public Sub New(strName As String)
+    Private ReadOnly resetDefault As String
+
+    Public Sub New(strName As String, Optional defaultValue As String = "")
         strElementName = strName
+        resetDefault = defaultValue
     End Sub
 
     ''' <summary>
@@ -866,6 +870,15 @@ Public Class UIElement
             Dim names As New List(Of String) From {strElementName}
             AddChildNames(lstChildren, names)
             Return String.Join(", ", names)
+        End Get
+    End Property
+
+    ''' <summary>
+    ''' Returns the default value as a string. Can be overridden by child classes.
+    ''' </summary>
+    Public Overridable ReadOnly Property defaultAsString As String
+        Get
+            Return resetDefault
         End Get
     End Property
 
@@ -889,5 +902,147 @@ Public Class UIElement
         Return clonedElement
     End Function
 
+End Class
+
+''' <summary>
+''' A UIElement that has a boolean default value.
+''' </summary>
+Public Class UIElementBoolean
+    Inherits UIElement
+
+    ''' <summary>
+    ''' The default boolean value for this element.
+    ''' </summary>
+    Public Property resetdefault As Boolean
+
+    ''' <summary>
+    ''' Returns "True" if default is True, otherwise "False".
+    ''' </summary>
+    Public Overrides ReadOnly Property DefaultAsString As String
+        Get
+            Return If(resetdefault, "True", "False")
+        End Get
+    End Property
+
+    Public Sub New(strName As String, Optional defaultValue As Boolean = False)
+        MyBase.New(strName)
+        Me.resetdefault = defaultValue
+    End Sub
+End Class
+
+''' <summary>
+''' Abstract base class for numeric UI elements. Requires child classes to implement min, max, and increment properties.
+''' </summary>
+Public MustInherit Class UIElementNumber
+    Inherits UIElement
+
+    Protected Sub New(strName As String, Optional defaultValue As String = "")
+        MyBase.New(strName, defaultValue)
+    End Sub
+
+    ''' <summary>
+    ''' The minimum value allowed for this element.
+    ''' </summary>
+    Public MustOverride ReadOnly Property min As Double
+
+    ''' <summary>
+    ''' The maximum value allowed for this element.
+    ''' </summary>
+    Public MustOverride ReadOnly Property max As Double
+
+    ''' <summary>
+    ''' The increment step for this element.
+    ''' </summary>
+    Public MustOverride ReadOnly Property increment As Double
+End Class
+
+''' <summary>
+''' Represents a UI element for integer values, with required min, max, and increment properties.
+''' </summary>
+Public Class UIElementInteger
+    Inherits UIElementNumber
+
+    Private ReadOnly _min As Integer
+    Private ReadOnly _max As Integer
+    Private ReadOnly _increment As Integer
+
+    Public Sub New(strName As String, minValue As Integer, maxValue As Integer, incrementValue As Integer, Optional defaultValue As String = "")
+        MyBase.New(strName, defaultValue)
+        _min = minValue
+        _max = maxValue
+        _increment = incrementValue
+    End Sub
+
+    ''' <summary>
+    ''' The minimum integer value allowed for this element.
+    ''' </summary>
+    Public Overrides ReadOnly Property min As Double
+        Get
+            Return _min
+        End Get
+    End Property
+
+    ''' <summary>
+    ''' The maximum integer value allowed for this element.
+    ''' </summary>
+    Public Overrides ReadOnly Property max As Double
+        Get
+            Return _max
+        End Get
+    End Property
+
+    ''' <summary>
+    ''' The increment step for this element (integer).
+    ''' </summary>
+    Public Overrides ReadOnly Property increment As Double
+        Get
+            Return _increment
+        End Get
+    End Property
+End Class
+
+''' <summary>
+''' Represents a UI element for real (double) values, with required min, max, and increment properties.
+''' </summary>
+Public Class UIElementReal
+    Inherits UIElementNumber
+
+    Private ReadOnly _min As Double
+    Private ReadOnly _max As Double
+    Private ReadOnly _increment As Double
+
+    Public Sub New(strName As String, minValue As Double, maxValue As Double, incrementValue As Double, Optional defaultValue As String = "")
+        MyBase.New(strName, defaultValue)
+        _min = minValue
+        _max = maxValue
+        _increment = incrementValue
+    End Sub
+
+    ''' <summary>
+    ''' The minimum double value allowed for this element.
+    ''' </summary>
+    Public Overrides ReadOnly Property min As Double
+        Get
+            Return _min
+        End Get
+    End Property
+
+    ''' <summary>
+    ''' The maximum double value allowed for this element.
+    ''' </summary>
+    Public Overrides ReadOnly Property max As Double
+        Get
+            Return _max
+        End Get
+    End Property
+
+    ''' <summary>
+    ''' The increment step for this element (double).
+    ''' </summary>
+    Public Overrides ReadOnly Property increment As Double
+        Get
+            Return _increment
+        End Get
+    End Property
 End Class
 

--- a/instat/ucrButtons.vb
+++ b/instat/ucrButtons.vb
@@ -572,18 +572,30 @@ Public Class ucrButtons
 
         ' Process children and remove duplicates among siblings
         Dim seenSignatures As New HashSet(Of String)(StringComparer.OrdinalIgnoreCase)
-        Dim newChildren As New List(Of UIElement)
+        Dim childrenParse1 As New List(Of UIElement)
         For Each child In element.lstChildren
             Dim cleanedChild = GetUIElementNoDuplicateSiblings(child, bIgnoreTrueFalse)
             If cleanedChild IsNot Nothing AndAlso Not IsSignatureInSet(cleanedChild.strSignature, seenSignatures, bIgnoreTrueFalse) Then
                 seenSignatures.Add(cleanedChild.strSignature)
-                newChildren.Add(cleanedChild)
+                childrenParse1.Add(cleanedChild)
+            End If
+        Next
+
+        'loop backwards through new children to see if we can remove any more siblings
+        seenSignatures = New HashSet(Of String)(StringComparer.OrdinalIgnoreCase)
+        Dim childrenParse2 As New List(Of UIElement)
+        For iChildIndex As Integer = childrenParse1.Count - 1 To 0 Step -1
+            Dim child = childrenParse1(iChildIndex)
+            Dim cleanedChild = GetUIElementNoDuplicateSiblings(child, bIgnoreTrueFalse)
+            If cleanedChild IsNot Nothing AndAlso Not IsSignatureInSet(cleanedChild.strSignature, seenSignatures, bIgnoreTrueFalse) Then
+                seenSignatures.Add(cleanedChild.strSignature)
+                childrenParse2.Add(cleanedChild)
             End If
         Next
 
         ' Create a new node to avoid mutating the original
         Dim newElement As New UIElement(element.strElementName)
-        newElement.lstChildren = newChildren
+        newElement.lstChildren = childrenParse2
         Return newElement
     End Function
 


### PR DESCRIPTION
This PR automatically creates a user interface specification for the `Trait Correlations XP` dialog.
It does this by traversing the tree of transformations specified in the dialog's JSON file. It then determines which values need to be set at the top-level (i.e. in the main panel of the dialog) and which values only need to be set when a condition is met (e.g. only need to be made visible when a checkbox is checked).

@rdstern This PR is not yet ready for testing.