### PR TITLE
Return to Start Screen After Closing Data Book

### DIFF
--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -1856,7 +1856,7 @@ Public Class frmMain
                                     MessageBoxButtons.YesNo, "Close Data") Then
             Exit Sub
         End If
-
+        SetToDefaultLayout()
         clsRLink.CloseDataBook()
         strSaveFilePath = ""
     End Sub


### PR DESCRIPTION
Making sure when using File>close data book, it automatically sends user back to starting screen view

fixes partly #9897

This PR fixes the issue below
@derekagorhom one addition to the changes is when I use File > Close Data Book and I have switched the Window to the Column (or maybe other) types of metadata, then I don't get the usual starting screen. I can use the curly arrow to get it back. Could that please be done automatically.

@lilyclements , @rdstern this is ready for review 
Thanks 