### PR TITLE
Calling geometry correctly in Climatic Maps Dialog

### DIFF
--- a/instat/dlgClimaticStationMaps.vb
+++ b/instat/dlgClimaticStationMaps.vb
@@ -76,7 +76,9 @@ Public Class dlgClimaticStationMaps
         ucrSelectorStation.SetParameter(New RParameter("data", 0))
         ucrSelectorStation.SetParameterIsrfunction()
 
+        ucrReceiverGeometry.SetParameter(New RParameter("geometry", 0))
         ucrReceiverGeometry.Selector = ucrSelectorOutline
+        ucrReceiverGeometry.SetParameterIsRFunction()
 
         ucrReceiverFill.SetParameter(New RParameter("fill", 0))
         ucrReceiverFill.Selector = ucrSelectorOutline
@@ -306,6 +308,7 @@ Public Class dlgClimaticStationMaps
         ucrInputColour.SetRCode(clsLabelRepelFunction, bReset)
         ucrNudSize.SetRCode(clsLabelRepelFunction, bReset)
         ucrChkAddPoints.SetRCode(clsGGplotOperator, bReset)
+        ucrReceiverGeometry.SetRCode(clsSfAesFunction, bReset)
         If bReset Then
             ucrChkLabelledRectangle.SetRCode(clsGGplotOperator, bReset)
             ucrChkLabelAll.SetRCode(clsLabelRepelFunction, bReset)
@@ -481,6 +484,16 @@ Public Class dlgClimaticStationMaps
             If GeometryOutput IsNot Nothing AndAlso Not GeometryOutput.Type = Internals.SymbolicExpressionType.Null Then
                 ucrReceiverGeometry.Add(GeometryOutput.AsCharacter(0), ucrSelectorOutline.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
             End If
+            clsSfAesFunction.AddParameter("geometry", clsRFunctionParameter:=clsGetGeometry)
+        End If
+    End Sub
+
+    Private Sub ucrReceiverGeometry_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverGeometry.ControlValueChanged
+        clsSfAesFunction.RemoveParameterByName("geometry")
+        If ucrReceiverGeometry.IsEmpty Then
+            AutoFillGeometry()
+        Else
+            clsSfAesFunction.AddParameter("geometry", clsRFunctionParameter:=ucrReceiverGeometry.GetVariables)
         End If
     End Sub
 


### PR DESCRIPTION
As outlined in #7661

We want to call in the `geometry` parameter into the correct place when the receiver is filled, and to otherwise call in the `data_book$get_geometry(...)` option. 