### PR TITLE
Disabling option for filter in Row Summaries

### DIFF
--- a/instat/dlgRowSummary.vb
+++ b/instat/dlgRowSummary.vb
@@ -54,6 +54,8 @@ Public Class dlgRowSummary
         Dim dctRangeValues As New Dictionary(Of String, String)
         Dim dctTypeValues As New Dictionary(Of String, String)
 
+        ucrSelectorForRowSummaries.bUseCurrentFilter = False ' temporarily disabling filtering option - see #4141
+
         ucrReceiverForRowSummaries.SetParameter(New RParameter("x", 0, bNewIncludeArgumentName:=False))
         ucrReceiverForRowSummaries.Selector = ucrSelectorForRowSummaries
         ucrReceiverForRowSummaries.SetMeAsReceiver()


### PR DESCRIPTION
Fixes #4141

We will return to the remaining issues later, but the "return later" tab has been given