### PR TITLE
Design Amendments when Exporting to Google Buckets 

### DIFF
--- a/instat/dlgExportClimaticDefinitions.Designer.vb
+++ b/instat/dlgExportClimaticDefinitions.Designer.vb
@@ -34,7 +34,6 @@ Partial Class dlgExportClimaticDefinitions
         Me.cmdDefine = New System.Windows.Forms.Button()
         Me.lblStation = New System.Windows.Forms.Label()
         Me.lblCountry = New System.Windows.Forms.Label()
-        Me.ucrInputCountry = New instat.ucrInputTextBox()
         Me.ucrChkIncludeSummaryData = New instat.ucrCheck()
         Me.grpSummaries = New System.Windows.Forms.GroupBox()
         Me.ucrReceiverExtremIndicator = New instat.ucrReceiverSingle()
@@ -65,7 +64,8 @@ Partial Class dlgExportClimaticDefinitions
         Me.ucrReceiverStationName = New instat.ucrReceiverSingle()
         Me.lblStationName = New System.Windows.Forms.Label()
         Me.lblCountryMetada = New System.Windows.Forms.Label()
-        Me.ucrInputCountryMetadata = New instat.ucrInputTextBox()
+        Me.ucrInputComboCountry = New instat.ucrInputComboBox()
+        Me.ucrInputComboCountryMetadata = New instat.ucrInputComboBox()
         Me.grpSummaries.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -212,18 +212,6 @@ Partial Class dlgExportClimaticDefinitions
         Me.lblCountry.TabIndex = 21
         Me.lblCountry.Text = "Country:"
         '
-        'ucrInputCountry
-        '
-        Me.ucrInputCountry.AddQuotesIfUnrecognised = True
-        Me.ucrInputCountry.AutoSize = True
-        Me.ucrInputCountry.IsMultiline = False
-        Me.ucrInputCountry.IsReadOnly = False
-        Me.ucrInputCountry.Location = New System.Drawing.Point(478, 205)
-        Me.ucrInputCountry.Margin = New System.Windows.Forms.Padding(14)
-        Me.ucrInputCountry.Name = "ucrInputCountry"
-        Me.ucrInputCountry.Size = New System.Drawing.Size(180, 32)
-        Me.ucrInputCountry.TabIndex = 22
-        '
         'ucrChkIncludeSummaryData
         '
         Me.ucrChkIncludeSummaryData.AutoSize = True
@@ -251,7 +239,7 @@ Partial Class dlgExportClimaticDefinitions
         Me.grpSummaries.Controls.Add(Me.lblDataByYear)
         Me.grpSummaries.Controls.Add(Me.ucrReceiverDataYear)
         Me.grpSummaries.Controls.Add(Me.ucrReceiverDataYearMonth)
-        Me.grpSummaries.Location = New System.Drawing.Point(13, 396)
+        Me.grpSummaries.Location = New System.Drawing.Point(14, 396)
         Me.grpSummaries.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.grpSummaries.Name = "grpSummaries"
         Me.grpSummaries.Padding = New System.Windows.Forms.Padding(4, 5, 4, 5)
@@ -567,24 +555,39 @@ Partial Class dlgExportClimaticDefinitions
         Me.lblCountryMetada.TabIndex = 17
         Me.lblCountryMetada.Text = "Country:"
         '
-        'ucrInputCountryMetadata
+        'ucrInputComboCountry
         '
-        Me.ucrInputCountryMetadata.AddQuotesIfUnrecognised = True
-        Me.ucrInputCountryMetadata.AutoSize = True
-        Me.ucrInputCountryMetadata.IsMultiline = False
-        Me.ucrInputCountryMetadata.IsReadOnly = False
-        Me.ucrInputCountryMetadata.Location = New System.Drawing.Point(478, 463)
-        Me.ucrInputCountryMetadata.Margin = New System.Windows.Forms.Padding(14)
-        Me.ucrInputCountryMetadata.Name = "ucrInputCountryMetadata"
-        Me.ucrInputCountryMetadata.Size = New System.Drawing.Size(180, 32)
-        Me.ucrInputCountryMetadata.TabIndex = 18
+        Me.ucrInputComboCountry.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboCountry.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputComboCountry.GetSetSelectedIndex = -1
+        Me.ucrInputComboCountry.IsReadOnly = False
+        Me.ucrInputComboCountry.Location = New System.Drawing.Point(478, 206)
+        Me.ucrInputComboCountry.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrInputComboCountry.Name = "ucrInputComboCountry"
+        Me.ucrInputComboCountry.Size = New System.Drawing.Size(180, 32)
+        Me.ucrInputComboCountry.TabIndex = 22
+        '
+        'ucrInputComboCountryMetadata
+        '
+        Me.ucrInputComboCountryMetadata.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboCountryMetadata.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputComboCountryMetadata.GetSetSelectedIndex = -1
+        Me.ucrInputComboCountryMetadata.IsReadOnly = False
+        Me.ucrInputComboCountryMetadata.Location = New System.Drawing.Point(478, 463)
+        Me.ucrInputComboCountryMetadata.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrInputComboCountryMetadata.Name = "ucrInputComboCountryMetadata"
+        Me.ucrInputComboCountryMetadata.Size = New System.Drawing.Size(180, 32)
+        Me.ucrInputComboCountryMetadata.TabIndex = 18
         '
         'dlgExportClimaticDefinitions
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(9.0!, 20.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(699, 819)
+        Me.ClientSize = New System.Drawing.Size(698, 819)
+        Me.Controls.Add(Me.grpSummaries)
+        Me.Controls.Add(Me.ucrInputComboCountryMetadata)
+        Me.Controls.Add(Me.ucrInputComboCountry)
         Me.Controls.Add(Me.lblExport)
         Me.Controls.Add(Me.cmdChooseFile)
         Me.Controls.Add(Me.ucrInputTokenPath)
@@ -597,9 +600,7 @@ Partial Class dlgExportClimaticDefinitions
         Me.Controls.Add(Me.cmdDefine)
         Me.Controls.Add(Me.lblStation)
         Me.Controls.Add(Me.lblCountry)
-        Me.Controls.Add(Me.ucrInputCountry)
         Me.Controls.Add(Me.ucrChkIncludeSummaryData)
-        Me.Controls.Add(Me.grpSummaries)
         Me.Controls.Add(Me.ucrSelectorExportDefinitions)
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.lblDistrict)
@@ -613,7 +614,6 @@ Partial Class dlgExportClimaticDefinitions
         Me.Controls.Add(Me.ucrReceiverStationName)
         Me.Controls.Add(Me.lblStationName)
         Me.Controls.Add(Me.lblCountryMetada)
-        Me.Controls.Add(Me.ucrInputCountryMetadata)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.MaximizeBox = False
@@ -639,7 +639,6 @@ Partial Class dlgExportClimaticDefinitions
     Friend WithEvents cmdDefine As Button
     Friend WithEvents lblStation As Label
     Friend WithEvents lblCountry As Label
-    Friend WithEvents ucrInputCountry As ucrInputTextBox
     Friend WithEvents ucrChkIncludeSummaryData As ucrCheck
     Friend WithEvents grpSummaries As GroupBox
     Friend WithEvents ucrChkMonthlyTemp As ucrCheck
@@ -666,9 +665,10 @@ Partial Class dlgExportClimaticDefinitions
     Friend WithEvents ucrReceiverStationName As ucrReceiverSingle
     Friend WithEvents lblStationName As Label
     Friend WithEvents lblCountryMetada As Label
-    Friend WithEvents ucrInputCountryMetadata As ucrInputTextBox
     Friend WithEvents ucrReceiverExtremIndicator As ucrReceiverSingle
     Friend WithEvents ucrReceiverRainIndicator As ucrReceiverSingle
     Friend WithEvents lblRainIndicator As Label
     Friend WithEvents lblExtremRain As Label
+    Friend WithEvents ucrInputComboCountryMetadata As ucrInputComboBox
+    Friend WithEvents ucrInputComboCountry As ucrInputComboBox
 End Class

--- a/instat/dlgExportClimaticDefinitions.Designer.vb
+++ b/instat/dlgExportClimaticDefinitions.Designer.vb
@@ -22,7 +22,6 @@ Partial Class dlgExportClimaticDefinitions
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
-        Me.ucrReceiverYear = New instat.ucrReceiverSingle()
         Me.lblExport = New System.Windows.Forms.Label()
         Me.cmdChooseFile = New System.Windows.Forms.Button()
         Me.ucrInputTokenPath = New instat.ucrInputTextBox()
@@ -36,27 +35,25 @@ Partial Class dlgExportClimaticDefinitions
         Me.lblStation = New System.Windows.Forms.Label()
         Me.lblCountry = New System.Windows.Forms.Label()
         Me.ucrInputCountry = New instat.ucrInputTextBox()
-        Me.lblMonth = New System.Windows.Forms.Label()
-        Me.lblYear = New System.Windows.Forms.Label()
-        Me.ucrReceiverMonth = New instat.ucrReceiverSingle()
         Me.ucrChkIncludeSummaryData = New instat.ucrCheck()
         Me.grpSummaries = New System.Windows.Forms.GroupBox()
+        Me.ucrReceiverExtremIndicator = New instat.ucrReceiverSingle()
+        Me.ucrReceiverRainIndicator = New instat.ucrReceiverSingle()
+        Me.lblRainIndicator = New System.Windows.Forms.Label()
+        Me.lblExtremRain = New System.Windows.Forms.Label()
+        Me.lblDataByYearMonth = New System.Windows.Forms.Label()
         Me.ucrChkMonthlyTemp = New instat.ucrCheck()
         Me.ucrChkSeasonStartProp = New instat.ucrCheck()
-        Me.ucrChkExtremes = New instat.ucrCheck()
         Me.ucrChkCropSuccessProp = New instat.ucrCheck()
         Me.ucrChkAnnualTemp = New instat.ucrCheck()
         Me.ucrChkAnnualRainfall = New instat.ucrCheck()
         Me.lblCropData = New System.Windows.Forms.Label()
-        Me.lblDataByYearMonth = New System.Windows.Forms.Label()
+        Me.ucrReceiverCropData = New instat.ucrReceiverSingle()
         Me.lblDataByYear = New System.Windows.Forms.Label()
-        Me.lblRain = New System.Windows.Forms.Label()
-        Me.ucrReceiverRain = New instat.ucrReceiverSingle()
-        Me.ucrSelectorExportDefinitions = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.ucrBase = New instat.ucrButtons()
         Me.ucrReceiverDataYear = New instat.ucrReceiverSingle()
         Me.ucrReceiverDataYearMonth = New instat.ucrReceiverSingle()
-        Me.ucrReceiverCropData = New instat.ucrReceiverSingle()
+        Me.ucrSelectorExportDefinitions = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrBase = New instat.ucrButtons()
         Me.lblDistrict = New System.Windows.Forms.Label()
         Me.lblElavation = New System.Windows.Forms.Label()
         Me.lblLatitude = New System.Windows.Forms.Label()
@@ -69,43 +66,28 @@ Partial Class dlgExportClimaticDefinitions
         Me.lblStationName = New System.Windows.Forms.Label()
         Me.lblCountryMetada = New System.Windows.Forms.Label()
         Me.ucrInputCountryMetadata = New instat.ucrInputTextBox()
-        Me.ucrReceiverExtremIndicator = New instat.ucrReceiverSingle()
-        Me.ucrReceiverRainIndicator = New instat.ucrReceiverSingle()
-        Me.lblRainIndicator = New System.Windows.Forms.Label()
-        Me.lblExtremRain = New System.Windows.Forms.Label()
         Me.grpSummaries.SuspendLayout()
         Me.SuspendLayout()
-        '
-        'ucrReceiverYear
-        '
-        Me.ucrReceiverYear.AutoSize = True
-        Me.ucrReceiverYear.frmParent = Me
-        Me.ucrReceiverYear.Location = New System.Drawing.Point(330, 126)
-        Me.ucrReceiverYear.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverYear.Name = "ucrReceiverYear"
-        Me.ucrReceiverYear.Selector = Nothing
-        Me.ucrReceiverYear.Size = New System.Drawing.Size(120, 20)
-        Me.ucrReceiverYear.strNcFilePath = ""
-        Me.ucrReceiverYear.TabIndex = 52
-        Me.ucrReceiverYear.ucrSelector = Nothing
         '
         'lblExport
         '
         Me.lblExport.AutoSize = True
         Me.lblExport.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblExport.Location = New System.Drawing.Point(64, 46)
+        Me.lblExport.Location = New System.Drawing.Point(105, 69)
+        Me.lblExport.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblExport.Name = "lblExport"
-        Me.lblExport.Size = New System.Drawing.Size(41, 13)
-        Me.lblExport.TabIndex = 81
+        Me.lblExport.Size = New System.Drawing.Size(57, 20)
+        Me.lblExport.TabIndex = 5
         Me.lblExport.Text = "Token:"
         '
         'cmdChooseFile
         '
         Me.cmdChooseFile.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdChooseFile.Location = New System.Drawing.Point(311, 40)
+        Me.cmdChooseFile.Location = New System.Drawing.Point(465, 62)
+        Me.cmdChooseFile.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.cmdChooseFile.Name = "cmdChooseFile"
-        Me.cmdChooseFile.Size = New System.Drawing.Size(80, 23)
-        Me.cmdChooseFile.TabIndex = 83
+        Me.cmdChooseFile.Size = New System.Drawing.Size(120, 35)
+        Me.cmdChooseFile.TabIndex = 4
         Me.cmdChooseFile.Text = "Browse"
         Me.cmdChooseFile.UseVisualStyleBackColor = True
         '
@@ -115,11 +97,11 @@ Partial Class dlgExportClimaticDefinitions
         Me.ucrInputTokenPath.AutoSize = True
         Me.ucrInputTokenPath.IsMultiline = False
         Me.ucrInputTokenPath.IsReadOnly = False
-        Me.ucrInputTokenPath.Location = New System.Drawing.Point(111, 43)
-        Me.ucrInputTokenPath.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrInputTokenPath.Location = New System.Drawing.Point(166, 66)
+        Me.ucrInputTokenPath.Margin = New System.Windows.Forms.Padding(9, 12, 9, 12)
         Me.ucrInputTokenPath.Name = "ucrInputTokenPath"
-        Me.ucrInputTokenPath.Size = New System.Drawing.Size(191, 21)
-        Me.ucrInputTokenPath.TabIndex = 82
+        Me.ucrInputTokenPath.Size = New System.Drawing.Size(286, 32)
+        Me.ucrInputTokenPath.TabIndex = 3
         '
         'rdoUploadSummaries
         '
@@ -129,10 +111,11 @@ Partial Class dlgExportClimaticDefinitions
         Me.rdoUploadSummaries.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
         Me.rdoUploadSummaries.FlatStyle = System.Windows.Forms.FlatStyle.Flat
         Me.rdoUploadSummaries.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.rdoUploadSummaries.Location = New System.Drawing.Point(227, 7)
+        Me.rdoUploadSummaries.Location = New System.Drawing.Point(340, 11)
+        Me.rdoUploadSummaries.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.rdoUploadSummaries.Name = "rdoUploadSummaries"
-        Me.rdoUploadSummaries.Size = New System.Drawing.Size(122, 27)
-        Me.rdoUploadSummaries.TabIndex = 47
+        Me.rdoUploadSummaries.Size = New System.Drawing.Size(183, 42)
+        Me.rdoUploadSummaries.TabIndex = 2
         Me.rdoUploadSummaries.Text = "Upload Summaries"
         Me.rdoUploadSummaries.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         Me.rdoUploadSummaries.UseVisualStyleBackColor = True
@@ -145,10 +128,11 @@ Partial Class dlgExportClimaticDefinitions
         Me.rdoUpdateMetadata.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
         Me.rdoUpdateMetadata.FlatStyle = System.Windows.Forms.FlatStyle.Flat
         Me.rdoUpdateMetadata.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.rdoUpdateMetadata.Location = New System.Drawing.Point(114, 7)
+        Me.rdoUpdateMetadata.Location = New System.Drawing.Point(171, 11)
+        Me.rdoUpdateMetadata.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.rdoUpdateMetadata.Name = "rdoUpdateMetadata"
-        Me.rdoUpdateMetadata.Size = New System.Drawing.Size(116, 27)
-        Me.rdoUpdateMetadata.TabIndex = 46
+        Me.rdoUpdateMetadata.Size = New System.Drawing.Size(174, 42)
+        Me.rdoUpdateMetadata.TabIndex = 1
         Me.rdoUpdateMetadata.Text = "Update Metadata"
         Me.rdoUpdateMetadata.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         Me.rdoUpdateMetadata.UseVisualStyleBackColor = True
@@ -156,32 +140,33 @@ Partial Class dlgExportClimaticDefinitions
         'ucrPnlExportGoogle
         '
         Me.ucrPnlExportGoogle.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlExportGoogle.Location = New System.Drawing.Point(111, 2)
-        Me.ucrPnlExportGoogle.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrPnlExportGoogle.Location = New System.Drawing.Point(166, 3)
+        Me.ucrPnlExportGoogle.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrPnlExportGoogle.Name = "ucrPnlExportGoogle"
-        Me.ucrPnlExportGoogle.Size = New System.Drawing.Size(249, 33)
-        Me.ucrPnlExportGoogle.TabIndex = 45
+        Me.ucrPnlExportGoogle.Size = New System.Drawing.Size(374, 51)
+        Me.ucrPnlExportGoogle.TabIndex = 0
         '
         'ucrReceiverStation
         '
         Me.ucrReceiverStation.AutoSize = True
         Me.ucrReceiverStation.frmParent = Me
-        Me.ucrReceiverStation.Location = New System.Drawing.Point(330, 92)
+        Me.ucrReceiverStation.Location = New System.Drawing.Point(478, 143)
         Me.ucrReceiverStation.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverStation.Name = "ucrReceiverStation"
         Me.ucrReceiverStation.Selector = Nothing
-        Me.ucrReceiverStation.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverStation.Size = New System.Drawing.Size(180, 31)
         Me.ucrReceiverStation.strNcFilePath = ""
-        Me.ucrReceiverStation.TabIndex = 50
+        Me.ucrReceiverStation.TabIndex = 20
         Me.ucrReceiverStation.ucrSelector = Nothing
         '
         'lblDefinitionsID
         '
         Me.lblDefinitionsID.AutoSize = True
-        Me.lblDefinitionsID.Location = New System.Drawing.Point(1, 390)
+        Me.lblDefinitionsID.Location = New System.Drawing.Point(482, 244)
+        Me.lblDefinitionsID.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblDefinitionsID.Name = "lblDefinitionsID"
-        Me.lblDefinitionsID.Size = New System.Drawing.Size(73, 13)
-        Me.lblDefinitionsID.TabIndex = 67
+        Me.lblDefinitionsID.Size = New System.Drawing.Size(109, 20)
+        Me.lblDefinitionsID.TabIndex = 23
         Me.lblDefinitionsID.Text = "Definitions ID:"
         '
         'ucrInputDefinitionsID
@@ -190,38 +175,41 @@ Partial Class dlgExportClimaticDefinitions
         Me.ucrInputDefinitionsID.AutoSize = True
         Me.ucrInputDefinitionsID.IsMultiline = False
         Me.ucrInputDefinitionsID.IsReadOnly = False
-        Me.ucrInputDefinitionsID.Location = New System.Drawing.Point(86, 386)
-        Me.ucrInputDefinitionsID.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrInputDefinitionsID.Location = New System.Drawing.Point(478, 265)
+        Me.ucrInputDefinitionsID.Margin = New System.Windows.Forms.Padding(14)
         Me.ucrInputDefinitionsID.Name = "ucrInputDefinitionsID"
-        Me.ucrInputDefinitionsID.Size = New System.Drawing.Size(118, 21)
-        Me.ucrInputDefinitionsID.TabIndex = 68
+        Me.ucrInputDefinitionsID.Size = New System.Drawing.Size(180, 32)
+        Me.ucrInputDefinitionsID.TabIndex = 24
         '
         'cmdDefine
         '
         Me.cmdDefine.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDefine.Location = New System.Drawing.Point(330, 449)
