### PR TITLE
Bug Fixes in the  Graphics Sub-dialogue

### DIFF
--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -116,12 +116,16 @@ Public Class ucrGeomListWithParameters
         ucrChkApplyOnAllLayers.Checked = bApplyAesGlobally
         ucrChkIgnoreGlobalAes.SetRCode(clsGeomFunction, bReset)
         If ucrChkApplyOnAllLayers.Checked AndAlso ucrChkIgnoreGlobalAes.Checked Then
-            MsgBox("Error: Cannot check both 'Apply On All Layers' and 'Ignore Global Aesthetics' as this will remove all aesthetics from this layer. Setting both values to checked.", vbOKOnly)
+            MsgBox("Error: Cannot check both 'Apply On All Layers' and 'Ignore Global Aesthetics' as this will remove all aesthetics from this layer. Setting both values to unchecked.", vbOKOnly)
             ucrChkApplyOnAllLayers.Checked = False
             ucrChkIgnoreGlobalAes.Checked = False
         End If
         bAllowShowGlobalAsLocal = True
-
+        If ucrChkIgnoreGlobalAes.Checked Then
+            ucrChkApplyOnAllLayers.Checked = False
+        Else
+            ucrChkApplyOnAllLayers.Show()
+        End If
         ' This might stay as data frame depends on global/local option and therefore can't be linked to a function
         InitialiseSelectedDataFrame()
 
@@ -234,6 +238,25 @@ Public Class ucrGeomListWithParameters
         End If
         SetParameters()
         SetInterAes()
+        ShowHideControls()
+    End Sub
+
+    Private Sub ShowHideControls()
+        Dim filledCount As Integer = 0
+
+        For Each receiver In lstAesParameterReceivers
+            If Not receiver.IsEmpty Then
+                filledCount += 1
+            End If
+        Next
+
+        If filledCount <= 1 OrElse (lstAesParameterReceivers.Count - filledCount) > 2 Then
+            ucrChkIgnoreGlobalAes.Hide()
+            ucrChkApplyOnAllLayers.Hide()
+        Else
+            ucrChkIgnoreGlobalAes.Show()
+            ucrChkApplyOnAllLayers.Show()
+        End If
     End Sub
 
     Public Function TestForOkEnabled() As Boolean
@@ -299,6 +322,7 @@ Public Class ucrGeomListWithParameters
         ucrChkIgnoreGlobalAes.Show()
 
         SetReceiverColour()
+        ShowHideControls()
     End Sub
 
     Private Sub AddRFunctionParameter(parentFunction As RFunction, paramName As String, paramValue As String)

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -293,7 +293,7 @@ Public Class ucrGeomListWithParameters
         'Warning: the dataframe needs to be set first. Indeed, this will enable IgnoreGlobalAes in the "datafram_changed" sub. In the same sub, Ignore global aes will be unticked and thus setAes called. If not done in this order, Ignore global aes is unticked below before the check box has been enabled and thus the event IngnoreGlobalAes.check.changed is not raised, and set aes never called.
         If ucrChkApplyOnAllLayers.Checked Then
             ucrChkIgnoreGlobalAes.Checked = False
-            ucrChkIgnoreGlobalAes.Hide()
+            'ucrChkIgnoreGlobalAes.Hide()
         Else
             ucrChkIgnoreGlobalAes.Show()
         End If

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -291,7 +291,11 @@ Public Class ucrGeomListWithParameters
         'Question to be discussed: are we happy with this ? We don't want it to be the opposite, i.e. the global data frame to be changed when apply on all layers is ticked ? Would then need to "reset the global aes function"... See issue on github... All this should be revised when linking is studied.
         ucrGeomWithAesSelector.SetDataframe(strGlobalDataFrame, (Not ucrChkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")
         'Warning: the dataframe needs to be set first. Indeed, this will enable IgnoreGlobalAes in the "datafram_changed" sub. In the same sub, Ignore global aes will be unticked and thus setAes called. If not done in this order, Ignore global aes is unticked below before the check box has been enabled and thus the event IngnoreGlobalAes.check.changed is not raised, and set aes never called.
-
+        If ucrChkApplyOnAllLayers.Checked Then
+            ucrChkIgnoreGlobalAes.Checked = False
+        Else
+            ucrChkIgnoreGlobalAes.Show()
+        End If
         ucrChkIgnoreGlobalAes.Show()
 
         SetReceiverColour()

--- a/instat/UcrGeomListWithAes.vb
+++ b/instat/UcrGeomListWithAes.vb
@@ -291,12 +291,9 @@ Public Class ucrGeomListWithParameters
         'Question to be discussed: are we happy with this ? We don't want it to be the opposite, i.e. the global data frame to be changed when apply on all layers is ticked ? Would then need to "reset the global aes function"... See issue on github... All this should be revised when linking is studied.
         ucrGeomWithAesSelector.SetDataframe(strGlobalDataFrame, (Not ucrChkApplyOnAllLayers.Checked) OrElse strGlobalDataFrame = "")
         'Warning: the dataframe needs to be set first. Indeed, this will enable IgnoreGlobalAes in the "datafram_changed" sub. In the same sub, Ignore global aes will be unticked and thus setAes called. If not done in this order, Ignore global aes is unticked below before the check box has been enabled and thus the event IngnoreGlobalAes.check.changed is not raised, and set aes never called.
-        If ucrChkApplyOnAllLayers.Checked Then
-            ucrChkIgnoreGlobalAes.Checked = False
-            'ucrChkIgnoreGlobalAes.Hide()
-        Else
-            ucrChkIgnoreGlobalAes.Show()
-        End If
+
+        ucrChkIgnoreGlobalAes.Show()
+
         SetReceiverColour()
     End Sub
 


### PR DESCRIPTION
Fixes #6578 
Removed the bug that caused the the Ignore Global Aesthetics Control to disappear, but i realised that in the control value changed they didnt want the Ignore Global Aesthetics to be checked while apply on all layers was already checked so i left that condition as it is
@lilyclements if you say otherwise then i will remove that condition statement
