### PR TITLE
Added tooltips to the tricot model display sub-dialog

### DIFF
--- a/instat/sdgDisplayModelOptions.Designer.vb
+++ b/instat/sdgDisplayModelOptions.Designer.vb
@@ -22,6 +22,7 @@ Partial Class sdgDisplayModelOptions
     'Ne la modifiez pas à l'aide de l'éditeur de code.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
+        Me.components = New System.ComponentModel.Container()
         Me.lblNumber = New System.Windows.Forms.Label()
         Me.lblConfLevel = New System.Windows.Forms.Label()
         Me.tpGraphics = New System.Windows.Forms.TabPage()
@@ -54,9 +55,10 @@ Partial Class sdgDisplayModelOptions
         Me.ucrChkConfLimits = New instat.ucrCheck()
         Me.ucrChkANOVA = New instat.ucrCheck()
         Me.ucrChkModel = New instat.ucrCheck()
+        Me.ucrChkSave = New instat.ucrCheck()
         Me.tbpDisplayOptions = New System.Windows.Forms.TabControl()
         Me.ucrSdgButtons = New instat.ucrButtonsSubdialogue()
-        Me.ucrChkSave = New instat.ucrCheck()
+        Me.ttModelDisplay = New System.Windows.Forms.ToolTip(Me.components)
         Me.tpGraphics.SuspendLayout()
         Me.tpDisplay.SuspendLayout()
         Me.grpTrees.SuspendLayout()
@@ -430,6 +432,16 @@ Partial Class sdgDisplayModelOptions
         Me.ucrChkModel.Size = New System.Drawing.Size(348, 34)
         Me.ucrChkModel.TabIndex = 7
         '
+        'ucrChkSave
+        '
+        Me.ucrChkSave.AutoSize = True
+        Me.ucrChkSave.Checked = False
+        Me.ucrChkSave.Location = New System.Drawing.Point(250, 128)
+        Me.ucrChkSave.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrChkSave.Name = "ucrChkSave"
+        Me.ucrChkSave.Size = New System.Drawing.Size(348, 34)
+        Me.ucrChkSave.TabIndex = 25
+        '
         'tbpDisplayOptions
         '
         Me.tbpDisplayOptions.Controls.Add(Me.tpDisplay)
@@ -449,16 +461,6 @@ Partial Class sdgDisplayModelOptions
         Me.ucrSdgButtons.Name = "ucrSdgButtons"
         Me.ucrSdgButtons.Size = New System.Drawing.Size(336, 46)
         Me.ucrSdgButtons.TabIndex = 11
-        '
-        'ucrChkSave
-        '
-        Me.ucrChkSave.AutoSize = True
-        Me.ucrChkSave.Checked = False
-        Me.ucrChkSave.Location = New System.Drawing.Point(250, 128)
-        Me.ucrChkSave.Margin = New System.Windows.Forms.Padding(9)
-        Me.ucrChkSave.Name = "ucrChkSave"
-        Me.ucrChkSave.Size = New System.Drawing.Size(348, 34)
-        Me.ucrChkSave.TabIndex = 25
         '
         'sdgDisplayModelOptions
         '
@@ -521,4 +523,5 @@ Partial Class sdgDisplayModelOptions
     Friend WithEvents rdoTree As RadioButton
     Friend WithEvents grpTrees As GroupBox
     Friend WithEvents ucrChkSave As ucrCheck
+    Friend WithEvents ttModelDisplay As ToolTip
 End Class

--- a/instat/sdgDisplayModelOptions.resx
+++ b/instat/sdgDisplayModelOptions.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="ttModelDisplay.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/instat/sdgDisplayModelOptions.vb
+++ b/instat/sdgDisplayModelOptions.vb
@@ -41,6 +41,29 @@ Public Class sdgDisplayModelOptions
     End Enum
 
     Private Sub InitialiseDialog()
+
+        ' Adding tooltips
+        AddToolTip(ucrChkModel, "Provides an overview of the model including item rankings, coefficients, and model fit.")
+        AddToolTip(ucrChkANOVA, "Assesses the goodness of fit for the Plackett Luce model fitted")
+        AddToolTip(ucrChkEstimates, "Displays the model coefficients (item worths), with an option to log-transform them for easier interpretation.")
+        AddToolTip(ucrChkConfLimits, "Shows confidence intervals for the estimated item worths, indicating the uncertainty around each value.")
+        AddToolTip(ucrChkAIC, "Displays Akaike's Information Criterion to help compare model quality, with lower values indicating better fit.")
+        AddToolTip(ucrChkDeviance, "Reports the deviance statistic, measuring how well the model fits the observed data (lower is better).")
+        AddToolTip(ucrChkSndEstimetes, "Lists the predicted probabilities or rankings from the fitted model.")
+        AddToolTip(ucrChkParProp, "Shows the probability of one item being preferred over another based on the model.")
+        AddToolTip(ucrChkReability, "Measures how consistently the model distinguishes between items, often used to assess precision or predictability.")
+        AddToolTip(ucrChkItemPara, "Lists the estimated worth (preference scores) of each item in the model.")
+        AddToolTip(ucrChkVaCoMa, "Displays the estimated variances and covariances between item parameters.")
+        AddToolTip(ucrChkQuasiVa, "Provides quasi-variances and standard errors, allowing valid comparisons between multiple items without needing a reference item.")
+        AddToolTip(ucrChkRegret, "Displays regret values at each node, reflecting the potential loss from not choosing the optimal item (based on worst-case scenarios).")
+        AddToolTip(ucrChkNodeLabel, "Shows labels for each terminal node, often based on top items or group summaries.")
+        AddToolTip(ucrChkNodeRules, "Lists the conditions (e.g. variable splits) used to form each node in the tree.")
+        AddToolTip(ucrChkTopItem, "Highlights the most preferred items within each terminal node, helping interpret local preferences across subgroups.")
+        ttModelDisplay.SetToolTip(rdoMap, "Displays a tree with faceted dotplots beneath it, showing the estimated item worths at each terminal node. Helps visualise how item rankings vary across subgroups.")
+        ttModelDisplay.SetToolTip(rdoBar, "Plots the item worths as a bar chart for a single model, making it easy to compare relative rankings.")
+        ttModelDisplay.SetToolTip(rdoTree, "Shows the structure of the Plackett-Luce tree, including the variables used for splits and the decision rules at each node.")
+
+
         ucrChkModel.SetText("Summary")
         ucrChkModel.AddParameterValuesCondition(True, "summary", "True")
         ucrChkModel.AddParameterValuesCondition(False, "summary", "False")
@@ -229,6 +252,14 @@ Public Class sdgDisplayModelOptions
             ucrPnlPlots.SetRCode(clsDummyFunction, bReset)
         End If
         AddRemoveSummary()
+    End Sub
+
+    Private Sub AddToolTip(cntrl As ucrCore, value As String)
+        For Each element As Control In cntrl.Controls
+            If TypeOf element Is CheckBox Then
+                ttModelDisplay.SetToolTip(element, value)
+            End If
+        Next
     End Sub
 
     Private Sub ucrChkAIC_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkAIC.ControlValueChanged


### PR DESCRIPTION
Fixes #9744
@lilyclements @rachelkg @rdstern 
I have added the tooltips as given in the issue. 

@lilyclements I think you may have forgotten one (the general plot radio button).

I realized that for the custom controls (the ones starting with ucr), adding the tooltips directly wasn't working so I had to create a helper function for that.

Thank you.