+        Me.cmdDefine.Location = New System.Drawing.Point(466, 671)
+        Me.cmdDefine.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.cmdDefine.Name = "cmdDefine"
-        Me.cmdDefine.Size = New System.Drawing.Size(125, 25)
-        Me.cmdDefine.TabIndex = 72
+        Me.cmdDefine.Size = New System.Drawing.Size(188, 38)
+        Me.cmdDefine.TabIndex = 27
         Me.cmdDefine.Text = "Define"
         Me.cmdDefine.UseVisualStyleBackColor = True
         '
         'lblStation
         '
         Me.lblStation.AutoSize = True
-        Me.lblStation.Location = New System.Drawing.Point(330, 79)
+        Me.lblStation.Location = New System.Drawing.Point(482, 120)
+        Me.lblStation.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblStation.Name = "lblStation"
-        Me.lblStation.Size = New System.Drawing.Size(43, 13)
-        Me.lblStation.TabIndex = 49
-        Me.lblStation.Text = "Station:"
+        Me.lblStation.Size = New System.Drawing.Size(110, 20)
+        Me.lblStation.TabIndex = 19
+        Me.lblStation.Text = "Station Name:"
         '
         'lblCountry
         '
         Me.lblCountry.AutoSize = True
-        Me.lblCountry.Location = New System.Drawing.Point(28, 417)
+        Me.lblCountry.Location = New System.Drawing.Point(482, 184)
+        Me.lblCountry.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblCountry.Name = "lblCountry"
-        Me.lblCountry.Size = New System.Drawing.Size(46, 13)
-        Me.lblCountry.TabIndex = 69
+        Me.lblCountry.Size = New System.Drawing.Size(68, 20)
+        Me.lblCountry.TabIndex = 21
         Me.lblCountry.Text = "Country:"
         '
         'ucrInputCountry
@@ -230,177 +218,212 @@ Partial Class dlgExportClimaticDefinitions
         Me.ucrInputCountry.AutoSize = True
         Me.ucrInputCountry.IsMultiline = False
         Me.ucrInputCountry.IsReadOnly = False
-        Me.ucrInputCountry.Location = New System.Drawing.Point(86, 413)
-        Me.ucrInputCountry.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrInputCountry.Location = New System.Drawing.Point(478, 205)
+        Me.ucrInputCountry.Margin = New System.Windows.Forms.Padding(14)
         Me.ucrInputCountry.Name = "ucrInputCountry"
-        Me.ucrInputCountry.Size = New System.Drawing.Size(118, 21)
-        Me.ucrInputCountry.TabIndex = 70
-        '
-        'lblMonth
-        '
-        Me.lblMonth.AutoSize = True
-        Me.lblMonth.Location = New System.Drawing.Point(330, 151)
-        Me.lblMonth.Name = "lblMonth"
-        Me.lblMonth.Size = New System.Drawing.Size(40, 13)
-        Me.lblMonth.TabIndex = 53
-        Me.lblMonth.Text = "Month:"
-        '
-        'lblYear
-        '
-        Me.lblYear.AutoSize = True
-        Me.lblYear.Location = New System.Drawing.Point(330, 111)
-        Me.lblYear.Name = "lblYear"
-        Me.lblYear.Size = New System.Drawing.Size(32, 13)
-        Me.lblYear.TabIndex = 51
-        Me.lblYear.Text = "Year:"
-        '
-        'ucrReceiverMonth
-        '
-        Me.ucrReceiverMonth.AutoSize = True
-        Me.ucrReceiverMonth.frmParent = Me
-        Me.ucrReceiverMonth.Location = New System.Drawing.Point(330, 167)
-        Me.ucrReceiverMonth.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverMonth.Name = "ucrReceiverMonth"
-        Me.ucrReceiverMonth.Selector = Nothing
-        Me.ucrReceiverMonth.Size = New System.Drawing.Size(120, 20)
-        Me.ucrReceiverMonth.strNcFilePath = ""
-        Me.ucrReceiverMonth.TabIndex = 54
-        Me.ucrReceiverMonth.ucrSelector = Nothing
+        Me.ucrInputCountry.Size = New System.Drawing.Size(180, 32)
+        Me.ucrInputCountry.TabIndex = 22
         '
         'ucrChkIncludeSummaryData
         '
         Me.ucrChkIncludeSummaryData.AutoSize = True
         Me.ucrChkIncludeSummaryData.Checked = False
-        Me.ucrChkIncludeSummaryData.Location = New System.Drawing.Point(6, 445)
-        Me.ucrChkIncludeSummaryData.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkIncludeSummaryData.Location = New System.Drawing.Point(13, 675)
+        Me.ucrChkIncludeSummaryData.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkIncludeSummaryData.Name = "ucrChkIncludeSummaryData"
-        Me.ucrChkIncludeSummaryData.Size = New System.Drawing.Size(221, 31)
-        Me.ucrChkIncludeSummaryData.TabIndex = 71
+        Me.ucrChkIncludeSummaryData.Size = New System.Drawing.Size(368, 48)
+        Me.ucrChkIncludeSummaryData.TabIndex = 26
         '
         'grpSummaries
         '
+        Me.grpSummaries.Controls.Add(Me.ucrReceiverExtremIndicator)
+        Me.grpSummaries.Controls.Add(Me.ucrReceiverRainIndicator)
+        Me.grpSummaries.Controls.Add(Me.lblRainIndicator)
+        Me.grpSummaries.Controls.Add(Me.lblExtremRain)
+        Me.grpSummaries.Controls.Add(Me.lblDataByYearMonth)
         Me.grpSummaries.Controls.Add(Me.ucrChkMonthlyTemp)
         Me.grpSummaries.Controls.Add(Me.ucrChkSeasonStartProp)
-        Me.grpSummaries.Controls.Add(Me.ucrChkExtremes)
         Me.grpSummaries.Controls.Add(Me.ucrChkCropSuccessProp)
         Me.grpSummaries.Controls.Add(Me.ucrChkAnnualTemp)
         Me.grpSummaries.Controls.Add(Me.ucrChkAnnualRainfall)
-        Me.grpSummaries.Location = New System.Drawing.Point(2, 264)
+        Me.grpSummaries.Controls.Add(Me.lblCropData)
+        Me.grpSummaries.Controls.Add(Me.ucrReceiverCropData)
+        Me.grpSummaries.Controls.Add(Me.lblDataByYear)
+        Me.grpSummaries.Controls.Add(Me.ucrReceiverDataYear)
+        Me.grpSummaries.Controls.Add(Me.ucrReceiverDataYearMonth)
+        Me.grpSummaries.Location = New System.Drawing.Point(13, 396)
+        Me.grpSummaries.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.grpSummaries.Name = "grpSummaries"
-        Me.grpSummaries.Size = New System.Drawing.Size(313, 116)
-        Me.grpSummaries.TabIndex = 67
+        Me.grpSummaries.Padding = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.grpSummaries.Size = New System.Drawing.Size(669, 265)
+        Me.grpSummaries.TabIndex = 25
         Me.grpSummaries.TabStop = False
         Me.grpSummaries.Text = "Summaries"
+        '
+        'ucrReceiverExtremIndicator
+        '
+        Me.ucrReceiverExtremIndicator.AutoSize = True
+        Me.ucrReceiverExtremIndicator.frmParent = Me
+        Me.ucrReceiverExtremIndicator.Location = New System.Drawing.Point(472, 101)
+        Me.ucrReceiverExtremIndicator.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverExtremIndicator.Name = "ucrReceiverExtremIndicator"
+        Me.ucrReceiverExtremIndicator.Selector = Nothing
+        Me.ucrReceiverExtremIndicator.Size = New System.Drawing.Size(180, 31)
+        Me.ucrReceiverExtremIndicator.strNcFilePath = ""
+        Me.ucrReceiverExtremIndicator.TabIndex = 10
+        Me.ucrReceiverExtremIndicator.ucrSelector = Nothing
+        '
+        'ucrReceiverRainIndicator
+        '
+        Me.ucrReceiverRainIndicator.AutoSize = True
+        Me.ucrReceiverRainIndicator.frmParent = Me
+        Me.ucrReceiverRainIndicator.Location = New System.Drawing.Point(472, 63)
+        Me.ucrReceiverRainIndicator.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverRainIndicator.Name = "ucrReceiverRainIndicator"
+        Me.ucrReceiverRainIndicator.Selector = Nothing
+        Me.ucrReceiverRainIndicator.Size = New System.Drawing.Size(180, 31)
+        Me.ucrReceiverRainIndicator.strNcFilePath = ""
+        Me.ucrReceiverRainIndicator.TabIndex = 8
+        Me.ucrReceiverRainIndicator.ucrSelector = Nothing
+        '
+        'lblRainIndicator
+        '
+        Me.lblRainIndicator.AutoSize = True
+        Me.lblRainIndicator.Location = New System.Drawing.Point(298, 65)
+        Me.lblRainIndicator.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblRainIndicator.Name = "lblRainIndicator"
+        Me.lblRainIndicator.Size = New System.Drawing.Size(170, 20)
+        Me.lblRainIndicator.TabIndex = 7
+        Me.lblRainIndicator.Text = "Rain Indicator Column:"
+        '
+        'lblExtremRain
+        '
+        Me.lblExtremRain.AutoSize = True
+        Me.lblExtremRain.Location = New System.Drawing.Point(293, 103)
+        Me.lblExtremRain.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblExtremRain.Name = "lblExtremRain"
+        Me.lblExtremRain.Size = New System.Drawing.Size(175, 20)
+        Me.lblExtremRain.TabIndex = 9
+        Me.lblExtremRain.Text = "Extreme Rain Indicator:"
+        '
+        'lblDataByYearMonth
+        '
+        Me.lblDataByYearMonth.AutoSize = True
+        Me.lblDataByYearMonth.Location = New System.Drawing.Point(280, 145)
+        Me.lblDataByYearMonth.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblDataByYearMonth.Name = "lblDataByYearMonth"
+        Me.lblDataByYearMonth.Size = New System.Drawing.Size(188, 20)
+        Me.lblDataByYearMonth.TabIndex = 11
+        Me.lblDataByYearMonth.Text = "Data By Year and Month:"
         '
         'ucrChkMonthlyTemp
         '
         Me.ucrChkMonthlyTemp.AutoSize = True
         Me.ucrChkMonthlyTemp.Checked = False
-        Me.ucrChkMonthlyTemp.Location = New System.Drawing.Point(8, 77)
-        Me.ucrChkMonthlyTemp.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkMonthlyTemp.Location = New System.Drawing.Point(12, 140)
+        Me.ucrChkMonthlyTemp.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkMonthlyTemp.Name = "ucrChkMonthlyTemp"
-        Me.ucrChkMonthlyTemp.Size = New System.Drawing.Size(147, 34)
-        Me.ucrChkMonthlyTemp.TabIndex = 4
+        Me.ucrChkMonthlyTemp.Size = New System.Drawing.Size(220, 34)
+        Me.ucrChkMonthlyTemp.TabIndex = 2
         '
         'ucrChkSeasonStartProp
         '
         Me.ucrChkSeasonStartProp.AutoSize = True
         Me.ucrChkSeasonStartProp.Checked = False
-        Me.ucrChkSeasonStartProp.Location = New System.Drawing.Point(157, 44)
-        Me.ucrChkSeasonStartProp.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkSeasonStartProp.Location = New System.Drawing.Point(12, 224)
+        Me.ucrChkSeasonStartProp.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkSeasonStartProp.Name = "ucrChkSeasonStartProp"
-        Me.ucrChkSeasonStartProp.Size = New System.Drawing.Size(151, 34)
-        Me.ucrChkSeasonStartProp.TabIndex = 3
-        '
-        'ucrChkExtremes
-        '
-        Me.ucrChkExtremes.AutoSize = True
-        Me.ucrChkExtremes.Checked = False
-        Me.ucrChkExtremes.Location = New System.Drawing.Point(157, 77)
-        Me.ucrChkExtremes.Margin = New System.Windows.Forms.Padding(6)
-        Me.ucrChkExtremes.Name = "ucrChkExtremes"
-        Me.ucrChkExtremes.Size = New System.Drawing.Size(147, 34)
-        Me.ucrChkExtremes.TabIndex = 5
-        Me.ucrChkExtremes.Visible = False
+        Me.ucrChkSeasonStartProp.Size = New System.Drawing.Size(226, 37)
+        Me.ucrChkSeasonStartProp.TabIndex = 4
         '
         'ucrChkCropSuccessProp
         '
         Me.ucrChkCropSuccessProp.AutoSize = True
         Me.ucrChkCropSuccessProp.Checked = False
-        Me.ucrChkCropSuccessProp.Location = New System.Drawing.Point(157, 13)
-        Me.ucrChkCropSuccessProp.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkCropSuccessProp.Location = New System.Drawing.Point(12, 182)
+        Me.ucrChkCropSuccessProp.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkCropSuccessProp.Name = "ucrChkCropSuccessProp"
-        Me.ucrChkCropSuccessProp.Size = New System.Drawing.Size(153, 34)
-        Me.ucrChkCropSuccessProp.TabIndex = 1
+        Me.ucrChkCropSuccessProp.Size = New System.Drawing.Size(230, 52)
+        Me.ucrChkCropSuccessProp.TabIndex = 3
         '
         'ucrChkAnnualTemp
         '
         Me.ucrChkAnnualTemp.AutoSize = True
         Me.ucrChkAnnualTemp.Checked = False
-        Me.ucrChkAnnualTemp.Location = New System.Drawing.Point(8, 45)
-        Me.ucrChkAnnualTemp.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkAnnualTemp.Location = New System.Drawing.Point(12, 66)
+        Me.ucrChkAnnualTemp.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkAnnualTemp.Name = "ucrChkAnnualTemp"
-        Me.ucrChkAnnualTemp.Size = New System.Drawing.Size(149, 34)
-        Me.ucrChkAnnualTemp.TabIndex = 2
+        Me.ucrChkAnnualTemp.Size = New System.Drawing.Size(224, 34)
+        Me.ucrChkAnnualTemp.TabIndex = 1
         '
         'ucrChkAnnualRainfall
         '
         Me.ucrChkAnnualRainfall.AutoSize = True
         Me.ucrChkAnnualRainfall.Checked = False
-        Me.ucrChkAnnualRainfall.Location = New System.Drawing.Point(8, 13)
-        Me.ucrChkAnnualRainfall.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkAnnualRainfall.Location = New System.Drawing.Point(12, 24)
+        Me.ucrChkAnnualRainfall.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkAnnualRainfall.Name = "ucrChkAnnualRainfall"
-        Me.ucrChkAnnualRainfall.Size = New System.Drawing.Size(149, 34)
+        Me.ucrChkAnnualRainfall.Size = New System.Drawing.Size(224, 34)
         Me.ucrChkAnnualRainfall.TabIndex = 0
         '
         'lblCropData
         '
         Me.lblCropData.AutoSize = True
-        Me.lblCropData.Location = New System.Drawing.Point(330, 307)
+        Me.lblCropData.Location = New System.Drawing.Point(382, 184)
+        Me.lblCropData.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblCropData.Name = "lblCropData"
-        Me.lblCropData.Size = New System.Drawing.Size(58, 13)
-        Me.lblCropData.TabIndex = 61
+        Me.lblCropData.Size = New System.Drawing.Size(86, 20)
+        Me.lblCropData.TabIndex = 13
         Me.lblCropData.Text = "Crop Data:"
         '
-        'lblDataByYearMonth
+        'ucrReceiverCropData
         '
-        Me.lblDataByYearMonth.AutoSize = True
-        Me.lblDataByYearMonth.Location = New System.Drawing.Point(329, 267)
-        Me.lblDataByYearMonth.Name = "lblDataByYearMonth"
-        Me.lblDataByYearMonth.Size = New System.Drawing.Size(127, 13)
-        Me.lblDataByYearMonth.TabIndex = 59
-        Me.lblDataByYearMonth.Text = "Data By Year and Month:"
+        Me.ucrReceiverCropData.AutoSize = True
+        Me.ucrReceiverCropData.frmParent = Me
+        Me.ucrReceiverCropData.Location = New System.Drawing.Point(472, 182)
+        Me.ucrReceiverCropData.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverCropData.Name = "ucrReceiverCropData"
+        Me.ucrReceiverCropData.Selector = Nothing
+        Me.ucrReceiverCropData.Size = New System.Drawing.Size(180, 31)
+        Me.ucrReceiverCropData.strNcFilePath = ""
+        Me.ucrReceiverCropData.TabIndex = 14
+        Me.ucrReceiverCropData.ucrSelector = Nothing
         '
         'lblDataByYear
         '
         Me.lblDataByYear.AutoSize = True
-        Me.lblDataByYear.Location = New System.Drawing.Point(330, 227)
+        Me.lblDataByYear.Location = New System.Drawing.Point(360, 24)
+        Me.lblDataByYear.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblDataByYear.Name = "lblDataByYear"
-        Me.lblDataByYear.Size = New System.Drawing.Size(73, 13)
-        Me.lblDataByYear.TabIndex = 57
+        Me.lblDataByYear.Size = New System.Drawing.Size(108, 20)
+        Me.lblDataByYear.TabIndex = 5
         Me.lblDataByYear.Text = "Data By Year:"
         '
-        'lblRain
+        'ucrReceiverDataYear
         '
-        Me.lblRain.AutoSize = True
-        Me.lblRain.Location = New System.Drawing.Point(330, 191)
-        Me.lblRain.Name = "lblRain"
-        Me.lblRain.Size = New System.Drawing.Size(32, 13)
-        Me.lblRain.TabIndex = 55
-        Me.lblRain.Text = "Rain:"
+        Me.ucrReceiverDataYear.AutoSize = True
+        Me.ucrReceiverDataYear.frmParent = Me
+        Me.ucrReceiverDataYear.Location = New System.Drawing.Point(472, 22)
+        Me.ucrReceiverDataYear.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverDataYear.Name = "ucrReceiverDataYear"
+        Me.ucrReceiverDataYear.Selector = Nothing
+        Me.ucrReceiverDataYear.Size = New System.Drawing.Size(180, 31)
+        Me.ucrReceiverDataYear.strNcFilePath = ""
+        Me.ucrReceiverDataYear.TabIndex = 6
+        Me.ucrReceiverDataYear.ucrSelector = Nothing
         '
-        'ucrReceiverRain
+        'ucrReceiverDataYearMonth
         '
-        Me.ucrReceiverRain.AutoSize = True
-        Me.ucrReceiverRain.frmParent = Me
-        Me.ucrReceiverRain.Location = New System.Drawing.Point(330, 207)
-        Me.ucrReceiverRain.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverRain.Name = "ucrReceiverRain"
-        Me.ucrReceiverRain.Selector = Nothing
-        Me.ucrReceiverRain.Size = New System.Drawing.Size(120, 20)
-        Me.ucrReceiverRain.strNcFilePath = ""
-        Me.ucrReceiverRain.TabIndex = 56
-        Me.ucrReceiverRain.ucrSelector = Nothing
+        Me.ucrReceiverDataYearMonth.AutoSize = True
+        Me.ucrReceiverDataYearMonth.frmParent = Me
+        Me.ucrReceiverDataYearMonth.Location = New System.Drawing.Point(472, 143)
+        Me.ucrReceiverDataYearMonth.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverDataYearMonth.Name = "ucrReceiverDataYearMonth"
+        Me.ucrReceiverDataYearMonth.Selector = Nothing
+        Me.ucrReceiverDataYearMonth.Size = New System.Drawing.Size(180, 31)
+        Me.ucrReceiverDataYearMonth.strNcFilePath = ""
+        Me.ucrReceiverDataYearMonth.TabIndex = 12
+        Me.ucrReceiverDataYearMonth.ucrSelector = Nothing
         '
         'ucrSelectorExportDefinitions
         '
@@ -408,183 +431,140 @@ Partial Class dlgExportClimaticDefinitions
         Me.ucrSelectorExportDefinitions.bDropUnusedFilterLevels = False
         Me.ucrSelectorExportDefinitions.bShowHiddenColumns = False
         Me.ucrSelectorExportDefinitions.bUseCurrentFilter = True
-        Me.ucrSelectorExportDefinitions.Location = New System.Drawing.Point(2, 78)
+        Me.ucrSelectorExportDefinitions.Location = New System.Drawing.Point(13, 109)
         Me.ucrSelectorExportDefinitions.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorExportDefinitions.Name = "ucrSelectorExportDefinitions"
