### PR TITLE
Excluded Characters from the Explanatory model receiver

### DIFF
--- a/instat/dlgModellingTree.vb
+++ b/instat/dlgModellingTree.vb
@@ -86,6 +86,7 @@ Public Class dlgModellingTree
         ucrReceiverExpressionModellingTree.bWithQuotes = False
         ucrReceiverExpressionModellingTree.AddtoCombobox("1")
         ucrReceiverExpressionModellingTree.strSelectorHeading = "Variables"
+        ucrReceiverExpressionModellingTree.SetExcludedDataTypes({"character"})
 
         ucrInputCheck.SetLinkedDisplayControl(lblCheckVareity)
 

--- a/instat/dlgModellingTree.vb
+++ b/instat/dlgModellingTree.vb
@@ -86,7 +86,7 @@ Public Class dlgModellingTree
         ucrReceiverExpressionModellingTree.bWithQuotes = False
         ucrReceiverExpressionModellingTree.AddtoCombobox("1")
         ucrReceiverExpressionModellingTree.strSelectorHeading = "Variables"
-        ucrReceiverExpressionModellingTree.SetExcludedDataTypes({"character"})
+        ucrReceiverExpressionModellingTree.SetIncludedDataTypes({"numeric", "factor"})
 
         ucrInputCheck.SetLinkedDisplayControl(lblCheckVareity)
 


### PR DESCRIPTION
Fixes #9867 

This excludes charater variables from the Explanatory Model receiver in Tricot > Model > Modelling Trees