### PR TITLE
Fixed Bug found in General dialog title input Text

### DIFF
--- a/instat/UserTables/dlgGeneralTable.vb
+++ b/instat/UserTables/dlgGeneralTable.vb
@@ -49,6 +49,8 @@ Public Class dlgGeneralTable
         SetDefaults()
         SetRCodeForControls(True)
         TestOKEnabled()
+        ucrInputTitle.ResetText()
+        ucrInputTitleFooter.ResetText()
     End Sub
 
     Private Sub initialiseDialog()


### PR DESCRIPTION
Fixes #9879

I have added `ResetText()` to both ucrInputTitle and ucrInputTitleFooter and placed them on the clickReset command. 
@berylwaswa , @lilyclements this is Ready for review
Thanks