-        Me.ucrSelectorExportDefinitions.Size = New System.Drawing.Size(213, 183)
-        Me.ucrSelectorExportDefinitions.TabIndex = 48
+        Me.ucrSelectorExportDefinitions.Size = New System.Drawing.Size(320, 282)
+        Me.ucrSelectorExportDefinitions.TabIndex = 6
         '
         'ucrBase
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(2, 487)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrBase.Location = New System.Drawing.Point(14, 738)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(408, 52)
-        Me.ucrBase.TabIndex = 73
-        '
-        'ucrReceiverDataYear
-        '
-        Me.ucrReceiverDataYear.AutoSize = True
-        Me.ucrReceiverDataYear.frmParent = Me
-        Me.ucrReceiverDataYear.Location = New System.Drawing.Point(330, 244)
-        Me.ucrReceiverDataYear.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverDataYear.Name = "ucrReceiverDataYear"
-        Me.ucrReceiverDataYear.Selector = Nothing
-        Me.ucrReceiverDataYear.Size = New System.Drawing.Size(120, 20)
-        Me.ucrReceiverDataYear.strNcFilePath = ""
-        Me.ucrReceiverDataYear.TabIndex = 58
-        Me.ucrReceiverDataYear.ucrSelector = Nothing
-        '
-        'ucrReceiverDataYearMonth
-        '
-        Me.ucrReceiverDataYearMonth.AutoSize = True
-        Me.ucrReceiverDataYearMonth.frmParent = Me
-        Me.ucrReceiverDataYearMonth.Location = New System.Drawing.Point(330, 283)
-        Me.ucrReceiverDataYearMonth.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverDataYearMonth.Name = "ucrReceiverDataYearMonth"
-        Me.ucrReceiverDataYearMonth.Selector = Nothing
-        Me.ucrReceiverDataYearMonth.Size = New System.Drawing.Size(120, 20)
-        Me.ucrReceiverDataYearMonth.strNcFilePath = ""
-        Me.ucrReceiverDataYearMonth.TabIndex = 60
-        Me.ucrReceiverDataYearMonth.ucrSelector = Nothing
-        '
-        'ucrReceiverCropData
-        '
-        Me.ucrReceiverCropData.AutoSize = True
-        Me.ucrReceiverCropData.frmParent = Me
-        Me.ucrReceiverCropData.Location = New System.Drawing.Point(330, 323)
-        Me.ucrReceiverCropData.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverCropData.Name = "ucrReceiverCropData"
-        Me.ucrReceiverCropData.Selector = Nothing
-        Me.ucrReceiverCropData.Size = New System.Drawing.Size(120, 20)
-        Me.ucrReceiverCropData.strNcFilePath = ""
-        Me.ucrReceiverCropData.TabIndex = 62
-        Me.ucrReceiverCropData.ucrSelector = Nothing
+        Me.ucrBase.Size = New System.Drawing.Size(611, 77)
+        Me.ucrBase.TabIndex = 28
         '
         'lblDistrict
         '
         Me.lblDistrict.AutoSize = True
-        Me.lblDistrict.Location = New System.Drawing.Point(324, 270)
-        Me.lblDistrict.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.lblDistrict.Location = New System.Drawing.Point(482, 375)
         Me.lblDistrict.Name = "lblDistrict"
-        Me.lblDistrict.Size = New System.Drawing.Size(39, 13)
-        Me.lblDistrict.TabIndex = 79
-        Me.lblDistrict.Text = "District"
+        Me.lblDistrict.Size = New System.Drawing.Size(62, 20)
+        Me.lblDistrict.TabIndex = 15
+        Me.lblDistrict.Text = "District:"
         '
         'lblElavation
         '
         Me.lblElavation.AutoSize = True
-        Me.lblElavation.Location = New System.Drawing.Point(323, 222)
-        Me.lblElavation.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.lblElavation.Location = New System.Drawing.Point(482, 309)
         Me.lblElavation.Name = "lblElavation"
-        Me.lblElavation.Size = New System.Drawing.Size(51, 13)
-        Me.lblElavation.TabIndex = 77
-        Me.lblElavation.Text = "Elevation"
+        Me.lblElavation.Size = New System.Drawing.Size(78, 20)
+        Me.lblElavation.TabIndex = 13
+        Me.lblElavation.Text = "Elevation:"
         '
         'lblLatitude
         '
         Me.lblLatitude.AutoSize = True
-        Me.lblLatitude.Location = New System.Drawing.Point(322, 173)
-        Me.lblLatitude.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.lblLatitude.Location = New System.Drawing.Point(482, 247)
         Me.lblLatitude.Name = "lblLatitude"
-        Me.lblLatitude.Size = New System.Drawing.Size(45, 13)
-        Me.lblLatitude.TabIndex = 75
-        Me.lblLatitude.Text = "Latitude"
+        Me.lblLatitude.Size = New System.Drawing.Size(71, 20)
+        Me.lblLatitude.TabIndex = 11
+        Me.lblLatitude.Text = "Latitude:"
         '
         'lblLongitude
         '
         Me.lblLongitude.AutoSize = True
-        Me.lblLongitude.Location = New System.Drawing.Point(321, 123)
-        Me.lblLongitude.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.lblLongitude.Location = New System.Drawing.Point(482, 185)
         Me.lblLongitude.Name = "lblLongitude"
-        Me.lblLongitude.Size = New System.Drawing.Size(57, 13)
-        Me.lblLongitude.TabIndex = 73
-        Me.lblLongitude.Text = "Longitude "
+        Me.lblLongitude.Size = New System.Drawing.Size(84, 20)
+        Me.lblLongitude.TabIndex = 9
+        Me.lblLongitude.Text = "Longitude:"
         '
         'ucrReceiverLongititude
         '
         Me.ucrReceiverLongititude.AutoSize = True
         Me.ucrReceiverLongititude.frmParent = Me
-        Me.ucrReceiverLongititude.Location = New System.Drawing.Point(319, 140)
+        Me.ucrReceiverLongititude.Location = New System.Drawing.Point(478, 205)
         Me.ucrReceiverLongititude.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverLongititude.Name = "ucrReceiverLongititude"
         Me.ucrReceiverLongititude.Selector = Nothing
-        Me.ucrReceiverLongititude.Size = New System.Drawing.Size(120, 23)
+        Me.ucrReceiverLongititude.Size = New System.Drawing.Size(180, 35)
         Me.ucrReceiverLongititude.strNcFilePath = ""
-        Me.ucrReceiverLongititude.TabIndex = 74
+        Me.ucrReceiverLongititude.TabIndex = 10
         Me.ucrReceiverLongititude.ucrSelector = Nothing
         '
         'ucrReceiverLatitude
         '
         Me.ucrReceiverLatitude.AutoSize = True
         Me.ucrReceiverLatitude.frmParent = Me
-        Me.ucrReceiverLatitude.Location = New System.Drawing.Point(319, 192)
+        Me.ucrReceiverLatitude.Location = New System.Drawing.Point(478, 267)
         Me.ucrReceiverLatitude.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverLatitude.Name = "ucrReceiverLatitude"
         Me.ucrReceiverLatitude.Selector = Nothing
-        Me.ucrReceiverLatitude.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverLatitude.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverLatitude.strNcFilePath = ""
-        Me.ucrReceiverLatitude.TabIndex = 76
+        Me.ucrReceiverLatitude.TabIndex = 12
         Me.ucrReceiverLatitude.ucrSelector = Nothing
         '
         'ucrReceiverElavation
         '
         Me.ucrReceiverElavation.AutoSize = True
         Me.ucrReceiverElavation.frmParent = Me
-        Me.ucrReceiverElavation.Location = New System.Drawing.Point(319, 240)
+        Me.ucrReceiverElavation.Location = New System.Drawing.Point(478, 329)
         Me.ucrReceiverElavation.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverElavation.Name = "ucrReceiverElavation"
         Me.ucrReceiverElavation.Selector = Nothing
-        Me.ucrReceiverElavation.Size = New System.Drawing.Size(120, 23)
+        Me.ucrReceiverElavation.Size = New System.Drawing.Size(180, 35)
         Me.ucrReceiverElavation.strNcFilePath = ""
-        Me.ucrReceiverElavation.TabIndex = 78
+        Me.ucrReceiverElavation.TabIndex = 14
         Me.ucrReceiverElavation.ucrSelector = Nothing
         '
         'ucrReceiverDistrict
         '
         Me.ucrReceiverDistrict.AutoSize = True
         Me.ucrReceiverDistrict.frmParent = Me
-        Me.ucrReceiverDistrict.Location = New System.Drawing.Point(319, 289)
+        Me.ucrReceiverDistrict.Location = New System.Drawing.Point(478, 396)
         Me.ucrReceiverDistrict.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverDistrict.Name = "ucrReceiverDistrict"
         Me.ucrReceiverDistrict.Selector = Nothing
-        Me.ucrReceiverDistrict.Size = New System.Drawing.Size(120, 28)
+        Me.ucrReceiverDistrict.Size = New System.Drawing.Size(180, 43)
         Me.ucrReceiverDistrict.strNcFilePath = ""
-        Me.ucrReceiverDistrict.TabIndex = 80
+        Me.ucrReceiverDistrict.TabIndex = 16
         Me.ucrReceiverDistrict.ucrSelector = Nothing
         '
         'ucrReceiverStationName
         '
         Me.ucrReceiverStationName.AutoSize = True
         Me.ucrReceiverStationName.frmParent = Me
-        Me.ucrReceiverStationName.Location = New System.Drawing.Point(319, 93)
+        Me.ucrReceiverStationName.Location = New System.Drawing.Point(478, 143)
         Me.ucrReceiverStationName.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverStationName.Name = "ucrReceiverStationName"
         Me.ucrReceiverStationName.Selector = Nothing
-        Me.ucrReceiverStationName.Size = New System.Drawing.Size(120, 27)
+        Me.ucrReceiverStationName.Size = New System.Drawing.Size(180, 42)
         Me.ucrReceiverStationName.strNcFilePath = ""
-        Me.ucrReceiverStationName.TabIndex = 72
+        Me.ucrReceiverStationName.TabIndex = 8
         Me.ucrReceiverStationName.ucrSelector = Nothing
         '
         'lblStationName
         '
         Me.lblStationName.AutoSize = True
-        Me.lblStationName.Location = New System.Drawing.Point(321, 78)
-        Me.lblStationName.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.lblStationName.Location = New System.Drawing.Point(482, 120)
         Me.lblStationName.Name = "lblStationName"
-        Me.lblStationName.Size = New System.Drawing.Size(71, 13)
-        Me.lblStationName.TabIndex = 71
-        Me.lblStationName.Text = "Station Name"
+        Me.lblStationName.Size = New System.Drawing.Size(110, 20)
+        Me.lblStationName.TabIndex = 7
+        Me.lblStationName.Text = "Station Name:"
         '
         'lblCountryMetada
         '
         Me.lblCountryMetada.AutoSize = True
-        Me.lblCountryMetada.Location = New System.Drawing.Point(323, 316)
+        Me.lblCountryMetada.Location = New System.Drawing.Point(482, 439)
+        Me.lblCountryMetada.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblCountryMetada.Name = "lblCountryMetada"
-        Me.lblCountryMetada.Size = New System.Drawing.Size(46, 13)
-        Me.lblCountryMetada.TabIndex = 85
+        Me.lblCountryMetada.Size = New System.Drawing.Size(68, 20)
+        Me.lblCountryMetada.TabIndex = 17
         Me.lblCountryMetada.Text = "Country:"
         '
         'ucrInputCountryMetadata
@@ -593,68 +573,18 @@ Partial Class dlgExportClimaticDefinitions
         Me.ucrInputCountryMetadata.AutoSize = True
         Me.ucrInputCountryMetadata.IsMultiline = False
         Me.ucrInputCountryMetadata.IsReadOnly = False
-        Me.ucrInputCountryMetadata.Location = New System.Drawing.Point(319, 334)
-        Me.ucrInputCountryMetadata.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrInputCountryMetadata.Location = New System.Drawing.Point(478, 463)
+        Me.ucrInputCountryMetadata.Margin = New System.Windows.Forms.Padding(14)
         Me.ucrInputCountryMetadata.Name = "ucrInputCountryMetadata"
