### PR TITLE
Update compileCheck.yml

### DIFF
--- a/.github/workflows/compileCheck.yml
+++ b/.github/workflows/compileCheck.yml
@@ -15,7 +15,7 @@ jobs:
         configuration: [Debug, Release]
 
     # running on 2019 so that .NET version 4.5 and lower can be used
-    runs-on: windows-2019 
+    runs-on: windows-2022 
     
     # set variables
     env:


### PR DESCRIPTION
updating from Windows-2019 as now deprecated

Originally 2019 was used due to the .NET version. Testing to see if it can run on newer version of windows