-        Me.ucrInputCountryMetadata.Size = New System.Drawing.Size(118, 21)
-        Me.ucrInputCountryMetadata.TabIndex = 84
-        '
-        'ucrReceiverExtremIndicator
-        '
-        Me.ucrReceiverExtremIndicator.AutoSize = True
-        Me.ucrReceiverExtremIndicator.frmParent = Me
-        Me.ucrReceiverExtremIndicator.Location = New System.Drawing.Point(330, 414)
-        Me.ucrReceiverExtremIndicator.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverExtremIndicator.Name = "ucrReceiverExtremIndicator"
-        Me.ucrReceiverExtremIndicator.Selector = Nothing
-        Me.ucrReceiverExtremIndicator.Size = New System.Drawing.Size(120, 20)
-        Me.ucrReceiverExtremIndicator.strNcFilePath = ""
-        Me.ucrReceiverExtremIndicator.TabIndex = 66
-        Me.ucrReceiverExtremIndicator.ucrSelector = Nothing
-        '
-        'ucrReceiverRainIndicator
-        '
-        Me.ucrReceiverRainIndicator.AutoSize = True
-        Me.ucrReceiverRainIndicator.frmParent = Me
-        Me.ucrReceiverRainIndicator.Location = New System.Drawing.Point(330, 373)
-        Me.ucrReceiverRainIndicator.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverRainIndicator.Name = "ucrReceiverRainIndicator"
-        Me.ucrReceiverRainIndicator.Selector = Nothing
-        Me.ucrReceiverRainIndicator.Size = New System.Drawing.Size(120, 20)
-        Me.ucrReceiverRainIndicator.strNcFilePath = ""
-        Me.ucrReceiverRainIndicator.TabIndex = 64
-        Me.ucrReceiverRainIndicator.ucrSelector = Nothing
-        '
-        'lblRainIndicator
-        '
-        Me.lblRainIndicator.AutoSize = True
-        Me.lblRainIndicator.Location = New System.Drawing.Point(335, 357)
-        Me.lblRainIndicator.Name = "lblRainIndicator"
-        Me.lblRainIndicator.Size = New System.Drawing.Size(114, 13)
-        Me.lblRainIndicator.TabIndex = 63
-        Me.lblRainIndicator.Text = "Rain Indicator Column:"
-        '
-        'lblExtremRain
-        '
-        Me.lblExtremRain.AutoSize = True
-        Me.lblExtremRain.Location = New System.Drawing.Point(334, 400)
-        Me.lblExtremRain.Name = "lblExtremRain"
-        Me.lblExtremRain.Size = New System.Drawing.Size(117, 13)
-        Me.lblExtremRain.TabIndex = 65
-        Me.lblExtremRain.Text = "Extreme Rain Indicator:"
+        Me.ucrInputCountryMetadata.Size = New System.Drawing.Size(180, 32)
+        Me.ucrInputCountryMetadata.TabIndex = 18
         '
         'dlgExportClimaticDefinitions
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(9.0!, 20.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(459, 542)
-        Me.Controls.Add(Me.lblDataByYearMonth)
-        Me.Controls.Add(Me.lblRainIndicator)
-        Me.Controls.Add(Me.ucrReceiverRainIndicator)
-        Me.Controls.Add(Me.lblExtremRain)
-        Me.Controls.Add(Me.ucrReceiverExtremIndicator)
-        Me.Controls.Add(Me.ucrReceiverYear)
+        Me.ClientSize = New System.Drawing.Size(699, 819)
         Me.Controls.Add(Me.lblExport)
         Me.Controls.Add(Me.cmdChooseFile)
         Me.Controls.Add(Me.ucrInputTokenPath)
@@ -668,20 +598,10 @@ Partial Class dlgExportClimaticDefinitions
         Me.Controls.Add(Me.lblStation)
         Me.Controls.Add(Me.lblCountry)
         Me.Controls.Add(Me.ucrInputCountry)
-        Me.Controls.Add(Me.lblMonth)
-        Me.Controls.Add(Me.lblYear)
-        Me.Controls.Add(Me.ucrReceiverMonth)
         Me.Controls.Add(Me.ucrChkIncludeSummaryData)
         Me.Controls.Add(Me.grpSummaries)
-        Me.Controls.Add(Me.lblCropData)
-        Me.Controls.Add(Me.lblDataByYear)
-        Me.Controls.Add(Me.lblRain)
-        Me.Controls.Add(Me.ucrReceiverRain)
         Me.Controls.Add(Me.ucrSelectorExportDefinitions)
         Me.Controls.Add(Me.ucrBase)
-        Me.Controls.Add(Me.ucrReceiverDataYear)
-        Me.Controls.Add(Me.ucrReceiverDataYearMonth)
-        Me.Controls.Add(Me.ucrReceiverCropData)
         Me.Controls.Add(Me.lblDistrict)
         Me.Controls.Add(Me.lblElavation)
         Me.Controls.Add(Me.lblLatitude)
@@ -695,6 +615,7 @@ Partial Class dlgExportClimaticDefinitions
         Me.Controls.Add(Me.lblCountryMetada)
         Me.Controls.Add(Me.ucrInputCountryMetadata)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgExportClimaticDefinitions"
@@ -706,8 +627,6 @@ Partial Class dlgExportClimaticDefinitions
         Me.PerformLayout()
 
     End Sub
-
-    Friend WithEvents ucrReceiverYear As ucrReceiverSingle
     Friend WithEvents lblExport As Label
     Friend WithEvents cmdChooseFile As Button
     Friend WithEvents ucrInputTokenPath As ucrInputTextBox
@@ -721,22 +640,16 @@ Partial Class dlgExportClimaticDefinitions
     Friend WithEvents lblStation As Label
     Friend WithEvents lblCountry As Label
     Friend WithEvents ucrInputCountry As ucrInputTextBox
-    Friend WithEvents lblMonth As Label
-    Friend WithEvents lblYear As Label
-    Friend WithEvents ucrReceiverMonth As ucrReceiverSingle
     Friend WithEvents ucrChkIncludeSummaryData As ucrCheck
     Friend WithEvents grpSummaries As GroupBox
     Friend WithEvents ucrChkMonthlyTemp As ucrCheck
     Friend WithEvents ucrChkSeasonStartProp As ucrCheck
-    Friend WithEvents ucrChkExtremes As ucrCheck
     Friend WithEvents ucrChkCropSuccessProp As ucrCheck
     Friend WithEvents ucrChkAnnualTemp As ucrCheck
     Friend WithEvents ucrChkAnnualRainfall As ucrCheck
     Friend WithEvents lblCropData As Label
     Friend WithEvents lblDataByYearMonth As Label
     Friend WithEvents lblDataByYear As Label
-    Friend WithEvents lblRain As Label
-    Friend WithEvents ucrReceiverRain As ucrReceiverSingle
     Friend WithEvents ucrSelectorExportDefinitions As ucrSelectorByDataFrameAddRemove
     Friend WithEvents ucrBase As ucrButtons
     Friend WithEvents ucrReceiverDataYear As ucrReceiverSingle

--- a/instat/dlgExportClimaticDefinitions.vb
+++ b/instat/dlgExportClimaticDefinitions.vb
@@ -113,8 +113,8 @@ Public Class dlgExportClimaticDefinitions
         ucrInputDefinitionsID.SetParameter(New RParameter("definitions_id", 19))
         ucrInputDefinitionsID.SetLinkedDisplayControl(lblDefinitionsID)
 
-        ucrInputCountry.SetParameter(New RParameter("country", 20))
-        ucrInputCountry.SetLinkedDisplayControl(lblCountry)
+        ucrInputComboCountry.SetParameter(New RParameter("country", 20))
+        ucrInputComboCountry.SetLinkedDisplayControl(lblCountry)
 
         ucrInputTokenPath.SetParameter(New RParameter("filename", 0))
         ucrInputTokenPath.SetLinkedDisplayControl(lblExport)
@@ -154,12 +154,12 @@ Public Class dlgExportClimaticDefinitions
         ucrReceiverDistrict.bAutoFill = True
         ucrReceiverDistrict.SetLinkedDisplayControl(lblDistrict)
 
-        ucrInputCountryMetadata.SetParameter(New RParameter("country", 6))
-        ucrInputCountryMetadata.SetLinkedDisplayControl(lblCountryMetada)
+        ucrInputComboCountryMetadata.SetParameter(New RParameter("country", 6))
+        ucrInputComboCountryMetadata.SetLinkedDisplayControl(lblCountryMetada)
 
         ucrPnlExportGoogle.AddToLinkedControls({ucrReceiverStation}, {rdoUploadSummaries}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrPnlExportGoogle.AddToLinkedControls({ucrReceiverDistrict, ucrReceiverElavation, ucrReceiverLatitude, ucrInputCountryMetadata, ucrReceiverLongititude, ucrReceiverStationName}, {rdoUpdateMetadata}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrPnlExportGoogle.AddToLinkedControls({ucrInputCountry, ucrChkIncludeSummaryData, ucrInputDefinitionsID}, {rdoUploadSummaries}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlExportGoogle.AddToLinkedControls({ucrReceiverDistrict, ucrReceiverElavation, ucrReceiverLatitude, ucrInputComboCountryMetadata, ucrReceiverLongititude, ucrReceiverStationName}, {rdoUpdateMetadata}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlExportGoogle.AddToLinkedControls({ucrInputComboCountry, ucrChkIncludeSummaryData, ucrInputDefinitionsID}, {rdoUploadSummaries}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         DialogSize()
     End Sub
 
@@ -234,7 +234,7 @@ Public Class dlgExportClimaticDefinitions
         ucrInputTokenPath.SetRCode(ClsGcsAuthFileFunction, bReset)
 
         ucrInputDefinitionsID.SetRCode(clsExportRinstatToBucketFunction, bReset)
-        ucrInputCountry.SetRCode(clsExportRinstatToBucketFunction, bReset)
+        ucrInputComboCountry.SetRCode(clsExportRinstatToBucketFunction, bReset)
         ucrChkIncludeSummaryData.SetRCode(clsExportRinstatToBucketFunction, bReset)
 
         ucrReceiverDistrict.SetRCode(clsUpdateMetadataInfoFunction, bReset)
@@ -242,7 +242,7 @@ Public Class dlgExportClimaticDefinitions
         ucrReceiverLatitude.SetRCode(clsUpdateMetadataInfoFunction, bReset)
         ucrReceiverLongititude.SetRCode(clsUpdateMetadataInfoFunction, bReset)
         ucrReceiverStationName.SetRCode(clsUpdateMetadataInfoFunction, bReset)
-        ucrInputCountryMetadata.SetRCode(clsUpdateMetadataInfoFunction, bReset)
+        ucrInputComboCountryMetadata.SetRCode(clsUpdateMetadataInfoFunction, bReset)
 
         If bReset Then
             ucrChkAnnualRainfall.SetRCode(clsDummyFunction, bReset)
@@ -260,7 +260,7 @@ Public Class dlgExportClimaticDefinitions
         If rdoUploadSummaries.Checked Then
             ' Basic required fields
             Dim bRequiredFieldsFilled As Boolean = Not ucrReceiverStation.IsEmpty AndAlso
-                                               Not ucrInputCountry.IsEmpty AndAlso
+                                               Not ucrInputComboCountry.IsEmpty AndAlso
                                                Not ucrInputDefinitionsID.IsEmpty AndAlso
                                                Not ucrInputTokenPath.IsEmpty
 
@@ -292,7 +292,7 @@ Public Class dlgExportClimaticDefinitions
             ' Non-upload mode (metadata)
             If Not ucrReceiverStationName.IsEmpty AndAlso
            Not ucrInputTokenPath.IsEmpty AndAlso
-           Not ucrInputCountryMetadata.IsEmpty Then
+           Not ucrInputComboCountryMetadata.IsEmpty Then
                 ucrBase.OKEnabled(True)
             Else
                 ucrBase.OKEnabled(False)
@@ -379,9 +379,9 @@ Public Class dlgExportClimaticDefinitions
         TestOkEnabled()
     End Sub
 
-    Private Sub ucrInputCountry_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputCountry.ControlValueChanged
-        If Not ucrInputCountry.IsEmpty Then
-            clsExportRinstatToBucketFunction.AddParameter("country", Chr(34) & ucrInputCountry.GetText & Chr(34), iPosition:=20)
+    Private Sub ucrInputCountry_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputComboCountry.ControlValueChanged
+        If Not ucrInputComboCountry.IsEmpty Then
+            clsExportRinstatToBucketFunction.AddParameter("country", Chr(34) & ucrInputComboCountry.GetText & Chr(34), iPosition:=20)
         Else
             clsExportRinstatToBucketFunction.RemoveParameterByName("country")
         End If
@@ -476,14 +476,14 @@ Public Class dlgExportClimaticDefinitions
         clsUpdateMetadataInfoFunction.AddParameter("metadata_data", clsRFunctionParameter:=clsGetDataFrameFunction, iPosition:=0)
     End Sub
 
-    Private Sub ucrReceiverData_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverCropData.ControlContentsChanged, ucrReceiverDataYearMonth.ControlContentsChanged, ucrReceiverDataYear.ControlContentsChanged, ucrReceiverStation.ControlContentsChanged, ucrInputTokenPath.ControlContentsChanged, ucrInputCountryMetadata.ControlContentsChanged, ucrChkSeasonStartProp.ControlContentsChanged, ucrInputCountry.ControlContentsChanged, ucrInputDefinitionsID.ControlContentsChanged, ucrChkIncludeSummaryData.ControlContentsChanged, ucrReceiverLongititude.ControlContentsChanged, ucrReceiverLatitude.ControlContentsChanged,
+    Private Sub ucrReceiverData_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverCropData.ControlContentsChanged, ucrReceiverDataYearMonth.ControlContentsChanged, ucrReceiverDataYear.ControlContentsChanged, ucrReceiverStation.ControlContentsChanged, ucrInputTokenPath.ControlContentsChanged, ucrChkSeasonStartProp.ControlContentsChanged, ucrInputDefinitionsID.ControlContentsChanged, ucrChkIncludeSummaryData.ControlContentsChanged, ucrReceiverLongititude.ControlContentsChanged, ucrReceiverLatitude.ControlContentsChanged, ucrInputComboCountryMetadata.ControlContentsChanged, ucrInputComboCountry.ControlContentsChanged,
             ucrChkMonthlyTemp.ControlContentsChanged, ucrChkCropSuccessProp.ControlContentsChanged, ucrChkAnnualTemp.ControlContentsChanged, ucrChkAnnualRainfall.ControlContentsChanged, ucrSelectorExportDefinitions.ControlContentsChanged, ucrReceiverElavation.ControlContentsChanged, ucrReceiverDistrict.ControlContentsChanged, ucrReceiverStationName.ControlContentsChanged
         TestOkEnabled()
     End Sub
 
-    Private Sub ucrInputCountryMetadata_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputCountryMetadata.ControlValueChanged
-        If Not ucrInputCountryMetadata.IsEmpty Then
-            clsUpdateMetadataInfoFunction.AddParameter("country", Chr(34) & ucrInputCountryMetadata.GetText & Chr(34), iPosition:=6)
+    Private Sub ucrInputCountryMetadata_ControlValueChanged(ucrChangedControl As ucrCore)
+        If Not ucrInputComboCountryMetadata.IsEmpty Then
+            clsUpdateMetadataInfoFunction.AddParameter("country", Chr(34) & ucrInputComboCountryMetadata.GetText & Chr(34), iPosition:=6)
         Else
             clsUpdateMetadataInfoFunction.RemoveParameterByName("country")
         End If

--- a/instat/dlgExportClimaticDefinitions.vb
+++ b/instat/dlgExportClimaticDefinitions.vb
@@ -75,27 +75,6 @@ Public Class dlgExportClimaticDefinitions
         ucrReceiverCropData.strSelectorHeading = "Data Sets"
         ucrReceiverCropData.SetLinkedDisplayControl(lblCropData)
 
-        ucrReceiverRain.SetParameter(New RParameter("rain", 6))
-        ucrReceiverRain.Selector = ucrSelectorExportDefinitions
-        ucrReceiverRain.SetParameterIsString()
-        ucrReceiverRain.SetClimaticType("rain")
-        ucrReceiverRain.bAutoFill = True
-        ucrReceiverRain.SetLinkedDisplayControl(lblRain)
-
-        ucrReceiverYear.SetParameter(New RParameter("year", 7))
-        ucrReceiverYear.Selector = ucrSelectorExportDefinitions
-        ucrReceiverYear.SetParameterIsString()
-        ucrReceiverYear.SetClimaticType("year")
-        ucrReceiverYear.bAutoFill = True
-        ucrReceiverYear.SetLinkedDisplayControl(lblYear)
-
-        ucrReceiverMonth.SetParameter(New RParameter("month", 8))
-        ucrReceiverMonth.Selector = ucrSelectorExportDefinitions
-        ucrReceiverMonth.SetParameterIsString()
-        ucrReceiverMonth.SetClimaticType("month")
-        ucrReceiverMonth.bAutoFill = True
-        ucrReceiverMonth.SetLinkedDisplayControl(lblMonth)
-
         ucrReceiverRainIndicator.SetParameter(New RParameter("rain_days_name", 9))
         ucrReceiverRainIndicator.Selector = ucrSelectorExportDefinitions
         ucrReceiverRainIndicator.SetParameterIsString()
@@ -113,10 +92,6 @@ Public Class dlgExportClimaticDefinitions
         ucrChkAnnualTemp.SetText("Annual Temperature")
         ucrChkAnnualTemp.AddParameterValuesCondition(True, "temp", "True")
         ucrChkAnnualTemp.AddParameterValuesCondition(False, "temp", "False")
-
-        ucrChkExtremes.SetText("Extremes")
-        ucrChkExtremes.AddParameterValuesCondition(True, "extrem", "True")
-        ucrChkExtremes.AddParameterValuesCondition(False, "extrem", "False")
 
         ucrChkMonthlyTemp.SetText("Monthly Temperature")
         ucrChkMonthlyTemp.AddParameterValuesCondition(True, "monthly_temp", "True")
@@ -182,7 +157,7 @@ Public Class dlgExportClimaticDefinitions
         ucrInputCountryMetadata.SetParameter(New RParameter("country", 6))
         ucrInputCountryMetadata.SetLinkedDisplayControl(lblCountryMetada)
 
-        ucrPnlExportGoogle.AddToLinkedControls({ucrReceiverMonth, ucrReceiverYear, ucrReceiverStation}, {rdoUploadSummaries}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlExportGoogle.AddToLinkedControls({ucrReceiverStation}, {rdoUploadSummaries}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlExportGoogle.AddToLinkedControls({ucrReceiverDistrict, ucrReceiverElavation, ucrReceiverLatitude, ucrInputCountryMetadata, ucrReceiverLongititude, ucrReceiverStationName}, {rdoUpdateMetadata}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         ucrPnlExportGoogle.AddToLinkedControls({ucrInputCountry, ucrChkIncludeSummaryData, ucrInputDefinitionsID}, {rdoUploadSummaries}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         DialogSize()
@@ -252,12 +227,9 @@ Public Class dlgExportClimaticDefinitions
         ucrReceiverStation.SetRCode(clsExportRinstatToBucketFunction, bReset)
         ucrReceiverDataYear.SetRCode(clsExportRinstatToBucketFunction, bReset)
         ucrReceiverDataYearMonth.SetRCode(clsExportRinstatToBucketFunction, bReset)
-        ucrReceiverMonth.SetRCode(clsExportRinstatToBucketFunction, bReset)
-        ucrReceiverRain.SetRCode(clsExportRinstatToBucketFunction, bReset)
         'ucrReceiverRainIndicator.SetRCode(clsExportRinstatToBucketFunction, bReset)
         'ucrReceiverExtremIndicator.SetRCode(clsExportRinstatToBucketFunction, bReset)
 
-        ucrReceiverYear.SetRCode(clsExportRinstatToBucketFunction, bReset)
         ucrSelectorExportDefinitions.SetRCode(clsExportRinstatToBucketFunction)
         ucrInputTokenPath.SetRCode(ClsGcsAuthFileFunction, bReset)
 
@@ -276,7 +248,6 @@ Public Class dlgExportClimaticDefinitions
             ucrChkAnnualRainfall.SetRCode(clsDummyFunction, bReset)
             ucrChkAnnualTemp.SetRCode(clsDummyFunction, bReset)
             ucrChkCropSuccessProp.SetRCode(clsDummyFunction, bReset)
-            ucrChkExtremes.SetRCode(clsDummyFunction, bReset)
             ucrChkMonthlyTemp.SetRCode(clsDummyFunction, bReset)
             ucrChkSeasonStartProp.SetRCode(clsDummyFunction, bReset)
             ucrPnlExportGoogle.SetRCode(clsDummyFunction, bReset)
@@ -289,7 +260,6 @@ Public Class dlgExportClimaticDefinitions
         If rdoUploadSummaries.Checked Then
             ' Basic required fields
             Dim bRequiredFieldsFilled As Boolean = Not ucrReceiverStation.IsEmpty AndAlso
-                                               Not ucrReceiverYear.IsEmpty AndAlso
                                                Not ucrInputCountry.IsEmpty AndAlso
                                                Not ucrInputDefinitionsID.IsEmpty AndAlso
                                                Not ucrInputTokenPath.IsEmpty
@@ -300,13 +270,13 @@ Public Class dlgExportClimaticDefinitions
                 Dim bCropOK As Boolean = Not bCropChecked OrElse Not ucrReceiverCropData.IsEmpty
 
                 Dim bAnnualRainOK As Boolean = Not ucrChkAnnualRainfall.Checked OrElse
-                                           (Not ucrReceiverRain.IsEmpty AndAlso Not ucrReceiverDataYear.IsEmpty)
+                                           (Not ucrReceiverDataYear.IsEmpty)
 
                 Dim bAnnualTempOK As Boolean = Not ucrChkAnnualTemp.Checked OrElse
                                            Not ucrReceiverDataYear.IsEmpty
 
                 Dim bMonthlyTempOK As Boolean = Not ucrChkMonthlyTemp.Checked OrElse
-                                            (Not ucrReceiverMonth.IsEmpty AndAlso Not ucrReceiverDataYearMonth.IsEmpty)
+                                            (Not ucrReceiverDataYearMonth.IsEmpty)
 
                 ' Final OK decision
                 If bCropOK AndAlso bAnnualRainOK AndAlso bAnnualTempOK AndAlso bMonthlyTempOK Then
@@ -332,7 +302,7 @@ Public Class dlgExportClimaticDefinitions
 
 
     Private Sub AddRemoveSummary()
-        If ucrChkAnnualRainfall.Checked OrElse ucrChkAnnualTemp.Checked OrElse ucrChkCropSuccessProp.Checked OrElse ucrChkExtremes.Checked OrElse ucrChkMonthlyTemp.Checked OrElse ucrChkSeasonStartProp.Checked Then
+        If ucrChkAnnualRainfall.Checked OrElse ucrChkAnnualTemp.Checked OrElse ucrChkCropSuccessProp.Checked OrElse ucrChkMonthlyTemp.Checked OrElse ucrChkSeasonStartProp.Checked Then
             clsExportRinstatToBucketFunction.AddParameter("summaries", clsRFunctionParameter:=clsSummariesFunction, iPosition:=0)
         Else
             clsExportRinstatToBucketFunction.RemoveParameterByName("summaries")
@@ -387,16 +357,6 @@ Public Class dlgExportClimaticDefinitions
         TestOkEnabled()
     End Sub
 
-    Private Sub ucrChkExtremes_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkExtremes.ControlValueChanged
-        If ucrChkExtremes.Checked Then
-            clsSummariesFunction.AddParameter("extreme", Chr(34) & "extremes" & Chr(34), iPosition:=3, bIncludeArgumentName:=False)
-        Else
-            clsSummariesFunction.RemoveParameterByName("extreme")
-        End If
-        AddRemoveSummary()
-        EnableDisableDefineButton()
-    End Sub
-
     Private Sub ucrChkMonthlyTemp_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkMonthlyTemp.ControlValueChanged
         If ucrChkMonthlyTemp.Checked Then
             clsSummariesFunction.AddParameter("month_temp", Chr(34) & "monthly_temperature" & Chr(34), iPosition:=4, bIncludeArgumentName:=False)
@@ -438,21 +398,18 @@ Public Class dlgExportClimaticDefinitions
     Private Sub EnableDisableDefineButton()
         ucrReceiverDataYearMonth.Visible = False
         ucrReceiverDataYear.Visible = False
-        ucrReceiverRain.Visible = False
         ucrReceiverRainIndicator.Visible = False
         ucrReceiverExtremIndicator.Visible = False
         ucrReceiverCropData.Visible = False
         If rdoUploadSummaries.Checked Then
             ucrReceiverDataYearMonth.Visible = ucrChkMonthlyTemp.Checked
             ucrReceiverDataYear.Visible = ucrChkAnnualRainfall.Checked OrElse ucrChkAnnualTemp.Checked
-            ucrReceiverRain.Visible = ucrChkAnnualRainfall.Checked
             ucrReceiverExtremIndicator.Visible = ucrChkAnnualRainfall.Checked
             ucrReceiverRainIndicator.Visible = ucrChkAnnualRainfall.Checked
             ucrReceiverCropData.Visible = ucrChkCropSuccessProp.Checked OrElse ucrChkSeasonStartProp.Checked
         Else
             ucrReceiverDataYearMonth.Visible = False
             ucrReceiverDataYear.Visible = False
-            ucrReceiverRain.Visible = False
             ucrReceiverRainIndicator.Visible = False
             ucrReceiverExtremIndicator.Visible = False
             ucrReceiverCropData.Visible = False
@@ -481,6 +438,10 @@ Public Class dlgExportClimaticDefinitions
         TestOkEnabled()
     End Sub
 
+    Private Sub ucrReceiverDataYearMonth_Load(sender As Object, e As EventArgs) Handles ucrReceiverDataYearMonth.Load
+
+    End Sub
+
     Private Sub ucrPnlExportGoogle_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlExportGoogle.ControlValueChanged, ucrInputTokenPath.ControlValueChanged
         ucrBase.clsRsyntax.AddToBeforeCodes(ClsGcsAuthFileFunction, 0)
         If rdoUpdateMetadata.Checked Then
@@ -502,10 +463,10 @@ Public Class dlgExportClimaticDefinitions
     Private Sub DialogSize()
         If rdoUpdateMetadata.Checked Then
             Me.Size = New Size(475, 455)
-            Me.ucrBase.Location = New Point(4, 360)
+            Me.ucrBase.Location = New Point(14, 360)
         Else
             Me.Size = New Size(475, 570)
-            Me.ucrBase.Location = New Point(4, 475)
+            Me.ucrBase.Location = New Point(14, 475)
         End If
     End Sub
 
@@ -515,8 +476,7 @@ Public Class dlgExportClimaticDefinitions
         clsUpdateMetadataInfoFunction.AddParameter("metadata_data", clsRFunctionParameter:=clsGetDataFrameFunction, iPosition:=0)
     End Sub
 
-    Private Sub ucrReceiverData_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverRain.ControlContentsChanged, ucrReceiverCropData.ControlContentsChanged, ucrReceiverDataYearMonth.ControlContentsChanged, ucrReceiverDataYear.ControlContentsChanged, ucrReceiverStation.ControlContentsChanged, ucrInputTokenPath.ControlContentsChanged, ucrInputCountryMetadata.ControlContentsChanged,
-            ucrReceiverMonth.ControlContentsChanged, ucrReceiverYear.ControlContentsChanged, ucrChkSeasonStartProp.ControlContentsChanged, ucrInputCountry.ControlContentsChanged, ucrInputDefinitionsID.ControlContentsChanged, ucrChkIncludeSummaryData.ControlContentsChanged, ucrReceiverLongititude.ControlContentsChanged, ucrReceiverLatitude.ControlContentsChanged,
+    Private Sub ucrReceiverData_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverCropData.ControlContentsChanged, ucrReceiverDataYearMonth.ControlContentsChanged, ucrReceiverDataYear.ControlContentsChanged, ucrReceiverStation.ControlContentsChanged, ucrInputTokenPath.ControlContentsChanged, ucrInputCountryMetadata.ControlContentsChanged, ucrChkSeasonStartProp.ControlContentsChanged, ucrInputCountry.ControlContentsChanged, ucrInputDefinitionsID.ControlContentsChanged, ucrChkIncludeSummaryData.ControlContentsChanged, ucrReceiverLongititude.ControlContentsChanged, ucrReceiverLatitude.ControlContentsChanged,
             ucrChkMonthlyTemp.ControlContentsChanged, ucrChkCropSuccessProp.ControlContentsChanged, ucrChkAnnualTemp.ControlContentsChanged, ucrChkAnnualRainfall.ControlContentsChanged, ucrSelectorExportDefinitions.ControlContentsChanged, ucrReceiverElavation.ControlContentsChanged, ucrReceiverDistrict.ControlContentsChanged, ucrReceiverStationName.ControlContentsChanged
         TestOkEnabled()
     End Sub

--- a/instat/sdgDefineAnnualRainfall.Designer.vb
+++ b/instat/sdgDefineAnnualRainfall.Designer.vb
@@ -133,9 +133,10 @@ Partial Class sdgDefineAnnualRainfall
         'lblSeasonPlantingDay
         '
         Me.lblSeasonPlantingDay.AutoSize = True
-        Me.lblSeasonPlantingDay.Location = New System.Drawing.Point(250, 97)
+        Me.lblSeasonPlantingDay.Location = New System.Drawing.Point(375, 149)
+        Me.lblSeasonPlantingDay.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblSeasonPlantingDay.Name = "lblSeasonPlantingDay"
-        Me.lblSeasonPlantingDay.Size = New System.Drawing.Size(70, 13)
+        Me.lblSeasonPlantingDay.Size = New System.Drawing.Size(102, 20)
         Me.lblSeasonPlantingDay.TabIndex = 5
         Me.lblSeasonPlantingDay.Text = "Planting Day:"
         '
@@ -146,10 +147,11 @@ Partial Class sdgDefineAnnualRainfall
         Me.tbSummaries.Controls.Add(Me.tbSeasonStartProb)
         Me.tbSummaries.Controls.Add(Me.tbAnnualTempSummaries)
         Me.tbSummaries.Controls.Add(Me.tbMonthlyTemp)
-        Me.tbSummaries.Location = New System.Drawing.Point(12, 14)
+        Me.tbSummaries.Location = New System.Drawing.Point(18, 22)
+        Me.tbSummaries.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.tbSummaries.Name = "tbSummaries"
         Me.tbSummaries.SelectedIndex = 0
-        Me.tbSummaries.Size = New System.Drawing.Size(523, 506)
+        Me.tbSummaries.Size = New System.Drawing.Size(784, 778)
         Me.tbSummaries.TabIndex = 34
         '
         'tbAnnualRainfall
@@ -189,10 +191,11 @@ Partial Class sdgDefineAnnualRainfall
         Me.tbAnnualRainfall.Controls.Add(Me.ucrReceiverSeasonalRain)
         Me.tbAnnualRainfall.Controls.Add(Me.ucrReceiverAnnualRain)
         Me.tbAnnualRainfall.Controls.Add(Me.ucrSelectorDefineAnnualRain)
-        Me.tbAnnualRainfall.Location = New System.Drawing.Point(4, 22)
+        Me.tbAnnualRainfall.Location = New System.Drawing.Point(4, 29)
+        Me.tbAnnualRainfall.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.tbAnnualRainfall.Name = "tbAnnualRainfall"
-        Me.tbAnnualRainfall.Padding = New System.Windows.Forms.Padding(3)
-        Me.tbAnnualRainfall.Size = New System.Drawing.Size(515, 480)
+        Me.tbAnnualRainfall.Padding = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.tbAnnualRainfall.Size = New System.Drawing.Size(776, 745)
         Me.tbAnnualRainfall.TabIndex = 0
         Me.tbAnnualRainfall.Text = "Annual Rainfall"
         Me.tbAnnualRainfall.UseVisualStyleBackColor = True
@@ -200,9 +203,10 @@ Partial Class sdgDefineAnnualRainfall
         'lblExtremRain
         '
         Me.lblExtremRain.AutoSize = True
-        Me.lblExtremRain.Location = New System.Drawing.Point(12, 396)
+        Me.lblExtremRain.Location = New System.Drawing.Point(18, 609)
+        Me.lblExtremRain.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblExtremRain.Name = "lblExtremRain"
-        Me.lblExtremRain.Size = New System.Drawing.Size(86, 13)
+        Me.lblExtremRain.Size = New System.Drawing.Size(129, 20)
         Me.lblExtremRain.TabIndex = 11
         Me.lblExtremRain.Text = "Extreme Rainfall:"
         '
@@ -210,11 +214,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverExtremRian.AutoSize = True
         Me.ucrReceiverExtremRian.frmParent = Nothing
-        Me.ucrReceiverExtremRian.Location = New System.Drawing.Point(9, 414)
+        Me.ucrReceiverExtremRian.Location = New System.Drawing.Point(14, 637)
         Me.ucrReceiverExtremRian.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverExtremRian.Name = "ucrReceiverExtremRian"
         Me.ucrReceiverExtremRian.Selector = Nothing
-        Me.ucrReceiverExtremRian.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverExtremRian.Size = New System.Drawing.Size(180, 31)
         Me.ucrReceiverExtremRian.strNcFilePath = ""
         Me.ucrReceiverExtremRian.TabIndex = 12
         Me.ucrReceiverExtremRian.ucrSelector = Nothing
@@ -222,9 +226,10 @@ Partial Class sdgDefineAnnualRainfall
         'lblStartRainStatus
         '
         Me.lblStartRainStatus.AutoSize = True
-        Me.lblStartRainStatus.Location = New System.Drawing.Point(264, 326)
+        Me.lblStartRainStatus.Location = New System.Drawing.Point(396, 502)
+        Me.lblStartRainStatus.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblStartRainStatus.Name = "lblStartRainStatus"
-        Me.lblStartRainStatus.Size = New System.Drawing.Size(95, 13)
+        Me.lblStartRainStatus.Size = New System.Drawing.Size(144, 20)
         Me.lblStartRainStatus.TabIndex = 29
         Me.lblStartRainStatus.Text = "Start Rains Status:"
         '
@@ -232,11 +237,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverStartRainStatus.AutoSize = True
         Me.ucrReceiverStartRainStatus.frmParent = Nothing
-        Me.ucrReceiverStartRainStatus.Location = New System.Drawing.Point(264, 343)
+        Me.ucrReceiverStartRainStatus.Location = New System.Drawing.Point(396, 528)
         Me.ucrReceiverStartRainStatus.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverStartRainStatus.Name = "ucrReceiverStartRainStatus"
         Me.ucrReceiverStartRainStatus.Selector = Nothing
-        Me.ucrReceiverStartRainStatus.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverStartRainStatus.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverStartRainStatus.strNcFilePath = ""
         Me.ucrReceiverStartRainStatus.TabIndex = 30
         Me.ucrReceiverStartRainStatus.ucrSelector = Nothing
@@ -244,9 +249,10 @@ Partial Class sdgDefineAnnualRainfall
         'lblEndRainStatus
         '
         Me.lblEndRainStatus.AutoSize = True
-        Me.lblEndRainStatus.Location = New System.Drawing.Point(264, 367)
+        Me.lblEndRainStatus.Location = New System.Drawing.Point(396, 565)
+        Me.lblEndRainStatus.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblEndRainStatus.Name = "lblEndRainStatus"
-        Me.lblEndRainStatus.Size = New System.Drawing.Size(92, 13)
+        Me.lblEndRainStatus.Size = New System.Drawing.Size(138, 20)
         Me.lblEndRainStatus.TabIndex = 31
         Me.lblEndRainStatus.Text = "End Rains Status:"
         '
@@ -254,11 +260,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverEndRainStatus.AutoSize = True
         Me.ucrReceiverEndRainStatus.frmParent = Nothing
-        Me.ucrReceiverEndRainStatus.Location = New System.Drawing.Point(264, 383)
+        Me.ucrReceiverEndRainStatus.Location = New System.Drawing.Point(396, 589)
         Me.ucrReceiverEndRainStatus.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverEndRainStatus.Name = "ucrReceiverEndRainStatus"
         Me.ucrReceiverEndRainStatus.Selector = Nothing
-        Me.ucrReceiverEndRainStatus.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverEndRainStatus.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverEndRainStatus.strNcFilePath = ""
         Me.ucrReceiverEndRainStatus.TabIndex = 32
         Me.ucrReceiverEndRainStatus.ucrSelector = Nothing
@@ -266,9 +272,10 @@ Partial Class sdgDefineAnnualRainfall
         'lblEndSeasonStatus
         '
         Me.lblEndSeasonStatus.AutoSize = True
-        Me.lblEndSeasonStatus.Location = New System.Drawing.Point(264, 408)
+        Me.lblEndSeasonStatus.Location = New System.Drawing.Point(396, 628)
+        Me.lblEndSeasonStatus.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblEndSeasonStatus.Name = "lblEndSeasonStatus"
-        Me.lblEndSeasonStatus.Size = New System.Drawing.Size(101, 13)
+        Me.lblEndSeasonStatus.Size = New System.Drawing.Size(152, 20)
         Me.lblEndSeasonStatus.TabIndex = 33
         Me.lblEndSeasonStatus.Text = "End Season Status:"
         '
@@ -276,11 +283,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverEndSeasonStatus.AutoSize = True
         Me.ucrReceiverEndSeasonStatus.frmParent = Nothing
-        Me.ucrReceiverEndSeasonStatus.Location = New System.Drawing.Point(261, 422)
+        Me.ucrReceiverEndSeasonStatus.Location = New System.Drawing.Point(392, 649)
         Me.ucrReceiverEndSeasonStatus.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverEndSeasonStatus.Name = "ucrReceiverEndSeasonStatus"
         Me.ucrReceiverEndSeasonStatus.Selector = Nothing
-        Me.ucrReceiverEndSeasonStatus.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverEndSeasonStatus.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverEndSeasonStatus.strNcFilePath = ""
         Me.ucrReceiverEndSeasonStatus.TabIndex = 34
         Me.ucrReceiverEndSeasonStatus.ucrSelector = Nothing
@@ -288,9 +295,10 @@ Partial Class sdgDefineAnnualRainfall
         'lblRainyDaysYear
         '
         Me.lblRainyDaysYear.AutoSize = True
-        Me.lblRainyDaysYear.Location = New System.Drawing.Point(264, 86)
+        Me.lblRainyDaysYear.Location = New System.Drawing.Point(396, 132)
+        Me.lblRainyDaysYear.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblRainyDaysYear.Name = "lblRainyDaysYear"
-        Me.lblRainyDaysYear.Size = New System.Drawing.Size(103, 13)
+        Me.lblRainyDaysYear.Size = New System.Drawing.Size(151, 20)
         Me.lblRainyDaysYear.TabIndex = 17
         Me.lblRainyDaysYear.Text = " Rainy Days in Year:"
         '
@@ -298,11 +306,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverRainDaysYear.AutoSize = True
         Me.ucrReceiverRainDaysYear.frmParent = Nothing
-        Me.ucrReceiverRainDaysYear.Location = New System.Drawing.Point(264, 101)
+        Me.ucrReceiverRainDaysYear.Location = New System.Drawing.Point(396, 155)
         Me.ucrReceiverRainDaysYear.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverRainDaysYear.Name = "ucrReceiverRainDaysYear"
         Me.ucrReceiverRainDaysYear.Selector = Nothing
-        Me.ucrReceiverRainDaysYear.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverRainDaysYear.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverRainDaysYear.strNcFilePath = ""
         Me.ucrReceiverRainDaysYear.TabIndex = 18
         Me.ucrReceiverRainDaysYear.ucrSelector = Nothing
@@ -310,108 +318,120 @@ Partial Class sdgDefineAnnualRainfall
         'lblNoRainDaysSeason
         '
         Me.lblNoRainDaysSeason.AutoSize = True
-        Me.lblNoRainDaysSeason.Location = New System.Drawing.Point(264, 41)
+        Me.lblNoRainDaysSeason.Location = New System.Drawing.Point(396, 63)
+        Me.lblNoRainDaysSeason.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblNoRainDaysSeason.Name = "lblNoRainDaysSeason"
-        Me.lblNoRainDaysSeason.Size = New System.Drawing.Size(117, 13)
+        Me.lblNoRainDaysSeason.Size = New System.Drawing.Size(172, 20)
         Me.lblNoRainDaysSeason.TabIndex = 15
         Me.lblNoRainDaysSeason.Text = " Rainy Days in Season:"
         '
         'lblSeasonalLength
         '
         Me.lblSeasonalLength.AutoSize = True
-        Me.lblSeasonalLength.Location = New System.Drawing.Point(264, 124)
+        Me.lblSeasonalLength.Location = New System.Drawing.Point(396, 191)
+        Me.lblSeasonalLength.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblSeasonalLength.Name = "lblSeasonalLength"
-        Me.lblSeasonalLength.Size = New System.Drawing.Size(90, 13)
+        Me.lblSeasonalLength.Size = New System.Drawing.Size(134, 20)
         Me.lblSeasonalLength.TabIndex = 19
         Me.lblSeasonalLength.Text = "Seasonal Length:"
         '
         'lblSeasonalRain
         '
         Me.lblSeasonalRain.AutoSize = True
-        Me.lblSeasonalRain.Location = New System.Drawing.Point(12, 436)
+        Me.lblSeasonalRain.Location = New System.Drawing.Point(18, 671)
+        Me.lblSeasonalRain.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblSeasonalRain.Name = "lblSeasonalRain"
-        Me.lblSeasonalRain.Size = New System.Drawing.Size(79, 13)
+        Me.lblSeasonalRain.Size = New System.Drawing.Size(117, 20)
         Me.lblSeasonalRain.TabIndex = 13
         Me.lblSeasonalRain.Text = "Seasonal Rain:"
         '
         'lblAnnualRain
         '
         Me.lblAnnualRain.AutoSize = True
-        Me.lblAnnualRain.Location = New System.Drawing.Point(13, 356)
+        Me.lblAnnualRain.Location = New System.Drawing.Point(20, 548)
+        Me.lblAnnualRain.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblAnnualRain.Name = "lblAnnualRain"
-        Me.lblAnnualRain.Size = New System.Drawing.Size(68, 13)
+        Me.lblAnnualRain.Size = New System.Drawing.Size(100, 20)
         Me.lblAnnualRain.TabIndex = 9
         Me.lblAnnualRain.Text = "Annual Rain:"
         '
         'lblEndSeasonDate
         '
         Me.lblEndSeasonDate.AutoSize = True
-        Me.lblEndSeasonDate.Location = New System.Drawing.Point(264, 285)
+        Me.lblEndSeasonDate.Location = New System.Drawing.Point(396, 438)
+        Me.lblEndSeasonDate.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblEndSeasonDate.Name = "lblEndSeasonDate"
-        Me.lblEndSeasonDate.Size = New System.Drawing.Size(97, 13)
+        Me.lblEndSeasonDate.Size = New System.Drawing.Size(146, 20)
         Me.lblEndSeasonDate.TabIndex = 27
         Me.lblEndSeasonDate.Text = "End Season(Date):"
         '
         'lblEndSeasonDOY
         '
         Me.lblEndSeasonDOY.AutoSize = True
-        Me.lblEndSeasonDOY.Location = New System.Drawing.Point(264, 250)
+        Me.lblEndSeasonDOY.Location = New System.Drawing.Point(396, 385)
+        Me.lblEndSeasonDOY.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblEndSeasonDOY.Name = "lblEndSeasonDOY"
-        Me.lblEndSeasonDOY.Size = New System.Drawing.Size(97, 13)
+        Me.lblEndSeasonDOY.Size = New System.Drawing.Size(146, 20)
         Me.lblEndSeasonDOY.TabIndex = 25
         Me.lblEndSeasonDOY.Text = "End Season(DOY):"
         '
         'lblEndRainDate
         '
         Me.lblEndRainDate.AutoSize = True
-        Me.lblEndRainDate.Location = New System.Drawing.Point(264, 207)
+        Me.lblEndRainDate.Location = New System.Drawing.Point(396, 318)
+        Me.lblEndRainDate.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblEndRainDate.Name = "lblEndRainDate"
-        Me.lblEndRainDate.Size = New System.Drawing.Size(83, 13)
+        Me.lblEndRainDate.Size = New System.Drawing.Size(124, 20)
         Me.lblEndRainDate.TabIndex = 23
         Me.lblEndRainDate.Text = "End Rain(Date):"
         '
         'lblEndRainsDOY
         '
         Me.lblEndRainsDOY.AutoSize = True
-        Me.lblEndRainsDOY.Location = New System.Drawing.Point(264, 167)
+        Me.lblEndRainsDOY.Location = New System.Drawing.Point(396, 257)
+        Me.lblEndRainsDOY.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblEndRainsDOY.Name = "lblEndRainsDOY"
-        Me.lblEndRainsDOY.Size = New System.Drawing.Size(83, 13)
+        Me.lblEndRainsDOY.Size = New System.Drawing.Size(124, 20)
         Me.lblEndRainsDOY.TabIndex = 21
         Me.lblEndRainsDOY.Text = "End Rain(DOY):"
         '
         'lblStartRainDate
         '
         Me.lblStartRainDate.AutoSize = True
-        Me.lblStartRainDate.Location = New System.Drawing.Point(11, 316)
+        Me.lblStartRainDate.Location = New System.Drawing.Point(16, 486)
+        Me.lblStartRainDate.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblStartRainDate.Name = "lblStartRainDate"
-        Me.lblStartRainDate.Size = New System.Drawing.Size(86, 13)
+        Me.lblStartRainDate.Size = New System.Drawing.Size(130, 20)
         Me.lblStartRainDate.TabIndex = 7
         Me.lblStartRainDate.Text = "Start Rain(Date):"
         '
         'lblStartRainDOY
         '
         Me.lblStartRainDOY.AutoSize = True
-        Me.lblStartRainDOY.Location = New System.Drawing.Point(12, 274)
+        Me.lblStartRainDOY.Location = New System.Drawing.Point(18, 422)
+        Me.lblStartRainDOY.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblStartRainDOY.Name = "lblStartRainDOY"
-        Me.lblStartRainDOY.Size = New System.Drawing.Size(86, 13)
+        Me.lblStartRainDOY.Size = New System.Drawing.Size(130, 20)
         Me.lblStartRainDOY.TabIndex = 5
         Me.lblStartRainDOY.Text = "Start Rain(DOY):"
         '
         'lblYear
         '
         Me.lblYear.AutoSize = True
-        Me.lblYear.Location = New System.Drawing.Point(14, 231)
+        Me.lblYear.Location = New System.Drawing.Point(21, 355)
+        Me.lblYear.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblYear.Name = "lblYear"
-        Me.lblYear.Size = New System.Drawing.Size(32, 13)
+        Me.lblYear.Size = New System.Drawing.Size(47, 20)
         Me.lblYear.TabIndex = 3
         Me.lblYear.Text = "Year:"
         '
         'lblStation
         '
         Me.lblStation.AutoSize = True
-        Me.lblStation.Location = New System.Drawing.Point(15, 187)
+        Me.lblStation.Location = New System.Drawing.Point(22, 288)
+        Me.lblStation.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblStation.Name = "lblStation"
-        Me.lblStation.Size = New System.Drawing.Size(43, 13)
+        Me.lblStation.Size = New System.Drawing.Size(64, 20)
         Me.lblStation.TabIndex = 1
         Me.lblStation.Text = "Station:"
         '
@@ -419,11 +439,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverStartRainDate.AutoSize = True
         Me.ucrReceiverStartRainDate.frmParent = Nothing
-        Me.ucrReceiverStartRainDate.Location = New System.Drawing.Point(9, 333)
+        Me.ucrReceiverStartRainDate.Location = New System.Drawing.Point(14, 512)
         Me.ucrReceiverStartRainDate.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverStartRainDate.Name = "ucrReceiverStartRainDate"
         Me.ucrReceiverStartRainDate.Selector = Nothing
-        Me.ucrReceiverStartRainDate.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverStartRainDate.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverStartRainDate.strNcFilePath = ""
         Me.ucrReceiverStartRainDate.TabIndex = 8
         Me.ucrReceiverStartRainDate.ucrSelector = Nothing
@@ -432,11 +452,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverStartRainDOY.AutoSize = True
         Me.ucrReceiverStartRainDOY.frmParent = Nothing
-        Me.ucrReceiverStartRainDOY.Location = New System.Drawing.Point(9, 292)
+        Me.ucrReceiverStartRainDOY.Location = New System.Drawing.Point(14, 449)
         Me.ucrReceiverStartRainDOY.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverStartRainDOY.Name = "ucrReceiverStartRainDOY"
         Me.ucrReceiverStartRainDOY.Selector = Nothing
-        Me.ucrReceiverStartRainDOY.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverStartRainDOY.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverStartRainDOY.strNcFilePath = ""
         Me.ucrReceiverStartRainDOY.TabIndex = 6
         Me.ucrReceiverStartRainDOY.ucrSelector = Nothing
@@ -445,11 +465,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverYear.AutoSize = True
         Me.ucrReceiverYear.frmParent = Nothing
-        Me.ucrReceiverYear.Location = New System.Drawing.Point(9, 248)
+        Me.ucrReceiverYear.Location = New System.Drawing.Point(14, 382)
         Me.ucrReceiverYear.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverYear.Name = "ucrReceiverYear"
         Me.ucrReceiverYear.Selector = Nothing
-        Me.ucrReceiverYear.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverYear.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverYear.strNcFilePath = ""
         Me.ucrReceiverYear.TabIndex = 4
         Me.ucrReceiverYear.ucrSelector = Nothing
@@ -458,11 +478,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverStation.AutoSize = True
         Me.ucrReceiverStation.frmParent = Nothing
-        Me.ucrReceiverStation.Location = New System.Drawing.Point(11, 204)
+        Me.ucrReceiverStation.Location = New System.Drawing.Point(16, 314)
         Me.ucrReceiverStation.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverStation.Name = "ucrReceiverStation"
         Me.ucrReceiverStation.Selector = Nothing
-        Me.ucrReceiverStation.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverStation.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverStation.strNcFilePath = ""
         Me.ucrReceiverStation.TabIndex = 2
         Me.ucrReceiverStation.ucrSelector = Nothing
@@ -471,11 +491,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverEndSeasonDate.AutoSize = True
         Me.ucrReceiverEndSeasonDate.frmParent = Nothing
-        Me.ucrReceiverEndSeasonDate.Location = New System.Drawing.Point(264, 302)
+        Me.ucrReceiverEndSeasonDate.Location = New System.Drawing.Point(396, 465)
         Me.ucrReceiverEndSeasonDate.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverEndSeasonDate.Name = "ucrReceiverEndSeasonDate"
         Me.ucrReceiverEndSeasonDate.Selector = Nothing
-        Me.ucrReceiverEndSeasonDate.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverEndSeasonDate.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverEndSeasonDate.strNcFilePath = ""
         Me.ucrReceiverEndSeasonDate.TabIndex = 28
         Me.ucrReceiverEndSeasonDate.ucrSelector = Nothing
@@ -484,11 +504,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverEndSeasonDOY.AutoSize = True
         Me.ucrReceiverEndSeasonDOY.frmParent = Nothing
-        Me.ucrReceiverEndSeasonDOY.Location = New System.Drawing.Point(264, 263)
+        Me.ucrReceiverEndSeasonDOY.Location = New System.Drawing.Point(396, 405)
         Me.ucrReceiverEndSeasonDOY.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverEndSeasonDOY.Name = "ucrReceiverEndSeasonDOY"
         Me.ucrReceiverEndSeasonDOY.Selector = Nothing
-        Me.ucrReceiverEndSeasonDOY.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverEndSeasonDOY.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverEndSeasonDOY.strNcFilePath = ""
         Me.ucrReceiverEndSeasonDOY.TabIndex = 26
         Me.ucrReceiverEndSeasonDOY.ucrSelector = Nothing
@@ -497,11 +517,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverEndRainsDOY.AutoSize = True
         Me.ucrReceiverEndRainsDOY.frmParent = Nothing
-        Me.ucrReceiverEndRainsDOY.Location = New System.Drawing.Point(264, 184)
+        Me.ucrReceiverEndRainsDOY.Location = New System.Drawing.Point(396, 283)
         Me.ucrReceiverEndRainsDOY.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverEndRainsDOY.Name = "ucrReceiverEndRainsDOY"
         Me.ucrReceiverEndRainsDOY.Selector = Nothing
-        Me.ucrReceiverEndRainsDOY.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverEndRainsDOY.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverEndRainsDOY.strNcFilePath = ""
         Me.ucrReceiverEndRainsDOY.TabIndex = 22
         Me.ucrReceiverEndRainsDOY.ucrSelector = Nothing
@@ -510,11 +530,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverEndRainsDate.AutoSize = True
         Me.ucrReceiverEndRainsDate.frmParent = Nothing
-        Me.ucrReceiverEndRainsDate.Location = New System.Drawing.Point(264, 225)
+        Me.ucrReceiverEndRainsDate.Location = New System.Drawing.Point(396, 346)
         Me.ucrReceiverEndRainsDate.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverEndRainsDate.Name = "ucrReceiverEndRainsDate"
         Me.ucrReceiverEndRainsDate.Selector = Nothing
-        Me.ucrReceiverEndRainsDate.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverEndRainsDate.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverEndRainsDate.strNcFilePath = ""
         Me.ucrReceiverEndRainsDate.TabIndex = 24
         Me.ucrReceiverEndRainsDate.ucrSelector = Nothing
@@ -523,11 +543,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverSeasonalLength.AutoSize = True
         Me.ucrReceiverSeasonalLength.frmParent = Nothing
-        Me.ucrReceiverSeasonalLength.Location = New System.Drawing.Point(264, 142)
+        Me.ucrReceiverSeasonalLength.Location = New System.Drawing.Point(396, 218)
         Me.ucrReceiverSeasonalLength.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverSeasonalLength.Name = "ucrReceiverSeasonalLength"
         Me.ucrReceiverSeasonalLength.Selector = Nothing
-        Me.ucrReceiverSeasonalLength.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverSeasonalLength.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverSeasonalLength.strNcFilePath = ""
         Me.ucrReceiverSeasonalLength.TabIndex = 20
         Me.ucrReceiverSeasonalLength.ucrSelector = Nothing
@@ -536,11 +556,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverRainDaysSeason.AutoSize = True
         Me.ucrReceiverRainDaysSeason.frmParent = Nothing
-        Me.ucrReceiverRainDaysSeason.Location = New System.Drawing.Point(264, 58)
+        Me.ucrReceiverRainDaysSeason.Location = New System.Drawing.Point(396, 89)
         Me.ucrReceiverRainDaysSeason.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverRainDaysSeason.Name = "ucrReceiverRainDaysSeason"
         Me.ucrReceiverRainDaysSeason.Selector = Nothing
-        Me.ucrReceiverRainDaysSeason.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverRainDaysSeason.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverRainDaysSeason.strNcFilePath = ""
         Me.ucrReceiverRainDaysSeason.TabIndex = 16
         Me.ucrReceiverRainDaysSeason.ucrSelector = Nothing
@@ -549,11 +569,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverSeasonalRain.AutoSize = True
         Me.ucrReceiverSeasonalRain.frmParent = Nothing
-        Me.ucrReceiverSeasonalRain.Location = New System.Drawing.Point(9, 452)
+        Me.ucrReceiverSeasonalRain.Location = New System.Drawing.Point(14, 695)
         Me.ucrReceiverSeasonalRain.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverSeasonalRain.Name = "ucrReceiverSeasonalRain"
         Me.ucrReceiverSeasonalRain.Selector = Nothing
-        Me.ucrReceiverSeasonalRain.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverSeasonalRain.Size = New System.Drawing.Size(180, 31)
         Me.ucrReceiverSeasonalRain.strNcFilePath = ""
         Me.ucrReceiverSeasonalRain.TabIndex = 14
         Me.ucrReceiverSeasonalRain.ucrSelector = Nothing
@@ -562,11 +582,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverAnnualRain.AutoSize = True
         Me.ucrReceiverAnnualRain.frmParent = Nothing
-        Me.ucrReceiverAnnualRain.Location = New System.Drawing.Point(11, 372)
+        Me.ucrReceiverAnnualRain.Location = New System.Drawing.Point(16, 572)
         Me.ucrReceiverAnnualRain.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverAnnualRain.Name = "ucrReceiverAnnualRain"
         Me.ucrReceiverAnnualRain.Selector = Nothing
-        Me.ucrReceiverAnnualRain.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverAnnualRain.Size = New System.Drawing.Size(180, 31)
         Me.ucrReceiverAnnualRain.strNcFilePath = ""
         Me.ucrReceiverAnnualRain.TabIndex = 10
         Me.ucrReceiverAnnualRain.ucrSelector = Nothing
@@ -577,10 +597,10 @@ Partial Class sdgDefineAnnualRainfall
         Me.ucrSelectorDefineAnnualRain.bDropUnusedFilterLevels = False
         Me.ucrSelectorDefineAnnualRain.bShowHiddenColumns = False
         Me.ucrSelectorDefineAnnualRain.bUseCurrentFilter = True
-        Me.ucrSelectorDefineAnnualRain.Location = New System.Drawing.Point(7, 5)
+        Me.ucrSelectorDefineAnnualRain.Location = New System.Drawing.Point(10, 8)
         Me.ucrSelectorDefineAnnualRain.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorDefineAnnualRain.Name = "ucrSelectorDefineAnnualRain"
-        Me.ucrSelectorDefineAnnualRain.Size = New System.Drawing.Size(226, 182)
+        Me.ucrSelectorDefineAnnualRain.Size = New System.Drawing.Size(339, 412)
         Me.ucrSelectorDefineAnnualRain.TabIndex = 0
         '
         'tbCropSuccessProp
@@ -598,10 +618,11 @@ Partial Class sdgDefineAnnualRainfall
         Me.tbCropSuccessProp.Controls.Add(Me.ucrReceiverTotalRain)
         Me.tbCropSuccessProp.Controls.Add(Me.ucrReceiverStationCrop)
         Me.tbCropSuccessProp.Controls.Add(Me.ucrSelectorCropProp)
-        Me.tbCropSuccessProp.Location = New System.Drawing.Point(4, 22)
+        Me.tbCropSuccessProp.Location = New System.Drawing.Point(4, 29)
+        Me.tbCropSuccessProp.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.tbCropSuccessProp.Name = "tbCropSuccessProp"
-        Me.tbCropSuccessProp.Padding = New System.Windows.Forms.Padding(3)
-        Me.tbCropSuccessProp.Size = New System.Drawing.Size(515, 480)
+        Me.tbCropSuccessProp.Padding = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.tbCropSuccessProp.Size = New System.Drawing.Size(776, 745)
         Me.tbCropSuccessProp.TabIndex = 1
         Me.tbCropSuccessProp.Text = "Crop Success Prop"
         Me.tbCropSuccessProp.UseVisualStyleBackColor = True
@@ -609,9 +630,10 @@ Partial Class sdgDefineAnnualRainfall
         'lblPropSuccessWithoutStart
         '
         Me.lblPropSuccessWithoutStart.AutoSize = True
-        Me.lblPropSuccessWithoutStart.Location = New System.Drawing.Point(248, 220)
+        Me.lblPropSuccessWithoutStart.Location = New System.Drawing.Point(372, 338)
+        Me.lblPropSuccessWithoutStart.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblPropSuccessWithoutStart.Name = "lblPropSuccessWithoutStart"
-        Me.lblPropSuccessWithoutStart.Size = New System.Drawing.Size(180, 13)
+        Me.lblPropSuccessWithoutStart.Size = New System.Drawing.Size(270, 20)
         Me.lblPropSuccessWithoutStart.TabIndex = 11
         Me.lblPropSuccessWithoutStart.Text = "Proportion of Success (without start):"
         '
@@ -619,11 +641,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverPropSuccessNoStart.AutoSize = True
         Me.ucrReceiverPropSuccessNoStart.frmParent = Nothing
-        Me.ucrReceiverPropSuccessNoStart.Location = New System.Drawing.Point(248, 238)
+        Me.ucrReceiverPropSuccessNoStart.Location = New System.Drawing.Point(372, 366)
         Me.ucrReceiverPropSuccessNoStart.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverPropSuccessNoStart.Name = "ucrReceiverPropSuccessNoStart"
         Me.ucrReceiverPropSuccessNoStart.Selector = Nothing
-        Me.ucrReceiverPropSuccessNoStart.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverPropSuccessNoStart.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverPropSuccessNoStart.strNcFilePath = ""
         Me.ucrReceiverPropSuccessNoStart.TabIndex = 12
         Me.ucrReceiverPropSuccessNoStart.ucrSelector = Nothing
@@ -631,45 +653,50 @@ Partial Class sdgDefineAnnualRainfall
         'lblPlantingLength
         '
         Me.lblPlantingLength.AutoSize = True
-        Me.lblPlantingLength.Location = New System.Drawing.Point(248, 137)
+        Me.lblPlantingLength.Location = New System.Drawing.Point(372, 211)
+        Me.lblPlantingLength.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblPlantingLength.Name = "lblPlantingLength"
-        Me.lblPlantingLength.Size = New System.Drawing.Size(84, 13)
+        Me.lblPlantingLength.Size = New System.Drawing.Size(124, 20)
         Me.lblPlantingLength.TabIndex = 7
         Me.lblPlantingLength.Text = "Planting Length:"
         '
         'lblPlantingDay
         '
         Me.lblPlantingDay.AutoSize = True
-        Me.lblPlantingDay.Location = New System.Drawing.Point(248, 95)
+        Me.lblPlantingDay.Location = New System.Drawing.Point(372, 146)
+        Me.lblPlantingDay.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblPlantingDay.Name = "lblPlantingDay"
-        Me.lblPlantingDay.Size = New System.Drawing.Size(70, 13)
+        Me.lblPlantingDay.Size = New System.Drawing.Size(102, 20)
         Me.lblPlantingDay.TabIndex = 5
         Me.lblPlantingDay.Text = "Planting Day:"
         '
         'lblProbSuccess
         '
         Me.lblProbSuccess.AutoSize = True
-        Me.lblProbSuccess.Location = New System.Drawing.Point(248, 176)
+        Me.lblProbSuccess.Location = New System.Drawing.Point(372, 271)
+        Me.lblProbSuccess.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblProbSuccess.Name = "lblProbSuccess"
-        Me.lblProbSuccess.Size = New System.Drawing.Size(165, 13)
+        Me.lblProbSuccess.Size = New System.Drawing.Size(247, 20)
         Me.lblProbSuccess.TabIndex = 9
         Me.lblProbSuccess.Text = "Proportion of Success (with start):"
         '
         'lblTotalRain
         '
         Me.lblTotalRain.AutoSize = True
-        Me.lblTotalRain.Location = New System.Drawing.Point(248, 54)
+        Me.lblTotalRain.Location = New System.Drawing.Point(372, 83)
+        Me.lblTotalRain.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblTotalRain.Name = "lblTotalRain"
-        Me.lblTotalRain.Size = New System.Drawing.Size(59, 13)
+        Me.lblTotalRain.Size = New System.Drawing.Size(85, 20)
         Me.lblTotalRain.TabIndex = 3
         Me.lblTotalRain.Text = "Total Rain:"
         '
         'lblCropStation
         '
         Me.lblCropStation.AutoSize = True
-        Me.lblCropStation.Location = New System.Drawing.Point(248, 11)
+        Me.lblCropStation.Location = New System.Drawing.Point(372, 17)
+        Me.lblCropStation.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblCropStation.Name = "lblCropStation"
-        Me.lblCropStation.Size = New System.Drawing.Size(43, 13)
+        Me.lblCropStation.Size = New System.Drawing.Size(64, 20)
         Me.lblCropStation.TabIndex = 1
         Me.lblCropStation.Text = "Station:"
         '
@@ -677,11 +704,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverPlantingLenghth.AutoSize = True
         Me.ucrReceiverPlantingLenghth.frmParent = Nothing
-        Me.ucrReceiverPlantingLenghth.Location = New System.Drawing.Point(248, 153)
+        Me.ucrReceiverPlantingLenghth.Location = New System.Drawing.Point(372, 235)
         Me.ucrReceiverPlantingLenghth.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverPlantingLenghth.Name = "ucrReceiverPlantingLenghth"
         Me.ucrReceiverPlantingLenghth.Selector = Nothing
-        Me.ucrReceiverPlantingLenghth.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverPlantingLenghth.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverPlantingLenghth.strNcFilePath = ""
         Me.ucrReceiverPlantingLenghth.TabIndex = 8
         Me.ucrReceiverPlantingLenghth.ucrSelector = Nothing
@@ -690,11 +717,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverPropSuccess.AutoSize = True
         Me.ucrReceiverPropSuccess.frmParent = Nothing
-        Me.ucrReceiverPropSuccess.Location = New System.Drawing.Point(248, 194)
+        Me.ucrReceiverPropSuccess.Location = New System.Drawing.Point(372, 298)
         Me.ucrReceiverPropSuccess.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverPropSuccess.Name = "ucrReceiverPropSuccess"
         Me.ucrReceiverPropSuccess.Selector = Nothing
-        Me.ucrReceiverPropSuccess.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverPropSuccess.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverPropSuccess.strNcFilePath = ""
         Me.ucrReceiverPropSuccess.TabIndex = 10
         Me.ucrReceiverPropSuccess.ucrSelector = Nothing
@@ -703,11 +730,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverPlantingDay.AutoSize = True
         Me.ucrReceiverPlantingDay.frmParent = Nothing
-        Me.ucrReceiverPlantingDay.Location = New System.Drawing.Point(248, 114)
+        Me.ucrReceiverPlantingDay.Location = New System.Drawing.Point(372, 175)
         Me.ucrReceiverPlantingDay.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverPlantingDay.Name = "ucrReceiverPlantingDay"
         Me.ucrReceiverPlantingDay.Selector = Nothing
-        Me.ucrReceiverPlantingDay.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverPlantingDay.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverPlantingDay.strNcFilePath = ""
         Me.ucrReceiverPlantingDay.TabIndex = 6
         Me.ucrReceiverPlantingDay.ucrSelector = Nothing
@@ -716,11 +743,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverTotalRain.AutoSize = True
         Me.ucrReceiverTotalRain.frmParent = Nothing
-        Me.ucrReceiverTotalRain.Location = New System.Drawing.Point(248, 71)
+        Me.ucrReceiverTotalRain.Location = New System.Drawing.Point(372, 109)
         Me.ucrReceiverTotalRain.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverTotalRain.Name = "ucrReceiverTotalRain"
         Me.ucrReceiverTotalRain.Selector = Nothing
-        Me.ucrReceiverTotalRain.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverTotalRain.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverTotalRain.strNcFilePath = ""
         Me.ucrReceiverTotalRain.TabIndex = 4
         Me.ucrReceiverTotalRain.ucrSelector = Nothing
@@ -729,11 +756,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverStationCrop.AutoSize = True
         Me.ucrReceiverStationCrop.frmParent = Nothing
-        Me.ucrReceiverStationCrop.Location = New System.Drawing.Point(248, 28)
+        Me.ucrReceiverStationCrop.Location = New System.Drawing.Point(372, 43)
         Me.ucrReceiverStationCrop.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverStationCrop.Name = "ucrReceiverStationCrop"
         Me.ucrReceiverStationCrop.Selector = Nothing
-        Me.ucrReceiverStationCrop.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverStationCrop.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverStationCrop.strNcFilePath = ""
         Me.ucrReceiverStationCrop.TabIndex = 2
         Me.ucrReceiverStationCrop.ucrSelector = Nothing
@@ -744,10 +771,10 @@ Partial Class sdgDefineAnnualRainfall
         Me.ucrSelectorCropProp.bDropUnusedFilterLevels = False
         Me.ucrSelectorCropProp.bShowHiddenColumns = False
         Me.ucrSelectorCropProp.bUseCurrentFilter = True
-        Me.ucrSelectorCropProp.Location = New System.Drawing.Point(11, 8)
+        Me.ucrSelectorCropProp.Location = New System.Drawing.Point(16, 12)
         Me.ucrSelectorCropProp.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorCropProp.Name = "ucrSelectorCropProp"
-        Me.ucrSelectorCropProp.Size = New System.Drawing.Size(226, 268)
+        Me.ucrSelectorCropProp.Size = New System.Drawing.Size(339, 412)
         Me.ucrSelectorCropProp.TabIndex = 0
         '
         'tbSeasonStartProb
@@ -761,10 +788,11 @@ Partial Class sdgDefineAnnualRainfall
         Me.tbSeasonStartProb.Controls.Add(Me.ucrReceiverSeasonYear)
         Me.tbSeasonStartProb.Controls.Add(Me.ucrReceiverSeasonStationProb)
         Me.tbSeasonStartProb.Controls.Add(Me.ucrSelectorSeasonStartProp)
-        Me.tbSeasonStartProb.Location = New System.Drawing.Point(4, 22)
+        Me.tbSeasonStartProb.Location = New System.Drawing.Point(4, 29)
+        Me.tbSeasonStartProb.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.tbSeasonStartProb.Name = "tbSeasonStartProb"
-        Me.tbSeasonStartProb.Padding = New System.Windows.Forms.Padding(3)
-        Me.tbSeasonStartProb.Size = New System.Drawing.Size(515, 480)
+        Me.tbSeasonStartProb.Padding = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.tbSeasonStartProb.Size = New System.Drawing.Size(776, 745)
         Me.tbSeasonStartProb.TabIndex = 2
         Me.tbSeasonStartProb.Text = "Season Start Prob"
         Me.tbSeasonStartProb.UseVisualStyleBackColor = True
@@ -772,27 +800,30 @@ Partial Class sdgDefineAnnualRainfall
         'lblPlantingDayCond
         '
         Me.lblPlantingDayCond.AutoSize = True
-        Me.lblPlantingDayCond.Location = New System.Drawing.Point(250, 139)
+        Me.lblPlantingDayCond.Location = New System.Drawing.Point(375, 214)
+        Me.lblPlantingDayCond.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblPlantingDayCond.Name = "lblPlantingDayCond"
-        Me.lblPlantingDayCond.Size = New System.Drawing.Size(117, 13)
+        Me.lblPlantingDayCond.Size = New System.Drawing.Size(173, 20)
         Me.lblPlantingDayCond.TabIndex = 7
         Me.lblPlantingDayCond.Text = "Planting Day Condition:"
         '
         'lblSeasonYear
         '
         Me.lblSeasonYear.AutoSize = True
-        Me.lblSeasonYear.Location = New System.Drawing.Point(250, 56)
+        Me.lblSeasonYear.Location = New System.Drawing.Point(375, 86)
+        Me.lblSeasonYear.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblSeasonYear.Name = "lblSeasonYear"
-        Me.lblSeasonYear.Size = New System.Drawing.Size(32, 13)
+        Me.lblSeasonYear.Size = New System.Drawing.Size(47, 20)
         Me.lblSeasonYear.TabIndex = 3
         Me.lblSeasonYear.Text = "Year:"
         '
         'lblStationSeasonProb
         '
         Me.lblStationSeasonProb.AutoSize = True
-        Me.lblStationSeasonProb.Location = New System.Drawing.Point(250, 13)
+        Me.lblStationSeasonProb.Location = New System.Drawing.Point(375, 20)
+        Me.lblStationSeasonProb.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblStationSeasonProb.Name = "lblStationSeasonProb"
-        Me.lblStationSeasonProb.Size = New System.Drawing.Size(43, 13)
+        Me.lblStationSeasonProb.Size = New System.Drawing.Size(64, 20)
         Me.lblStationSeasonProb.TabIndex = 1
         Me.lblStationSeasonProb.Text = "Station:"
         '
@@ -800,11 +831,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverPlantingDayCondition.AutoSize = True
         Me.ucrReceiverPlantingDayCondition.frmParent = Nothing
-        Me.ucrReceiverPlantingDayCondition.Location = New System.Drawing.Point(250, 155)
+        Me.ucrReceiverPlantingDayCondition.Location = New System.Drawing.Point(375, 238)
         Me.ucrReceiverPlantingDayCondition.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverPlantingDayCondition.Name = "ucrReceiverPlantingDayCondition"
         Me.ucrReceiverPlantingDayCondition.Selector = Nothing
-        Me.ucrReceiverPlantingDayCondition.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverPlantingDayCondition.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverPlantingDayCondition.strNcFilePath = ""
         Me.ucrReceiverPlantingDayCondition.TabIndex = 8
         Me.ucrReceiverPlantingDayCondition.ucrSelector = Nothing
@@ -813,11 +844,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverSeasonPlantingDay.AutoSize = True
         Me.ucrReceiverSeasonPlantingDay.frmParent = Nothing
-        Me.ucrReceiverSeasonPlantingDay.Location = New System.Drawing.Point(250, 116)
+        Me.ucrReceiverSeasonPlantingDay.Location = New System.Drawing.Point(375, 178)
         Me.ucrReceiverSeasonPlantingDay.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverSeasonPlantingDay.Name = "ucrReceiverSeasonPlantingDay"
         Me.ucrReceiverSeasonPlantingDay.Selector = Nothing
-        Me.ucrReceiverSeasonPlantingDay.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverSeasonPlantingDay.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverSeasonPlantingDay.strNcFilePath = ""
         Me.ucrReceiverSeasonPlantingDay.TabIndex = 6
         Me.ucrReceiverSeasonPlantingDay.ucrSelector = Nothing
@@ -826,11 +857,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverSeasonYear.AutoSize = True
         Me.ucrReceiverSeasonYear.frmParent = Nothing
-        Me.ucrReceiverSeasonYear.Location = New System.Drawing.Point(250, 73)
+        Me.ucrReceiverSeasonYear.Location = New System.Drawing.Point(375, 112)
         Me.ucrReceiverSeasonYear.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverSeasonYear.Name = "ucrReceiverSeasonYear"
         Me.ucrReceiverSeasonYear.Selector = Nothing
-        Me.ucrReceiverSeasonYear.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverSeasonYear.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverSeasonYear.strNcFilePath = ""
         Me.ucrReceiverSeasonYear.TabIndex = 4
         Me.ucrReceiverSeasonYear.ucrSelector = Nothing
@@ -839,11 +870,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverSeasonStationProb.AutoSize = True
         Me.ucrReceiverSeasonStationProb.frmParent = Nothing
-        Me.ucrReceiverSeasonStationProb.Location = New System.Drawing.Point(250, 30)
+        Me.ucrReceiverSeasonStationProb.Location = New System.Drawing.Point(375, 46)
         Me.ucrReceiverSeasonStationProb.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverSeasonStationProb.Name = "ucrReceiverSeasonStationProb"
         Me.ucrReceiverSeasonStationProb.Selector = Nothing
-        Me.ucrReceiverSeasonStationProb.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverSeasonStationProb.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverSeasonStationProb.strNcFilePath = ""
         Me.ucrReceiverSeasonStationProb.TabIndex = 2
         Me.ucrReceiverSeasonStationProb.ucrSelector = Nothing
@@ -854,10 +885,10 @@ Partial Class sdgDefineAnnualRainfall
         Me.ucrSelectorSeasonStartProp.bDropUnusedFilterLevels = False
         Me.ucrSelectorSeasonStartProp.bShowHiddenColumns = False
         Me.ucrSelectorSeasonStartProp.bUseCurrentFilter = True
-        Me.ucrSelectorSeasonStartProp.Location = New System.Drawing.Point(13, 10)
+        Me.ucrSelectorSeasonStartProp.Location = New System.Drawing.Point(20, 15)
         Me.ucrSelectorSeasonStartProp.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorSeasonStartProp.Name = "ucrSelectorSeasonStartProp"
-        Me.ucrSelectorSeasonStartProp.Size = New System.Drawing.Size(226, 268)
+        Me.ucrSelectorSeasonStartProp.Size = New System.Drawing.Size(339, 412)
         Me.ucrSelectorSeasonStartProp.TabIndex = 0
         '
         'tbAnnualTempSummaries
@@ -879,10 +910,11 @@ Partial Class sdgDefineAnnualRainfall
         Me.tbAnnualTempSummaries.Controls.Add(Me.ucrReceiverAnnualTempYr)
         Me.tbAnnualTempSummaries.Controls.Add(Me.ucrReceiverAnnualTempStation)
         Me.tbAnnualTempSummaries.Controls.Add(Me.ucrSelectorAnnualTemp)
-        Me.tbAnnualTempSummaries.Location = New System.Drawing.Point(4, 22)
+        Me.tbAnnualTempSummaries.Location = New System.Drawing.Point(4, 29)
+        Me.tbAnnualTempSummaries.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.tbAnnualTempSummaries.Name = "tbAnnualTempSummaries"
-        Me.tbAnnualTempSummaries.Padding = New System.Windows.Forms.Padding(3)
-        Me.tbAnnualTempSummaries.Size = New System.Drawing.Size(515, 480)
+        Me.tbAnnualTempSummaries.Padding = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.tbAnnualTempSummaries.Size = New System.Drawing.Size(776, 745)
         Me.tbAnnualTempSummaries.TabIndex = 3
         Me.tbAnnualTempSummaries.Text = "Annual Temperature"
         Me.tbAnnualTempSummaries.UseVisualStyleBackColor = True
@@ -890,72 +922,80 @@ Partial Class sdgDefineAnnualRainfall
         'lblMinMinAnnual
         '
         Me.lblMinMinAnnual.AutoSize = True
-        Me.lblMinMinAnnual.Location = New System.Drawing.Point(248, 135)
+        Me.lblMinMinAnnual.Location = New System.Drawing.Point(372, 208)
+        Me.lblMinMinAnnual.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMinMinAnnual.Name = "lblMinMinAnnual"
-        Me.lblMinMinAnnual.Size = New System.Drawing.Size(98, 13)
+        Me.lblMinMinAnnual.Size = New System.Drawing.Size(145, 20)
         Me.lblMinMinAnnual.TabIndex = 7
         Me.lblMinMinAnnual.Text = "Min Minimum Temp"
         '
         'lblMeanAnnualTemp
         '
         Me.lblMeanAnnualTemp.AutoSize = True
-        Me.lblMeanAnnualTemp.Location = New System.Drawing.Point(248, 93)
+        Me.lblMeanAnnualTemp.Location = New System.Drawing.Point(372, 143)
+        Me.lblMeanAnnualTemp.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMeanAnnualTemp.Name = "lblMeanAnnualTemp"
-        Me.lblMeanAnnualTemp.Size = New System.Drawing.Size(108, 13)
+        Me.lblMeanAnnualTemp.Size = New System.Drawing.Size(160, 20)
         Me.lblMeanAnnualTemp.TabIndex = 5
         Me.lblMeanAnnualTemp.Text = "Mean Minimum Temp"
         '
         'lblMaxMinAnnual
         '
         Me.lblMaxMinAnnual.AutoSize = True
-        Me.lblMaxMinAnnual.Location = New System.Drawing.Point(248, 174)
+        Me.lblMaxMinAnnual.Location = New System.Drawing.Point(372, 268)
+        Me.lblMaxMinAnnual.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMaxMinAnnual.Name = "lblMaxMinAnnual"
-        Me.lblMaxMinAnnual.Size = New System.Drawing.Size(101, 13)
+        Me.lblMaxMinAnnual.Size = New System.Drawing.Size(149, 20)
         Me.lblMaxMinAnnual.TabIndex = 9
         Me.lblMaxMinAnnual.Text = "Max Minimum Temp"
         '
         'lblAnnualTempYear
         '
         Me.lblAnnualTempYear.AutoSize = True
-        Me.lblAnnualTempYear.Location = New System.Drawing.Point(248, 52)
+        Me.lblAnnualTempYear.Location = New System.Drawing.Point(372, 80)
+        Me.lblAnnualTempYear.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblAnnualTempYear.Name = "lblAnnualTempYear"
-        Me.lblAnnualTempYear.Size = New System.Drawing.Size(32, 13)
+        Me.lblAnnualTempYear.Size = New System.Drawing.Size(47, 20)
         Me.lblAnnualTempYear.TabIndex = 3
         Me.lblAnnualTempYear.Text = "Year:"
         '
         'lblAnnualTempStation
         '
         Me.lblAnnualTempStation.AutoSize = True
-        Me.lblAnnualTempStation.Location = New System.Drawing.Point(248, 9)
+        Me.lblAnnualTempStation.Location = New System.Drawing.Point(372, 14)
+        Me.lblAnnualTempStation.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblAnnualTempStation.Name = "lblAnnualTempStation"
-        Me.lblAnnualTempStation.Size = New System.Drawing.Size(43, 13)
+        Me.lblAnnualTempStation.Size = New System.Drawing.Size(64, 20)
         Me.lblAnnualTempStation.TabIndex = 1
         Me.lblAnnualTempStation.Text = "Station:"
         '
         'lblMaxMaxAnnual
         '
         Me.lblMaxMaxAnnual.AutoSize = True
-        Me.lblMaxMaxAnnual.Location = New System.Drawing.Point(248, 295)
+        Me.lblMaxMaxAnnual.Location = New System.Drawing.Point(372, 454)
+        Me.lblMaxMaxAnnual.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMaxMaxAnnual.Name = "lblMaxMaxAnnual"
-        Me.lblMaxMaxAnnual.Size = New System.Drawing.Size(104, 13)
+        Me.lblMaxMaxAnnual.Size = New System.Drawing.Size(153, 20)
         Me.lblMaxMaxAnnual.TabIndex = 15
         Me.lblMaxMaxAnnual.Text = "Max Maximum Temp"
         '
         'lblMinMaxAnnual
         '
         Me.lblMinMaxAnnual.AutoSize = True
-        Me.lblMinMaxAnnual.Location = New System.Drawing.Point(248, 253)
+        Me.lblMinMaxAnnual.Location = New System.Drawing.Point(372, 389)
+        Me.lblMinMaxAnnual.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMinMaxAnnual.Name = "lblMinMaxAnnual"
-        Me.lblMinMaxAnnual.Size = New System.Drawing.Size(104, 13)
+        Me.lblMinMaxAnnual.Size = New System.Drawing.Size(153, 20)
         Me.lblMinMaxAnnual.TabIndex = 13
         Me.lblMinMaxAnnual.Text = "Min Maximum Temp:"
         '
         'lblMeanMaxAnnual
         '
         Me.lblMeanMaxAnnual.AutoSize = True
-        Me.lblMeanMaxAnnual.Location = New System.Drawing.Point(248, 214)
+        Me.lblMeanMaxAnnual.Location = New System.Drawing.Point(372, 329)
+        Me.lblMeanMaxAnnual.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMeanMaxAnnual.Name = "lblMeanMaxAnnual"
-        Me.lblMeanMaxAnnual.Size = New System.Drawing.Size(111, 13)
+        Me.lblMeanMaxAnnual.Size = New System.Drawing.Size(164, 20)
         Me.lblMeanMaxAnnual.TabIndex = 11
         Me.lblMeanMaxAnnual.Text = "Mean Maximum Temp"
         '
@@ -963,11 +1003,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMinMinAnnual.AutoSize = True
         Me.ucrReceiverMinMinAnnual.frmParent = Nothing
-        Me.ucrReceiverMinMinAnnual.Location = New System.Drawing.Point(248, 151)
+        Me.ucrReceiverMinMinAnnual.Location = New System.Drawing.Point(372, 232)
         Me.ucrReceiverMinMinAnnual.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMinMinAnnual.Name = "ucrReceiverMinMinAnnual"
         Me.ucrReceiverMinMinAnnual.Selector = Nothing
-        Me.ucrReceiverMinMinAnnual.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMinMinAnnual.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMinMinAnnual.strNcFilePath = ""
         Me.ucrReceiverMinMinAnnual.TabIndex = 8
         Me.ucrReceiverMinMinAnnual.ucrSelector = Nothing
@@ -976,11 +1016,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMaxMaxAnnual.AutoSize = True
         Me.ucrReceiverMaxMaxAnnual.frmParent = Nothing
-        Me.ucrReceiverMaxMaxAnnual.Location = New System.Drawing.Point(248, 308)
+        Me.ucrReceiverMaxMaxAnnual.Location = New System.Drawing.Point(372, 474)
         Me.ucrReceiverMaxMaxAnnual.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMaxMaxAnnual.Name = "ucrReceiverMaxMaxAnnual"
         Me.ucrReceiverMaxMaxAnnual.Selector = Nothing
-        Me.ucrReceiverMaxMaxAnnual.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMaxMaxAnnual.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMaxMaxAnnual.strNcFilePath = ""
         Me.ucrReceiverMaxMaxAnnual.TabIndex = 16
         Me.ucrReceiverMaxMaxAnnual.ucrSelector = Nothing
@@ -989,11 +1029,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMeanMaxAnnual.AutoSize = True
         Me.ucrReceiverMeanMaxAnnual.frmParent = Nothing
-        Me.ucrReceiverMeanMaxAnnual.Location = New System.Drawing.Point(248, 231)
+        Me.ucrReceiverMeanMaxAnnual.Location = New System.Drawing.Point(372, 355)
         Me.ucrReceiverMeanMaxAnnual.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMeanMaxAnnual.Name = "ucrReceiverMeanMaxAnnual"
         Me.ucrReceiverMeanMaxAnnual.Selector = Nothing
-        Me.ucrReceiverMeanMaxAnnual.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMeanMaxAnnual.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMeanMaxAnnual.strNcFilePath = ""
         Me.ucrReceiverMeanMaxAnnual.TabIndex = 12
         Me.ucrReceiverMeanMaxAnnual.ucrSelector = Nothing
@@ -1002,11 +1042,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMinMaxAnnual.AutoSize = True
         Me.ucrReceiverMinMaxAnnual.frmParent = Nothing
-        Me.ucrReceiverMinMaxAnnual.Location = New System.Drawing.Point(248, 271)
+        Me.ucrReceiverMinMaxAnnual.Location = New System.Drawing.Point(372, 417)
         Me.ucrReceiverMinMaxAnnual.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMinMaxAnnual.Name = "ucrReceiverMinMaxAnnual"
         Me.ucrReceiverMinMaxAnnual.Selector = Nothing
-        Me.ucrReceiverMinMaxAnnual.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMinMaxAnnual.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMinMaxAnnual.strNcFilePath = ""
         Me.ucrReceiverMinMaxAnnual.TabIndex = 14
         Me.ucrReceiverMinMaxAnnual.ucrSelector = Nothing
@@ -1015,11 +1055,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMaxMinAnnual.AutoSize = True
         Me.ucrReceiverMaxMinAnnual.frmParent = Nothing
-        Me.ucrReceiverMaxMinAnnual.Location = New System.Drawing.Point(248, 192)
+        Me.ucrReceiverMaxMinAnnual.Location = New System.Drawing.Point(372, 295)
         Me.ucrReceiverMaxMinAnnual.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMaxMinAnnual.Name = "ucrReceiverMaxMinAnnual"
         Me.ucrReceiverMaxMinAnnual.Selector = Nothing
-        Me.ucrReceiverMaxMinAnnual.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMaxMinAnnual.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMaxMinAnnual.strNcFilePath = ""
         Me.ucrReceiverMaxMinAnnual.TabIndex = 10
         Me.ucrReceiverMaxMinAnnual.ucrSelector = Nothing
@@ -1028,11 +1068,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMeanAnnual.AutoSize = True
         Me.ucrReceiverMeanAnnual.frmParent = Nothing
-        Me.ucrReceiverMeanAnnual.Location = New System.Drawing.Point(248, 112)
+        Me.ucrReceiverMeanAnnual.Location = New System.Drawing.Point(372, 172)
         Me.ucrReceiverMeanAnnual.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMeanAnnual.Name = "ucrReceiverMeanAnnual"
         Me.ucrReceiverMeanAnnual.Selector = Nothing
-        Me.ucrReceiverMeanAnnual.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMeanAnnual.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMeanAnnual.strNcFilePath = ""
         Me.ucrReceiverMeanAnnual.TabIndex = 6
         Me.ucrReceiverMeanAnnual.ucrSelector = Nothing
@@ -1041,11 +1081,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverAnnualTempYr.AutoSize = True
         Me.ucrReceiverAnnualTempYr.frmParent = Nothing
-        Me.ucrReceiverAnnualTempYr.Location = New System.Drawing.Point(248, 69)
+        Me.ucrReceiverAnnualTempYr.Location = New System.Drawing.Point(372, 106)
         Me.ucrReceiverAnnualTempYr.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverAnnualTempYr.Name = "ucrReceiverAnnualTempYr"
         Me.ucrReceiverAnnualTempYr.Selector = Nothing
-        Me.ucrReceiverAnnualTempYr.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverAnnualTempYr.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverAnnualTempYr.strNcFilePath = ""
         Me.ucrReceiverAnnualTempYr.TabIndex = 4
         Me.ucrReceiverAnnualTempYr.ucrSelector = Nothing
@@ -1054,11 +1094,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverAnnualTempStation.AutoSize = True
         Me.ucrReceiverAnnualTempStation.frmParent = Nothing
-        Me.ucrReceiverAnnualTempStation.Location = New System.Drawing.Point(248, 26)
+        Me.ucrReceiverAnnualTempStation.Location = New System.Drawing.Point(372, 40)
         Me.ucrReceiverAnnualTempStation.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverAnnualTempStation.Name = "ucrReceiverAnnualTempStation"
         Me.ucrReceiverAnnualTempStation.Selector = Nothing
-        Me.ucrReceiverAnnualTempStation.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverAnnualTempStation.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverAnnualTempStation.strNcFilePath = ""
         Me.ucrReceiverAnnualTempStation.TabIndex = 2
         Me.ucrReceiverAnnualTempStation.ucrSelector = Nothing
@@ -1069,10 +1109,10 @@ Partial Class sdgDefineAnnualRainfall
         Me.ucrSelectorAnnualTemp.bDropUnusedFilterLevels = False
         Me.ucrSelectorAnnualTemp.bShowHiddenColumns = False
         Me.ucrSelectorAnnualTemp.bUseCurrentFilter = True
-        Me.ucrSelectorAnnualTemp.Location = New System.Drawing.Point(11, 6)
+        Me.ucrSelectorAnnualTemp.Location = New System.Drawing.Point(16, 9)
         Me.ucrSelectorAnnualTemp.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorAnnualTemp.Name = "ucrSelectorAnnualTemp"
-        Me.ucrSelectorAnnualTemp.Size = New System.Drawing.Size(226, 268)
+        Me.ucrSelectorAnnualTemp.Size = New System.Drawing.Size(339, 412)
         Me.ucrSelectorAnnualTemp.TabIndex = 0
         '
         'tbMonthlyTemp
@@ -1096,10 +1136,11 @@ Partial Class sdgDefineAnnualRainfall
         Me.tbMonthlyTemp.Controls.Add(Me.ucrReceiverYearMonthly)
         Me.tbMonthlyTemp.Controls.Add(Me.ucrReceiverMonthlyTemp)
         Me.tbMonthlyTemp.Controls.Add(Me.ucrSelecetorMonthlyTemp)
-        Me.tbMonthlyTemp.Location = New System.Drawing.Point(4, 22)
+        Me.tbMonthlyTemp.Location = New System.Drawing.Point(4, 29)
+        Me.tbMonthlyTemp.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.tbMonthlyTemp.Name = "tbMonthlyTemp"
-        Me.tbMonthlyTemp.Padding = New System.Windows.Forms.Padding(3)
-        Me.tbMonthlyTemp.Size = New System.Drawing.Size(515, 480)
+        Me.tbMonthlyTemp.Padding = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.tbMonthlyTemp.Size = New System.Drawing.Size(776, 745)
         Me.tbMonthlyTemp.TabIndex = 4
         Me.tbMonthlyTemp.Text = "Monthly Temperature"
         Me.tbMonthlyTemp.UseVisualStyleBackColor = True
@@ -1107,81 +1148,90 @@ Partial Class sdgDefineAnnualRainfall
         'lblMonth
         '
         Me.lblMonth.AutoSize = True
-        Me.lblMonth.Location = New System.Drawing.Point(247, 95)
+        Me.lblMonth.Location = New System.Drawing.Point(370, 146)
+        Me.lblMonth.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMonth.Name = "lblMonth"
-        Me.lblMonth.Size = New System.Drawing.Size(40, 13)
+        Me.lblMonth.Size = New System.Drawing.Size(58, 20)
         Me.lblMonth.TabIndex = 5
         Me.lblMonth.Text = "Month:"
         '
         'lblMinMInMonthly
         '
         Me.lblMinMInMonthly.AutoSize = True
-        Me.lblMinMInMonthly.Location = New System.Drawing.Point(247, 181)
+        Me.lblMinMInMonthly.Location = New System.Drawing.Point(370, 278)
+        Me.lblMinMInMonthly.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMinMInMonthly.Name = "lblMinMInMonthly"
-        Me.lblMinMInMonthly.Size = New System.Drawing.Size(98, 13)
+        Me.lblMinMInMonthly.Size = New System.Drawing.Size(145, 20)
         Me.lblMinMInMonthly.TabIndex = 9
         Me.lblMinMInMonthly.Text = "Min Minimum Temp"
         '
         'lblMeanMinMonthly
         '
         Me.lblMeanMinMonthly.AutoSize = True
-        Me.lblMeanMinMonthly.Location = New System.Drawing.Point(247, 139)
+        Me.lblMeanMinMonthly.Location = New System.Drawing.Point(370, 214)
+        Me.lblMeanMinMonthly.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMeanMinMonthly.Name = "lblMeanMinMonthly"
-        Me.lblMeanMinMonthly.Size = New System.Drawing.Size(108, 13)
+        Me.lblMeanMinMonthly.Size = New System.Drawing.Size(160, 20)
         Me.lblMeanMinMonthly.TabIndex = 7
         Me.lblMeanMinMonthly.Text = "Mean Minimum Temp"
         '
         'lblMaxMinMonthly
         '
         Me.lblMaxMinMonthly.AutoSize = True
-        Me.lblMaxMinMonthly.Location = New System.Drawing.Point(247, 220)
+        Me.lblMaxMinMonthly.Location = New System.Drawing.Point(370, 338)
+        Me.lblMaxMinMonthly.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMaxMinMonthly.Name = "lblMaxMinMonthly"
-        Me.lblMaxMinMonthly.Size = New System.Drawing.Size(101, 13)
+        Me.lblMaxMinMonthly.Size = New System.Drawing.Size(149, 20)
         Me.lblMaxMinMonthly.TabIndex = 11
         Me.lblMaxMinMonthly.Text = "Max Minimum Temp"
         '
         'lblYearMonthTemp
         '
         Me.lblYearMonthTemp.AutoSize = True
-        Me.lblYearMonthTemp.Location = New System.Drawing.Point(247, 54)
+        Me.lblYearMonthTemp.Location = New System.Drawing.Point(370, 83)
+        Me.lblYearMonthTemp.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblYearMonthTemp.Name = "lblYearMonthTemp"
-        Me.lblYearMonthTemp.Size = New System.Drawing.Size(32, 13)
+        Me.lblYearMonthTemp.Size = New System.Drawing.Size(47, 20)
         Me.lblYearMonthTemp.TabIndex = 3
         Me.lblYearMonthTemp.Text = "Year:"
         '
         'lblStationMonthTemp
         '
         Me.lblStationMonthTemp.AutoSize = True
-        Me.lblStationMonthTemp.Location = New System.Drawing.Point(247, 15)
+        Me.lblStationMonthTemp.Location = New System.Drawing.Point(370, 23)
+        Me.lblStationMonthTemp.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblStationMonthTemp.Name = "lblStationMonthTemp"
-        Me.lblStationMonthTemp.Size = New System.Drawing.Size(43, 13)
+        Me.lblStationMonthTemp.Size = New System.Drawing.Size(64, 20)
         Me.lblStationMonthTemp.TabIndex = 1
         Me.lblStationMonthTemp.Text = "Station:"
         '
         'lblMaxMaxMonthly
         '
         Me.lblMaxMaxMonthly.AutoSize = True
-        Me.lblMaxMaxMonthly.Location = New System.Drawing.Point(247, 341)
+        Me.lblMaxMaxMonthly.Location = New System.Drawing.Point(370, 525)
+        Me.lblMaxMaxMonthly.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMaxMaxMonthly.Name = "lblMaxMaxMonthly"
-        Me.lblMaxMaxMonthly.Size = New System.Drawing.Size(104, 13)
+        Me.lblMaxMaxMonthly.Size = New System.Drawing.Size(153, 20)
         Me.lblMaxMaxMonthly.TabIndex = 17
         Me.lblMaxMaxMonthly.Text = "Max Maximum Temp"
         '
         'lblMinMaxMonthly
         '
         Me.lblMinMaxMonthly.AutoSize = True
-        Me.lblMinMaxMonthly.Location = New System.Drawing.Point(247, 299)
+        Me.lblMinMaxMonthly.Location = New System.Drawing.Point(370, 460)
+        Me.lblMinMaxMonthly.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMinMaxMonthly.Name = "lblMinMaxMonthly"
-        Me.lblMinMaxMonthly.Size = New System.Drawing.Size(104, 13)
+        Me.lblMinMaxMonthly.Size = New System.Drawing.Size(153, 20)
         Me.lblMinMaxMonthly.TabIndex = 15
         Me.lblMinMaxMonthly.Text = "Min Maximum Temp:"
         '
         'lblMeanMaxMonthly
         '
         Me.lblMeanMaxMonthly.AutoSize = True
-        Me.lblMeanMaxMonthly.Location = New System.Drawing.Point(247, 260)
+        Me.lblMeanMaxMonthly.Location = New System.Drawing.Point(370, 400)
+        Me.lblMeanMaxMonthly.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMeanMaxMonthly.Name = "lblMeanMaxMonthly"
-        Me.lblMeanMaxMonthly.Size = New System.Drawing.Size(111, 13)
+        Me.lblMeanMaxMonthly.Size = New System.Drawing.Size(164, 20)
         Me.lblMeanMaxMonthly.TabIndex = 13
         Me.lblMeanMaxMonthly.Text = "Mean Maximum Temp"
         '
@@ -1189,11 +1239,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMonthMonthly.AutoSize = True
         Me.ucrReceiverMonthMonthly.frmParent = Nothing
-        Me.ucrReceiverMonthMonthly.Location = New System.Drawing.Point(247, 112)
+        Me.ucrReceiverMonthMonthly.Location = New System.Drawing.Point(370, 172)
         Me.ucrReceiverMonthMonthly.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMonthMonthly.Name = "ucrReceiverMonthMonthly"
         Me.ucrReceiverMonthMonthly.Selector = Nothing
-        Me.ucrReceiverMonthMonthly.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMonthMonthly.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMonthMonthly.strNcFilePath = ""
         Me.ucrReceiverMonthMonthly.TabIndex = 6
         Me.ucrReceiverMonthMonthly.ucrSelector = Nothing
@@ -1202,11 +1252,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMinMinMonthly.AutoSize = True
         Me.ucrReceiverMinMinMonthly.frmParent = Nothing
-        Me.ucrReceiverMinMinMonthly.Location = New System.Drawing.Point(247, 197)
+        Me.ucrReceiverMinMinMonthly.Location = New System.Drawing.Point(370, 303)
         Me.ucrReceiverMinMinMonthly.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMinMinMonthly.Name = "ucrReceiverMinMinMonthly"
         Me.ucrReceiverMinMinMonthly.Selector = Nothing
-        Me.ucrReceiverMinMinMonthly.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMinMinMonthly.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMinMinMonthly.strNcFilePath = ""
         Me.ucrReceiverMinMinMonthly.TabIndex = 10
         Me.ucrReceiverMinMinMonthly.ucrSelector = Nothing
@@ -1215,11 +1265,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMaxMaxMonthly.AutoSize = True
         Me.ucrReceiverMaxMaxMonthly.frmParent = Nothing
-        Me.ucrReceiverMaxMaxMonthly.Location = New System.Drawing.Point(247, 354)
+        Me.ucrReceiverMaxMaxMonthly.Location = New System.Drawing.Point(370, 545)
         Me.ucrReceiverMaxMaxMonthly.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMaxMaxMonthly.Name = "ucrReceiverMaxMaxMonthly"
         Me.ucrReceiverMaxMaxMonthly.Selector = Nothing
-        Me.ucrReceiverMaxMaxMonthly.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMaxMaxMonthly.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMaxMaxMonthly.strNcFilePath = ""
         Me.ucrReceiverMaxMaxMonthly.TabIndex = 18
         Me.ucrReceiverMaxMaxMonthly.ucrSelector = Nothing
@@ -1228,11 +1278,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMeanmaxMonthly.AutoSize = True
         Me.ucrReceiverMeanmaxMonthly.frmParent = Nothing
-        Me.ucrReceiverMeanmaxMonthly.Location = New System.Drawing.Point(247, 277)
+        Me.ucrReceiverMeanmaxMonthly.Location = New System.Drawing.Point(370, 426)
         Me.ucrReceiverMeanmaxMonthly.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMeanmaxMonthly.Name = "ucrReceiverMeanmaxMonthly"
         Me.ucrReceiverMeanmaxMonthly.Selector = Nothing
-        Me.ucrReceiverMeanmaxMonthly.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMeanmaxMonthly.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMeanmaxMonthly.strNcFilePath = ""
         Me.ucrReceiverMeanmaxMonthly.TabIndex = 14
         Me.ucrReceiverMeanmaxMonthly.ucrSelector = Nothing
@@ -1241,11 +1291,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMinMaxMonthly.AutoSize = True
         Me.ucrReceiverMinMaxMonthly.frmParent = Nothing
-        Me.ucrReceiverMinMaxMonthly.Location = New System.Drawing.Point(247, 317)
+        Me.ucrReceiverMinMaxMonthly.Location = New System.Drawing.Point(370, 488)
         Me.ucrReceiverMinMaxMonthly.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMinMaxMonthly.Name = "ucrReceiverMinMaxMonthly"
         Me.ucrReceiverMinMaxMonthly.Selector = Nothing
-        Me.ucrReceiverMinMaxMonthly.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMinMaxMonthly.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMinMaxMonthly.strNcFilePath = ""
         Me.ucrReceiverMinMaxMonthly.TabIndex = 16
         Me.ucrReceiverMinMaxMonthly.ucrSelector = Nothing
@@ -1254,11 +1304,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMaxMinMonthly.AutoSize = True
         Me.ucrReceiverMaxMinMonthly.frmParent = Nothing
-        Me.ucrReceiverMaxMinMonthly.Location = New System.Drawing.Point(247, 238)
+        Me.ucrReceiverMaxMinMonthly.Location = New System.Drawing.Point(370, 366)
         Me.ucrReceiverMaxMinMonthly.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMaxMinMonthly.Name = "ucrReceiverMaxMinMonthly"
         Me.ucrReceiverMaxMinMonthly.Selector = Nothing
-        Me.ucrReceiverMaxMinMonthly.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMaxMinMonthly.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMaxMinMonthly.strNcFilePath = ""
         Me.ucrReceiverMaxMinMonthly.TabIndex = 12
         Me.ucrReceiverMaxMinMonthly.ucrSelector = Nothing
@@ -1267,11 +1317,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMeanminMontly.AutoSize = True
         Me.ucrReceiverMeanminMontly.frmParent = Nothing
-        Me.ucrReceiverMeanminMontly.Location = New System.Drawing.Point(247, 158)
+        Me.ucrReceiverMeanminMontly.Location = New System.Drawing.Point(370, 243)
         Me.ucrReceiverMeanminMontly.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMeanminMontly.Name = "ucrReceiverMeanminMontly"
         Me.ucrReceiverMeanminMontly.Selector = Nothing
-        Me.ucrReceiverMeanminMontly.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMeanminMontly.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMeanminMontly.strNcFilePath = ""
         Me.ucrReceiverMeanminMontly.TabIndex = 8
         Me.ucrReceiverMeanminMontly.ucrSelector = Nothing
@@ -1280,11 +1330,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverYearMonthly.AutoSize = True
         Me.ucrReceiverYearMonthly.frmParent = Nothing
-        Me.ucrReceiverYearMonthly.Location = New System.Drawing.Point(247, 71)
+        Me.ucrReceiverYearMonthly.Location = New System.Drawing.Point(370, 109)
         Me.ucrReceiverYearMonthly.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverYearMonthly.Name = "ucrReceiverYearMonthly"
         Me.ucrReceiverYearMonthly.Selector = Nothing
-        Me.ucrReceiverYearMonthly.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverYearMonthly.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverYearMonthly.strNcFilePath = ""
         Me.ucrReceiverYearMonthly.TabIndex = 4
         Me.ucrReceiverYearMonthly.ucrSelector = Nothing
@@ -1293,11 +1343,11 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverMonthlyTemp.AutoSize = True
         Me.ucrReceiverMonthlyTemp.frmParent = Nothing
-        Me.ucrReceiverMonthlyTemp.Location = New System.Drawing.Point(247, 32)
+        Me.ucrReceiverMonthlyTemp.Location = New System.Drawing.Point(370, 49)
         Me.ucrReceiverMonthlyTemp.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMonthlyTemp.Name = "ucrReceiverMonthlyTemp"
         Me.ucrReceiverMonthlyTemp.Selector = Nothing
-        Me.ucrReceiverMonthlyTemp.Size = New System.Drawing.Size(120, 25)
+        Me.ucrReceiverMonthlyTemp.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverMonthlyTemp.strNcFilePath = ""
         Me.ucrReceiverMonthlyTemp.TabIndex = 2
         Me.ucrReceiverMonthlyTemp.ucrSelector = Nothing
@@ -1308,30 +1358,31 @@ Partial Class sdgDefineAnnualRainfall
         Me.ucrSelecetorMonthlyTemp.bDropUnusedFilterLevels = False
         Me.ucrSelecetorMonthlyTemp.bShowHiddenColumns = False
         Me.ucrSelecetorMonthlyTemp.bUseCurrentFilter = True
-        Me.ucrSelecetorMonthlyTemp.Location = New System.Drawing.Point(10, 12)
+        Me.ucrSelecetorMonthlyTemp.Location = New System.Drawing.Point(15, 18)
         Me.ucrSelecetorMonthlyTemp.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelecetorMonthlyTemp.Name = "ucrSelecetorMonthlyTemp"
-        Me.ucrSelecetorMonthlyTemp.Size = New System.Drawing.Size(226, 268)
+        Me.ucrSelecetorMonthlyTemp.Size = New System.Drawing.Size(339, 412)
         Me.ucrSelecetorMonthlyTemp.TabIndex = 0
         '
         'ucrBase
         '
         Me.ucrBase.AutoSize = True
-        Me.ucrBase.Location = New System.Drawing.Point(157, 527)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrBase.Location = New System.Drawing.Point(236, 811)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(224, 30)
+        Me.ucrBase.Size = New System.Drawing.Size(336, 46)
         Me.ucrBase.TabIndex = 35
         '
         'sdgDefineAnnualRainfall
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(9.0!, 20.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(547, 562)
+        Me.ClientSize = New System.Drawing.Size(820, 865)
         Me.Controls.Add(Me.tbSummaries)
         Me.Controls.Add(Me.ucrBase)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "sdgDefineAnnualRainfall"

--- a/instat/sdgDefineAnnualRainfall.vb
+++ b/instat/sdgDefineAnnualRainfall.vb
@@ -407,6 +407,13 @@ Public Class sdgDefineAnnualRainfall
         ucrReceiverMinMinAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("min_tmin_column", 4), iAdditionalPairNo:=1)
         ucrReceiverMaxMinAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("max_tmin_column", 5), iAdditionalPairNo:=1)
 
+        ucrReceiverMeanmaxMonthly.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("mean_monthly_tmax_column", 5), iAdditionalPairNo:=1)
+        ucrReceiverMinMaxMonthly.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("min_monthly_tmax_column", 6), iAdditionalPairNo:=1)
+        ucrReceiverMaxMaxMonthly.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("max_monthly_tmax_column", 7), iAdditionalPairNo:=1)
+        ucrReceiverMaxMinMonthly.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("max_monthly_tmin_column", 8), iAdditionalPairNo:=1)
+        ucrReceiverMinMinMonthly.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("min_monthly_tmin_column", 9), iAdditionalPairNo:=1)
+        ucrReceiverMeanminMontly.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("mean_monthly_tmin_column", 10), iAdditionalPairNo:=1)
+
         ucrReceiverAnnualRain.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
         ucrReceiverExtremRian.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
 


### PR DESCRIPTION
As outlined in #9926

1. Removing the "Year" and "Month" receivers from the main dialog
2. Removing the "Rain" receiver from the main dialog
3. Setting up tab order correctly
4. Amending the layout to be more intuitive for the user
5. Removing the option for extremes as this is part of the annual summaries
6. Changing "Country" inputs to drop downs
7. Setting up correctly the parameter values for "Monthly Temperature Summaries" in the sdg for `export_r_instat_to_buckets` function