### PR TITLE
Amendments to Export to Buckets design

### DIFF
--- a/instat/dlgExportClimaticDefinitions.Designer.vb
+++ b/instat/dlgExportClimaticDefinitions.Designer.vb
@@ -22,7 +22,7 @@ Partial Class dlgExportClimaticDefinitions
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
-        Me.ucrReceiverYear = New instat.ucrReceiverSingle()
+
         Me.lblExport = New System.Windows.Forms.Label()
         Me.cmdChooseFile = New System.Windows.Forms.Button()
         Me.ucrInputTokenPath = New instat.ucrInputTextBox()
@@ -35,28 +35,25 @@ Partial Class dlgExportClimaticDefinitions
         Me.cmdDefine = New System.Windows.Forms.Button()
         Me.lblStation = New System.Windows.Forms.Label()
         Me.lblCountry = New System.Windows.Forms.Label()
-        Me.ucrInputCountry = New instat.ucrInputTextBox()
-        Me.lblMonth = New System.Windows.Forms.Label()
-        Me.lblYear = New System.Windows.Forms.Label()
-        Me.ucrReceiverMonth = New instat.ucrReceiverSingle()
         Me.ucrChkIncludeSummaryData = New instat.ucrCheck()
         Me.grpSummaries = New System.Windows.Forms.GroupBox()
+        Me.ucrReceiverExtremIndicator = New instat.ucrReceiverSingle()
+        Me.ucrReceiverRainIndicator = New instat.ucrReceiverSingle()
+        Me.lblRainIndicator = New System.Windows.Forms.Label()
+        Me.lblExtremRain = New System.Windows.Forms.Label()
+        Me.lblDataByYearMonth = New System.Windows.Forms.Label()
         Me.ucrChkMonthlyTemp = New instat.ucrCheck()
         Me.ucrChkSeasonStartProp = New instat.ucrCheck()
-        Me.ucrChkExtremes = New instat.ucrCheck()
         Me.ucrChkCropSuccessProp = New instat.ucrCheck()
         Me.ucrChkAnnualTemp = New instat.ucrCheck()
         Me.ucrChkAnnualRainfall = New instat.ucrCheck()
         Me.lblCropData = New System.Windows.Forms.Label()
-        Me.lblDataByYearMonth = New System.Windows.Forms.Label()
+        Me.ucrReceiverCropData = New instat.ucrReceiverSingle()
         Me.lblDataByYear = New System.Windows.Forms.Label()
-        Me.lblRain = New System.Windows.Forms.Label()
-        Me.ucrReceiverRain = New instat.ucrReceiverSingle()
-        Me.ucrSelectorExportDefinitions = New instat.ucrSelectorByDataFrameAddRemove()
-        Me.ucrBase = New instat.ucrButtons()
         Me.ucrReceiverDataYear = New instat.ucrReceiverSingle()
         Me.ucrReceiverDataYearMonth = New instat.ucrReceiverSingle()
-        Me.ucrReceiverCropData = New instat.ucrReceiverSingle()
+        Me.ucrSelectorExportDefinitions = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrBase = New instat.ucrButtons()
         Me.lblDistrict = New System.Windows.Forms.Label()
         Me.lblElavation = New System.Windows.Forms.Label()
         Me.lblLatitude = New System.Windows.Forms.Label()
@@ -68,50 +65,30 @@ Partial Class dlgExportClimaticDefinitions
         Me.ucrReceiverStationName = New instat.ucrReceiverSingle()
         Me.lblStationName = New System.Windows.Forms.Label()
         Me.lblCountryMetada = New System.Windows.Forms.Label()
-        Me.ucrInputCountryMetadata = New instat.ucrInputTextBox()
-        Me.ucrReceiverExtremIndicator = New instat.ucrReceiverSingle()
-        Me.ucrReceiverRainIndicator = New instat.ucrReceiverSingle()
-        Me.lblRainIndicator = New System.Windows.Forms.Label()
-        Me.lblExtremRain = New System.Windows.Forms.Label()
-        Me.lblExtremeTmaxIndicator = New System.Windows.Forms.Label()
-        Me.ucrReceiverExtremeTmaxIndicator = New instat.ucrReceiverSingle()
-        Me.lblExtremeTminIndicator = New System.Windows.Forms.Label()
-        Me.ucrReceiverExtremeTminIndicator = New instat.ucrReceiverSingle()
+        Me.ucrInputComboCountry = New instat.ucrInputComboBox()
+        Me.ucrInputComboCountryMetadata = New instat.ucrInputComboBox()
         Me.grpSummaries.SuspendLayout()
         Me.SuspendLayout()
-        '
-        'ucrReceiverYear
-        '
-        Me.ucrReceiverYear.AutoSize = True
-        Me.ucrReceiverYear.frmParent = Me
-        Me.ucrReceiverYear.Location = New System.Drawing.Point(495, 194)
-        Me.ucrReceiverYear.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverYear.Name = "ucrReceiverYear"
-        Me.ucrReceiverYear.Selector = Nothing
-        Me.ucrReceiverYear.Size = New System.Drawing.Size(180, 31)
-        Me.ucrReceiverYear.strNcFilePath = ""
-        Me.ucrReceiverYear.TabIndex = 52
-        Me.ucrReceiverYear.ucrSelector = Nothing
         '
         'lblExport
         '
         Me.lblExport.AutoSize = True
         Me.lblExport.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblExport.Location = New System.Drawing.Point(96, 71)
+        Me.lblExport.Location = New System.Drawing.Point(105, 69)
         Me.lblExport.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblExport.Name = "lblExport"
         Me.lblExport.Size = New System.Drawing.Size(57, 20)
-        Me.lblExport.TabIndex = 81
+        Me.lblExport.TabIndex = 5
         Me.lblExport.Text = "Token:"
         '
         'cmdChooseFile
         '
         Me.cmdChooseFile.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdChooseFile.Location = New System.Drawing.Point(466, 62)
+        Me.cmdChooseFile.Location = New System.Drawing.Point(465, 62)
         Me.cmdChooseFile.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.cmdChooseFile.Name = "cmdChooseFile"
         Me.cmdChooseFile.Size = New System.Drawing.Size(120, 35)
-        Me.cmdChooseFile.TabIndex = 83
+        Me.cmdChooseFile.TabIndex = 4
         Me.cmdChooseFile.Text = "Browse"
         Me.cmdChooseFile.UseVisualStyleBackColor = True
         '
@@ -125,7 +102,7 @@ Partial Class dlgExportClimaticDefinitions
         Me.ucrInputTokenPath.Margin = New System.Windows.Forms.Padding(9, 12, 9, 12)
         Me.ucrInputTokenPath.Name = "ucrInputTokenPath"
         Me.ucrInputTokenPath.Size = New System.Drawing.Size(286, 32)
-        Me.ucrInputTokenPath.TabIndex = 82
+        Me.ucrInputTokenPath.TabIndex = 3
         '
         'rdoUploadSummaries
         '
@@ -139,7 +116,7 @@ Partial Class dlgExportClimaticDefinitions
         Me.rdoUploadSummaries.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.rdoUploadSummaries.Name = "rdoUploadSummaries"
         Me.rdoUploadSummaries.Size = New System.Drawing.Size(183, 42)
-        Me.rdoUploadSummaries.TabIndex = 47
+        Me.rdoUploadSummaries.TabIndex = 2
         Me.rdoUploadSummaries.Text = "Upload Summaries"
         Me.rdoUploadSummaries.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         Me.rdoUploadSummaries.UseVisualStyleBackColor = True
@@ -156,7 +133,7 @@ Partial Class dlgExportClimaticDefinitions
         Me.rdoUpdateMetadata.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.rdoUpdateMetadata.Name = "rdoUpdateMetadata"
         Me.rdoUpdateMetadata.Size = New System.Drawing.Size(174, 42)
-        Me.rdoUpdateMetadata.TabIndex = 46
+        Me.rdoUpdateMetadata.TabIndex = 1
         Me.rdoUpdateMetadata.Text = "Update Metadata"
         Me.rdoUpdateMetadata.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         Me.rdoUpdateMetadata.UseVisualStyleBackColor = True
@@ -168,29 +145,29 @@ Partial Class dlgExportClimaticDefinitions
         Me.ucrPnlExportGoogle.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrPnlExportGoogle.Name = "ucrPnlExportGoogle"
         Me.ucrPnlExportGoogle.Size = New System.Drawing.Size(374, 51)
-        Me.ucrPnlExportGoogle.TabIndex = 45
+        Me.ucrPnlExportGoogle.TabIndex = 0
         '
         'ucrReceiverStation
         '
         Me.ucrReceiverStation.AutoSize = True
         Me.ucrReceiverStation.frmParent = Me
-        Me.ucrReceiverStation.Location = New System.Drawing.Point(495, 142)
+        Me.ucrReceiverStation.Location = New System.Drawing.Point(478, 143)
         Me.ucrReceiverStation.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverStation.Name = "ucrReceiverStation"
         Me.ucrReceiverStation.Selector = Nothing
         Me.ucrReceiverStation.Size = New System.Drawing.Size(180, 31)
         Me.ucrReceiverStation.strNcFilePath = ""
-        Me.ucrReceiverStation.TabIndex = 50
+        Me.ucrReceiverStation.TabIndex = 20
         Me.ucrReceiverStation.ucrSelector = Nothing
         '
         'lblDefinitionsID
         '
         Me.lblDefinitionsID.AutoSize = True
-        Me.lblDefinitionsID.Location = New System.Drawing.Point(2, 600)
+        Me.lblDefinitionsID.Location = New System.Drawing.Point(482, 244)
         Me.lblDefinitionsID.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblDefinitionsID.Name = "lblDefinitionsID"
         Me.lblDefinitionsID.Size = New System.Drawing.Size(109, 20)
-        Me.lblDefinitionsID.TabIndex = 67
+        Me.lblDefinitionsID.TabIndex = 23
         Me.lblDefinitionsID.Text = "Definitions ID:"
         '
         'ucrInputDefinitionsID
@@ -199,228 +176,243 @@ Partial Class dlgExportClimaticDefinitions
         Me.ucrInputDefinitionsID.AutoSize = True
         Me.ucrInputDefinitionsID.IsMultiline = False
         Me.ucrInputDefinitionsID.IsReadOnly = False
-        Me.ucrInputDefinitionsID.Location = New System.Drawing.Point(129, 594)
+        Me.ucrInputDefinitionsID.Location = New System.Drawing.Point(478, 265)
         Me.ucrInputDefinitionsID.Margin = New System.Windows.Forms.Padding(14)
         Me.ucrInputDefinitionsID.Name = "ucrInputDefinitionsID"
-        Me.ucrInputDefinitionsID.Size = New System.Drawing.Size(177, 32)
-        Me.ucrInputDefinitionsID.TabIndex = 68
+        Me.ucrInputDefinitionsID.Size = New System.Drawing.Size(180, 32)
+        Me.ucrInputDefinitionsID.TabIndex = 24
         '
         'cmdDefine
         '
         Me.cmdDefine.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdDefine.Location = New System.Drawing.Point(9, 730)
+        Me.cmdDefine.Location = New System.Drawing.Point(466, 671)
         Me.cmdDefine.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.cmdDefine.Name = "cmdDefine"
         Me.cmdDefine.Size = New System.Drawing.Size(188, 38)
-        Me.cmdDefine.TabIndex = 72
+        Me.cmdDefine.TabIndex = 27
         Me.cmdDefine.Text = "Define"
         Me.cmdDefine.UseVisualStyleBackColor = True
         '
         'lblStation
         '
         Me.lblStation.AutoSize = True
-        Me.lblStation.Location = New System.Drawing.Point(495, 122)
+        Me.lblStation.Location = New System.Drawing.Point(482, 120)
         Me.lblStation.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblStation.Name = "lblStation"
-        Me.lblStation.Size = New System.Drawing.Size(64, 20)
-        Me.lblStation.TabIndex = 49
-        Me.lblStation.Text = "Station:"
+        Me.lblStation.Size = New System.Drawing.Size(110, 20)
+        Me.lblStation.TabIndex = 19
+        Me.lblStation.Text = "Station Name:"
         '
         'lblCountry
         '
         Me.lblCountry.AutoSize = True
-        Me.lblCountry.Location = New System.Drawing.Point(42, 642)
+        Me.lblCountry.Location = New System.Drawing.Point(482, 184)
         Me.lblCountry.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblCountry.Name = "lblCountry"
         Me.lblCountry.Size = New System.Drawing.Size(68, 20)
-        Me.lblCountry.TabIndex = 69
+        Me.lblCountry.TabIndex = 21
         Me.lblCountry.Text = "Country:"
-        '
-        'ucrInputCountry
-        '
-        Me.ucrInputCountry.AddQuotesIfUnrecognised = True
-        Me.ucrInputCountry.AutoSize = True
-        Me.ucrInputCountry.IsMultiline = False
-        Me.ucrInputCountry.IsReadOnly = False
-        Me.ucrInputCountry.Location = New System.Drawing.Point(129, 635)
-        Me.ucrInputCountry.Margin = New System.Windows.Forms.Padding(14)
-        Me.ucrInputCountry.Name = "ucrInputCountry"
-        Me.ucrInputCountry.Size = New System.Drawing.Size(177, 32)
-        Me.ucrInputCountry.TabIndex = 70
-        '
-        'lblMonth
-        '
-        Me.lblMonth.AutoSize = True
-        Me.lblMonth.Location = New System.Drawing.Point(495, 232)
-        Me.lblMonth.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblMonth.Name = "lblMonth"
-        Me.lblMonth.Size = New System.Drawing.Size(58, 20)
-        Me.lblMonth.TabIndex = 53
-        Me.lblMonth.Text = "Month:"
-        '
-        'lblYear
-        '
-        Me.lblYear.AutoSize = True
-        Me.lblYear.Location = New System.Drawing.Point(495, 171)
-        Me.lblYear.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblYear.Name = "lblYear"
-        Me.lblYear.Size = New System.Drawing.Size(47, 20)
-        Me.lblYear.TabIndex = 51
-        Me.lblYear.Text = "Year:"
-        '
-        'ucrReceiverMonth
-        '
-        Me.ucrReceiverMonth.AutoSize = True
-        Me.ucrReceiverMonth.frmParent = Me
-        Me.ucrReceiverMonth.Location = New System.Drawing.Point(495, 257)
-        Me.ucrReceiverMonth.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverMonth.Name = "ucrReceiverMonth"
-        Me.ucrReceiverMonth.Selector = Nothing
-        Me.ucrReceiverMonth.Size = New System.Drawing.Size(180, 31)
-        Me.ucrReceiverMonth.strNcFilePath = ""
-        Me.ucrReceiverMonth.TabIndex = 54
-        Me.ucrReceiverMonth.ucrSelector = Nothing
         '
         'ucrChkIncludeSummaryData
         '
         Me.ucrChkIncludeSummaryData.AutoSize = True
         Me.ucrChkIncludeSummaryData.Checked = False
-        Me.ucrChkIncludeSummaryData.Location = New System.Drawing.Point(9, 685)
+        Me.ucrChkIncludeSummaryData.Location = New System.Drawing.Point(13, 675)
         Me.ucrChkIncludeSummaryData.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkIncludeSummaryData.Name = "ucrChkIncludeSummaryData"
-        Me.ucrChkIncludeSummaryData.Size = New System.Drawing.Size(200, 38)
-        Me.ucrChkIncludeSummaryData.TabIndex = 71
+        Me.ucrChkIncludeSummaryData.Size = New System.Drawing.Size(368, 48)
+        Me.ucrChkIncludeSummaryData.TabIndex = 26
         '
         'grpSummaries
         '
+        Me.grpSummaries.Controls.Add(Me.ucrReceiverExtremIndicator)
+        Me.grpSummaries.Controls.Add(Me.ucrReceiverRainIndicator)
+        Me.grpSummaries.Controls.Add(Me.lblRainIndicator)
+        Me.grpSummaries.Controls.Add(Me.lblExtremRain)
+        Me.grpSummaries.Controls.Add(Me.lblDataByYearMonth)
         Me.grpSummaries.Controls.Add(Me.ucrChkMonthlyTemp)
         Me.grpSummaries.Controls.Add(Me.ucrChkSeasonStartProp)
-        Me.grpSummaries.Controls.Add(Me.ucrChkExtremes)
         Me.grpSummaries.Controls.Add(Me.ucrChkCropSuccessProp)
         Me.grpSummaries.Controls.Add(Me.ucrChkAnnualTemp)
         Me.grpSummaries.Controls.Add(Me.ucrChkAnnualRainfall)
-        Me.grpSummaries.Location = New System.Drawing.Point(3, 406)
+        Me.grpSummaries.Controls.Add(Me.lblCropData)
+        Me.grpSummaries.Controls.Add(Me.ucrReceiverCropData)
+        Me.grpSummaries.Controls.Add(Me.lblDataByYear)
+        Me.grpSummaries.Controls.Add(Me.ucrReceiverDataYear)
+        Me.grpSummaries.Controls.Add(Me.ucrReceiverDataYearMonth)
+        Me.grpSummaries.Location = New System.Drawing.Point(14, 396)
         Me.grpSummaries.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.grpSummaries.Name = "grpSummaries"
         Me.grpSummaries.Padding = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.grpSummaries.Size = New System.Drawing.Size(470, 178)
-        Me.grpSummaries.TabIndex = 67
+        Me.grpSummaries.Size = New System.Drawing.Size(669, 265)
+        Me.grpSummaries.TabIndex = 25
         Me.grpSummaries.TabStop = False
         Me.grpSummaries.Text = "Summaries"
+        '
+        'ucrReceiverExtremIndicator
+        '
+        Me.ucrReceiverExtremIndicator.AutoSize = True
+        Me.ucrReceiverExtremIndicator.frmParent = Me
+        Me.ucrReceiverExtremIndicator.Location = New System.Drawing.Point(472, 101)
+        Me.ucrReceiverExtremIndicator.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverExtremIndicator.Name = "ucrReceiverExtremIndicator"
+        Me.ucrReceiverExtremIndicator.Selector = Nothing
+        Me.ucrReceiverExtremIndicator.Size = New System.Drawing.Size(180, 31)
+        Me.ucrReceiverExtremIndicator.strNcFilePath = ""
+        Me.ucrReceiverExtremIndicator.TabIndex = 10
+        Me.ucrReceiverExtremIndicator.ucrSelector = Nothing
+        '
+        'ucrReceiverRainIndicator
+        '
+        Me.ucrReceiverRainIndicator.AutoSize = True
+        Me.ucrReceiverRainIndicator.frmParent = Me
+        Me.ucrReceiverRainIndicator.Location = New System.Drawing.Point(472, 63)
+        Me.ucrReceiverRainIndicator.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverRainIndicator.Name = "ucrReceiverRainIndicator"
+        Me.ucrReceiverRainIndicator.Selector = Nothing
+        Me.ucrReceiverRainIndicator.Size = New System.Drawing.Size(180, 31)
+        Me.ucrReceiverRainIndicator.strNcFilePath = ""
+        Me.ucrReceiverRainIndicator.TabIndex = 8
+        Me.ucrReceiverRainIndicator.ucrSelector = Nothing
+        '
+        'lblRainIndicator
+        '
+        Me.lblRainIndicator.AutoSize = True
+        Me.lblRainIndicator.Location = New System.Drawing.Point(298, 65)
+        Me.lblRainIndicator.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblRainIndicator.Name = "lblRainIndicator"
+        Me.lblRainIndicator.Size = New System.Drawing.Size(170, 20)
+        Me.lblRainIndicator.TabIndex = 7
+        Me.lblRainIndicator.Text = "Rain Indicator Column:"
+        '
+        'lblExtremRain
+        '
+        Me.lblExtremRain.AutoSize = True
+        Me.lblExtremRain.Location = New System.Drawing.Point(293, 103)
+        Me.lblExtremRain.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblExtremRain.Name = "lblExtremRain"
+        Me.lblExtremRain.Size = New System.Drawing.Size(175, 20)
+        Me.lblExtremRain.TabIndex = 9
+        Me.lblExtremRain.Text = "Extreme Rain Indicator:"
+        '
+        'lblDataByYearMonth
+        '
+        Me.lblDataByYearMonth.AutoSize = True
+        Me.lblDataByYearMonth.Location = New System.Drawing.Point(280, 145)
+        Me.lblDataByYearMonth.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblDataByYearMonth.Name = "lblDataByYearMonth"
+        Me.lblDataByYearMonth.Size = New System.Drawing.Size(188, 20)
+        Me.lblDataByYearMonth.TabIndex = 11
+        Me.lblDataByYearMonth.Text = "Data By Year and Month:"
         '
         'ucrChkMonthlyTemp
         '
         Me.ucrChkMonthlyTemp.AutoSize = True
         Me.ucrChkMonthlyTemp.Checked = False
-        Me.ucrChkMonthlyTemp.Location = New System.Drawing.Point(12, 118)
+        Me.ucrChkMonthlyTemp.Location = New System.Drawing.Point(12, 140)
         Me.ucrChkMonthlyTemp.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkMonthlyTemp.Name = "ucrChkMonthlyTemp"
-        Me.ucrChkMonthlyTemp.Size = New System.Drawing.Size(220, 52)
-        Me.ucrChkMonthlyTemp.TabIndex = 4
+        Me.ucrChkMonthlyTemp.Size = New System.Drawing.Size(220, 34)
+        Me.ucrChkMonthlyTemp.TabIndex = 2
         '
         'ucrChkSeasonStartProp
         '
         Me.ucrChkSeasonStartProp.AutoSize = True
         Me.ucrChkSeasonStartProp.Checked = False
-        Me.ucrChkSeasonStartProp.Location = New System.Drawing.Point(236, 68)
+        Me.ucrChkSeasonStartProp.Location = New System.Drawing.Point(12, 224)
         Me.ucrChkSeasonStartProp.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkSeasonStartProp.Name = "ucrChkSeasonStartProp"
-        Me.ucrChkSeasonStartProp.Size = New System.Drawing.Size(226, 52)
-        Me.ucrChkSeasonStartProp.TabIndex = 3
-        '
-        'ucrChkExtremes
-        '
-        Me.ucrChkExtremes.AutoSize = True
-        Me.ucrChkExtremes.Checked = False
-        Me.ucrChkExtremes.Location = New System.Drawing.Point(236, 118)
-        Me.ucrChkExtremes.Margin = New System.Windows.Forms.Padding(9)
-        Me.ucrChkExtremes.Name = "ucrChkExtremes"
-        Me.ucrChkExtremes.Size = New System.Drawing.Size(220, 52)
-        Me.ucrChkExtremes.TabIndex = 5
-        Me.ucrChkExtremes.Visible = False
+        Me.ucrChkSeasonStartProp.Size = New System.Drawing.Size(226, 37)
+        Me.ucrChkSeasonStartProp.TabIndex = 4
         '
         'ucrChkCropSuccessProp
         '
         Me.ucrChkCropSuccessProp.AutoSize = True
         Me.ucrChkCropSuccessProp.Checked = False
-        Me.ucrChkCropSuccessProp.Location = New System.Drawing.Point(236, 20)
+        Me.ucrChkCropSuccessProp.Location = New System.Drawing.Point(12, 182)
         Me.ucrChkCropSuccessProp.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkCropSuccessProp.Name = "ucrChkCropSuccessProp"
         Me.ucrChkCropSuccessProp.Size = New System.Drawing.Size(230, 52)
-        Me.ucrChkCropSuccessProp.TabIndex = 1
+        Me.ucrChkCropSuccessProp.TabIndex = 3
         '
         'ucrChkAnnualTemp
         '
         Me.ucrChkAnnualTemp.AutoSize = True
         Me.ucrChkAnnualTemp.Checked = False
-        Me.ucrChkAnnualTemp.Location = New System.Drawing.Point(12, 69)
+        Me.ucrChkAnnualTemp.Location = New System.Drawing.Point(12, 66)
         Me.ucrChkAnnualTemp.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkAnnualTemp.Name = "ucrChkAnnualTemp"
-        Me.ucrChkAnnualTemp.Size = New System.Drawing.Size(224, 52)
-        Me.ucrChkAnnualTemp.TabIndex = 2
+        Me.ucrChkAnnualTemp.Size = New System.Drawing.Size(224, 34)
+        Me.ucrChkAnnualTemp.TabIndex = 1
         '
         'ucrChkAnnualRainfall
         '
         Me.ucrChkAnnualRainfall.AutoSize = True
         Me.ucrChkAnnualRainfall.Checked = False
-        Me.ucrChkAnnualRainfall.Location = New System.Drawing.Point(12, 20)
+        Me.ucrChkAnnualRainfall.Location = New System.Drawing.Point(12, 24)
         Me.ucrChkAnnualRainfall.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkAnnualRainfall.Name = "ucrChkAnnualRainfall"
-        Me.ucrChkAnnualRainfall.Size = New System.Drawing.Size(224, 52)
+        Me.ucrChkAnnualRainfall.Size = New System.Drawing.Size(224, 34)
         Me.ucrChkAnnualRainfall.TabIndex = 0
         '
         'lblCropData
         '
         Me.lblCropData.AutoSize = True
-        Me.lblCropData.Location = New System.Drawing.Point(494, 684)
+        Me.lblCropData.Location = New System.Drawing.Point(382, 184)
         Me.lblCropData.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblCropData.Name = "lblCropData"
-        Me.lblCropData.Size = New System.Drawing.Size(157, 20)
-        Me.lblCropData.TabIndex = 61
-        Me.lblCropData.Text = "Crop Summary Data:"
+        Me.lblCropData.Size = New System.Drawing.Size(86, 20)
+        Me.lblCropData.TabIndex = 13
+        Me.lblCropData.Text = "Crop Data:"
         '
-        'lblDataByYearMonth
+        'ucrReceiverCropData
         '
-        Me.lblDataByYearMonth.AutoSize = True
-        Me.lblDataByYearMonth.Location = New System.Drawing.Point(492, 416)
-        Me.lblDataByYearMonth.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblDataByYearMonth.Name = "lblDataByYearMonth"
-        Me.lblDataByYearMonth.Size = New System.Drawing.Size(188, 20)
-        Me.lblDataByYearMonth.TabIndex = 59
-        Me.lblDataByYearMonth.Text = "Data By Year and Month:"
+        Me.ucrReceiverCropData.AutoSize = True
+        Me.ucrReceiverCropData.frmParent = Me
+        Me.ucrReceiverCropData.Location = New System.Drawing.Point(472, 182)
+        Me.ucrReceiverCropData.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverCropData.Name = "ucrReceiverCropData"
+        Me.ucrReceiverCropData.Selector = Nothing
+        Me.ucrReceiverCropData.Size = New System.Drawing.Size(180, 31)
+        Me.ucrReceiverCropData.strNcFilePath = ""
+        Me.ucrReceiverCropData.TabIndex = 14
+        Me.ucrReceiverCropData.ucrSelector = Nothing
         '
         'lblDataByYear
         '
         Me.lblDataByYear.AutoSize = True
-        Me.lblDataByYear.Location = New System.Drawing.Point(495, 349)
+        Me.lblDataByYear.Location = New System.Drawing.Point(360, 24)
         Me.lblDataByYear.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblDataByYear.Name = "lblDataByYear"
         Me.lblDataByYear.Size = New System.Drawing.Size(108, 20)
-        Me.lblDataByYear.TabIndex = 57
+        Me.lblDataByYear.TabIndex = 5
         Me.lblDataByYear.Text = "Data By Year:"
         '
-        'lblRain
+        'ucrReceiverDataYear
         '
-        Me.lblRain.AutoSize = True
-        Me.lblRain.Location = New System.Drawing.Point(495, 294)
-        Me.lblRain.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblRain.Name = "lblRain"
-        Me.lblRain.Size = New System.Drawing.Size(46, 20)
-        Me.lblRain.TabIndex = 55
-        Me.lblRain.Text = "Rain:"
+        Me.ucrReceiverDataYear.AutoSize = True
+        Me.ucrReceiverDataYear.frmParent = Me
+        Me.ucrReceiverDataYear.Location = New System.Drawing.Point(472, 22)
+        Me.ucrReceiverDataYear.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverDataYear.Name = "ucrReceiverDataYear"
+        Me.ucrReceiverDataYear.Selector = Nothing
+        Me.ucrReceiverDataYear.Size = New System.Drawing.Size(180, 31)
+        Me.ucrReceiverDataYear.strNcFilePath = ""
+        Me.ucrReceiverDataYear.TabIndex = 6
+        Me.ucrReceiverDataYear.ucrSelector = Nothing
         '
-        'ucrReceiverRain
+        'ucrReceiverDataYearMonth
         '
-        Me.ucrReceiverRain.AutoSize = True
-        Me.ucrReceiverRain.frmParent = Me
-        Me.ucrReceiverRain.Location = New System.Drawing.Point(495, 318)
-        Me.ucrReceiverRain.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverRain.Name = "ucrReceiverRain"
-        Me.ucrReceiverRain.Selector = Nothing
-        Me.ucrReceiverRain.Size = New System.Drawing.Size(180, 31)
-        Me.ucrReceiverRain.strNcFilePath = ""
-        Me.ucrReceiverRain.TabIndex = 56
-        Me.ucrReceiverRain.ucrSelector = Nothing
+        Me.ucrReceiverDataYearMonth.AutoSize = True
+        Me.ucrReceiverDataYearMonth.frmParent = Me
+        Me.ucrReceiverDataYearMonth.Location = New System.Drawing.Point(472, 143)
+        Me.ucrReceiverDataYearMonth.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverDataYearMonth.Name = "ucrReceiverDataYearMonth"
+        Me.ucrReceiverDataYearMonth.Selector = Nothing
+        Me.ucrReceiverDataYearMonth.Size = New System.Drawing.Size(180, 31)
+        Me.ucrReceiverDataYearMonth.strNcFilePath = ""
+        Me.ucrReceiverDataYearMonth.TabIndex = 12
+        Me.ucrReceiverDataYearMonth.ucrSelector = Nothing
         '
         'ucrSelectorExportDefinitions
         '
@@ -428,147 +420,108 @@ Partial Class dlgExportClimaticDefinitions
         Me.ucrSelectorExportDefinitions.bDropUnusedFilterLevels = False
         Me.ucrSelectorExportDefinitions.bShowHiddenColumns = False
         Me.ucrSelectorExportDefinitions.bUseCurrentFilter = True
-        Me.ucrSelectorExportDefinitions.Location = New System.Drawing.Point(3, 120)
+        Me.ucrSelectorExportDefinitions.Location = New System.Drawing.Point(13, 109)
         Me.ucrSelectorExportDefinitions.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorExportDefinitions.Name = "ucrSelectorExportDefinitions"
         Me.ucrSelectorExportDefinitions.Size = New System.Drawing.Size(320, 282)
-        Me.ucrSelectorExportDefinitions.TabIndex = 48
+        Me.ucrSelectorExportDefinitions.TabIndex = 6
         '
         'ucrBase
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(3, 800)
+        Me.ucrBase.Location = New System.Drawing.Point(14, 738)
         Me.ucrBase.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(611, 77)
-        Me.ucrBase.TabIndex = 73
-        '
-        'ucrReceiverDataYear
-        '
-        Me.ucrReceiverDataYear.AutoSize = True
-        Me.ucrReceiverDataYear.frmParent = Me
-        Me.ucrReceiverDataYear.Location = New System.Drawing.Point(495, 375)
-        Me.ucrReceiverDataYear.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverDataYear.Name = "ucrReceiverDataYear"
-        Me.ucrReceiverDataYear.Selector = Nothing
-        Me.ucrReceiverDataYear.Size = New System.Drawing.Size(180, 31)
-        Me.ucrReceiverDataYear.strNcFilePath = ""
-        Me.ucrReceiverDataYear.TabIndex = 58
-        Me.ucrReceiverDataYear.ucrSelector = Nothing
-        '
-        'ucrReceiverDataYearMonth
-        '
-        Me.ucrReceiverDataYearMonth.AutoSize = True
-        Me.ucrReceiverDataYearMonth.frmParent = Me
-        Me.ucrReceiverDataYearMonth.Location = New System.Drawing.Point(493, 440)
-        Me.ucrReceiverDataYearMonth.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverDataYearMonth.Name = "ucrReceiverDataYearMonth"
-        Me.ucrReceiverDataYearMonth.Selector = Nothing
-        Me.ucrReceiverDataYearMonth.Size = New System.Drawing.Size(180, 31)
-        Me.ucrReceiverDataYearMonth.strNcFilePath = ""
-        Me.ucrReceiverDataYearMonth.TabIndex = 60
-        Me.ucrReceiverDataYearMonth.ucrSelector = Nothing
-        '
-        'ucrReceiverCropData
-        '
-        Me.ucrReceiverCropData.AutoSize = True
-        Me.ucrReceiverCropData.frmParent = Me
-        Me.ucrReceiverCropData.Location = New System.Drawing.Point(494, 709)
-        Me.ucrReceiverCropData.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverCropData.Name = "ucrReceiverCropData"
-        Me.ucrReceiverCropData.Selector = Nothing
-        Me.ucrReceiverCropData.Size = New System.Drawing.Size(180, 31)
-        Me.ucrReceiverCropData.strNcFilePath = ""
-        Me.ucrReceiverCropData.TabIndex = 62
-        Me.ucrReceiverCropData.ucrSelector = Nothing
+        Me.ucrBase.TabIndex = 28
         '
         'lblDistrict
         '
         Me.lblDistrict.AutoSize = True
-        Me.lblDistrict.Location = New System.Drawing.Point(486, 415)
+        Me.lblDistrict.Location = New System.Drawing.Point(482, 375)
         Me.lblDistrict.Name = "lblDistrict"
-        Me.lblDistrict.Size = New System.Drawing.Size(58, 20)
-        Me.lblDistrict.TabIndex = 79
-        Me.lblDistrict.Text = "District"
+        Me.lblDistrict.Size = New System.Drawing.Size(62, 20)
+        Me.lblDistrict.TabIndex = 15
+        Me.lblDistrict.Text = "District:"
         '
         'lblElavation
         '
         Me.lblElavation.AutoSize = True
-        Me.lblElavation.Location = New System.Drawing.Point(484, 342)
+        Me.lblElavation.Location = New System.Drawing.Point(482, 309)
         Me.lblElavation.Name = "lblElavation"
-        Me.lblElavation.Size = New System.Drawing.Size(74, 20)
-        Me.lblElavation.TabIndex = 77
-        Me.lblElavation.Text = "Elevation"
+        Me.lblElavation.Size = New System.Drawing.Size(78, 20)
+        Me.lblElavation.TabIndex = 13
+        Me.lblElavation.Text = "Elevation:"
         '
         'lblLatitude
         '
         Me.lblLatitude.AutoSize = True
-        Me.lblLatitude.Location = New System.Drawing.Point(483, 266)
+        Me.lblLatitude.Location = New System.Drawing.Point(482, 247)
         Me.lblLatitude.Name = "lblLatitude"
-        Me.lblLatitude.Size = New System.Drawing.Size(67, 20)
-        Me.lblLatitude.TabIndex = 75
-        Me.lblLatitude.Text = "Latitude"
+        Me.lblLatitude.Size = New System.Drawing.Size(71, 20)
+        Me.lblLatitude.TabIndex = 11
+        Me.lblLatitude.Text = "Latitude:"
         '
         'lblLongitude
         '
         Me.lblLongitude.AutoSize = True
-        Me.lblLongitude.Location = New System.Drawing.Point(482, 189)
+        Me.lblLongitude.Location = New System.Drawing.Point(482, 185)
         Me.lblLongitude.Name = "lblLongitude"
         Me.lblLongitude.Size = New System.Drawing.Size(84, 20)
-        Me.lblLongitude.TabIndex = 73
-        Me.lblLongitude.Text = "Longitude "
+        Me.lblLongitude.TabIndex = 9
+        Me.lblLongitude.Text = "Longitude:"
         '
         'ucrReceiverLongititude
         '
         Me.ucrReceiverLongititude.AutoSize = True
         Me.ucrReceiverLongititude.frmParent = Me
-        Me.ucrReceiverLongititude.Location = New System.Drawing.Point(478, 215)
+        Me.ucrReceiverLongititude.Location = New System.Drawing.Point(478, 205)
         Me.ucrReceiverLongititude.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverLongititude.Name = "ucrReceiverLongititude"
         Me.ucrReceiverLongititude.Selector = Nothing
         Me.ucrReceiverLongititude.Size = New System.Drawing.Size(180, 35)
         Me.ucrReceiverLongititude.strNcFilePath = ""
-        Me.ucrReceiverLongititude.TabIndex = 74
+        Me.ucrReceiverLongititude.TabIndex = 10
         Me.ucrReceiverLongititude.ucrSelector = Nothing
         '
         'ucrReceiverLatitude
         '
         Me.ucrReceiverLatitude.AutoSize = True
         Me.ucrReceiverLatitude.frmParent = Me
-        Me.ucrReceiverLatitude.Location = New System.Drawing.Point(478, 295)
+        Me.ucrReceiverLatitude.Location = New System.Drawing.Point(478, 267)
         Me.ucrReceiverLatitude.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverLatitude.Name = "ucrReceiverLatitude"
         Me.ucrReceiverLatitude.Selector = Nothing
         Me.ucrReceiverLatitude.Size = New System.Drawing.Size(180, 38)
         Me.ucrReceiverLatitude.strNcFilePath = ""
-        Me.ucrReceiverLatitude.TabIndex = 76
+        Me.ucrReceiverLatitude.TabIndex = 12
         Me.ucrReceiverLatitude.ucrSelector = Nothing
         '
         'ucrReceiverElavation
         '
         Me.ucrReceiverElavation.AutoSize = True
         Me.ucrReceiverElavation.frmParent = Me
-        Me.ucrReceiverElavation.Location = New System.Drawing.Point(478, 369)
+        Me.ucrReceiverElavation.Location = New System.Drawing.Point(478, 329)
         Me.ucrReceiverElavation.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverElavation.Name = "ucrReceiverElavation"
         Me.ucrReceiverElavation.Selector = Nothing
         Me.ucrReceiverElavation.Size = New System.Drawing.Size(180, 35)
         Me.ucrReceiverElavation.strNcFilePath = ""
-        Me.ucrReceiverElavation.TabIndex = 78
+        Me.ucrReceiverElavation.TabIndex = 14
         Me.ucrReceiverElavation.ucrSelector = Nothing
         '
         'ucrReceiverDistrict
         '
         Me.ucrReceiverDistrict.AutoSize = True
         Me.ucrReceiverDistrict.frmParent = Me
-        Me.ucrReceiverDistrict.Location = New System.Drawing.Point(478, 445)
+        Me.ucrReceiverDistrict.Location = New System.Drawing.Point(478, 396)
         Me.ucrReceiverDistrict.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverDistrict.Name = "ucrReceiverDistrict"
         Me.ucrReceiverDistrict.Selector = Nothing
         Me.ucrReceiverDistrict.Size = New System.Drawing.Size(180, 43)
         Me.ucrReceiverDistrict.strNcFilePath = ""
-        Me.ucrReceiverDistrict.TabIndex = 80
+        Me.ucrReceiverDistrict.TabIndex = 16
         Me.ucrReceiverDistrict.ucrSelector = Nothing
         '
         'ucrReceiverStationName
@@ -581,7 +534,7 @@ Partial Class dlgExportClimaticDefinitions
         Me.ucrReceiverStationName.Selector = Nothing
         Me.ucrReceiverStationName.Size = New System.Drawing.Size(180, 42)
         Me.ucrReceiverStationName.strNcFilePath = ""
-        Me.ucrReceiverStationName.TabIndex = 72
+        Me.ucrReceiverStationName.TabIndex = 8
         Me.ucrReceiverStationName.ucrSelector = Nothing
         '
         'lblStationName
@@ -589,137 +542,53 @@ Partial Class dlgExportClimaticDefinitions
         Me.lblStationName.AutoSize = True
         Me.lblStationName.Location = New System.Drawing.Point(482, 120)
         Me.lblStationName.Name = "lblStationName"
-        Me.lblStationName.Size = New System.Drawing.Size(106, 20)
-        Me.lblStationName.TabIndex = 71
-        Me.lblStationName.Text = "Station Name"
+        Me.lblStationName.Size = New System.Drawing.Size(110, 20)
+        Me.lblStationName.TabIndex = 7
+        Me.lblStationName.Text = "Station Name:"
         '
         'lblCountryMetada
         '
         Me.lblCountryMetada.AutoSize = True
-        Me.lblCountryMetada.Location = New System.Drawing.Point(484, 486)
+        Me.lblCountryMetada.Location = New System.Drawing.Point(482, 439)
         Me.lblCountryMetada.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblCountryMetada.Name = "lblCountryMetada"
         Me.lblCountryMetada.Size = New System.Drawing.Size(68, 20)
-        Me.lblCountryMetada.TabIndex = 85
+        Me.lblCountryMetada.TabIndex = 17
         Me.lblCountryMetada.Text = "Country:"
         '
-        'ucrInputCountryMetadata
+        'ucrInputComboCountry
         '
-        Me.ucrInputCountryMetadata.AddQuotesIfUnrecognised = True
-        Me.ucrInputCountryMetadata.AutoSize = True
-        Me.ucrInputCountryMetadata.IsMultiline = False
-        Me.ucrInputCountryMetadata.IsReadOnly = False
-        Me.ucrInputCountryMetadata.Location = New System.Drawing.Point(478, 514)
-        Me.ucrInputCountryMetadata.Margin = New System.Windows.Forms.Padding(14)
-        Me.ucrInputCountryMetadata.Name = "ucrInputCountryMetadata"
-        Me.ucrInputCountryMetadata.Size = New System.Drawing.Size(177, 32)
-        Me.ucrInputCountryMetadata.TabIndex = 84
+        Me.ucrInputComboCountry.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboCountry.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputComboCountry.GetSetSelectedIndex = -1
+        Me.ucrInputComboCountry.IsReadOnly = False
+        Me.ucrInputComboCountry.Location = New System.Drawing.Point(478, 206)
+        Me.ucrInputComboCountry.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrInputComboCountry.Name = "ucrInputComboCountry"
+        Me.ucrInputComboCountry.Size = New System.Drawing.Size(180, 32)
+        Me.ucrInputComboCountry.TabIndex = 22
         '
-        'ucrReceiverExtremIndicator
+        'ucrInputComboCountryMetadata
         '
-        Me.ucrReceiverExtremIndicator.AutoSize = True
-        Me.ucrReceiverExtremIndicator.frmParent = Me
-        Me.ucrReceiverExtremIndicator.Location = New System.Drawing.Point(495, 637)
-        Me.ucrReceiverExtremIndicator.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverExtremIndicator.Name = "ucrReceiverExtremIndicator"
-        Me.ucrReceiverExtremIndicator.Selector = Nothing
-        Me.ucrReceiverExtremIndicator.Size = New System.Drawing.Size(180, 31)
-        Me.ucrReceiverExtremIndicator.strNcFilePath = ""
-        Me.ucrReceiverExtremIndicator.TabIndex = 66
-        Me.ucrReceiverExtremIndicator.ucrSelector = Nothing
-        '
-        'ucrReceiverRainIndicator
-        '
-        Me.ucrReceiverRainIndicator.AutoSize = True
-        Me.ucrReceiverRainIndicator.frmParent = Me
-        Me.ucrReceiverRainIndicator.Location = New System.Drawing.Point(495, 574)
-        Me.ucrReceiverRainIndicator.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverRainIndicator.Name = "ucrReceiverRainIndicator"
-        Me.ucrReceiverRainIndicator.Selector = Nothing
-        Me.ucrReceiverRainIndicator.Size = New System.Drawing.Size(180, 31)
-        Me.ucrReceiverRainIndicator.strNcFilePath = ""
-        Me.ucrReceiverRainIndicator.TabIndex = 64
-        Me.ucrReceiverRainIndicator.ucrSelector = Nothing
-        '
-        'lblRainIndicator
-        '
-        Me.lblRainIndicator.AutoSize = True
-        Me.lblRainIndicator.Location = New System.Drawing.Point(502, 549)
-        Me.lblRainIndicator.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblRainIndicator.Name = "lblRainIndicator"
-        Me.lblRainIndicator.Size = New System.Drawing.Size(170, 20)
-        Me.lblRainIndicator.TabIndex = 63
-        Me.lblRainIndicator.Text = "Rain Indicator Column:"
-        '
-        'lblExtremRain
-        '
-        Me.lblExtremRain.AutoSize = True
-        Me.lblExtremRain.Location = New System.Drawing.Point(501, 615)
-        Me.lblExtremRain.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblExtremRain.Name = "lblExtremRain"
-        Me.lblExtremRain.Size = New System.Drawing.Size(175, 20)
-        Me.lblExtremRain.TabIndex = 65
-        Me.lblExtremRain.Text = "Extreme Rain Indicator:"
-        '
-        'lblExtremeTmaxIndicator
-        '
-        Me.lblExtremeTmaxIndicator.AutoSize = True
-        Me.lblExtremeTmaxIndicator.Location = New System.Drawing.Point(500, 484)
-        Me.lblExtremeTmaxIndicator.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblExtremeTmaxIndicator.Name = "lblExtremeTmaxIndicator"
-        Me.lblExtremeTmaxIndicator.Size = New System.Drawing.Size(180, 20)
-        Me.lblExtremeTmaxIndicator.TabIndex = 86
-        Me.lblExtremeTmaxIndicator.Text = " Extreme tmax Indicator:"
-        '
-        'ucrReceiverExtremeTmaxIndicator
-        '
-        Me.ucrReceiverExtremeTmaxIndicator.AutoSize = True
-        Me.ucrReceiverExtremeTmaxIndicator.frmParent = Me
-        Me.ucrReceiverExtremeTmaxIndicator.Location = New System.Drawing.Point(494, 506)
-        Me.ucrReceiverExtremeTmaxIndicator.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverExtremeTmaxIndicator.Name = "ucrReceiverExtremeTmaxIndicator"
-        Me.ucrReceiverExtremeTmaxIndicator.Selector = Nothing
-        Me.ucrReceiverExtremeTmaxIndicator.Size = New System.Drawing.Size(180, 31)
-        Me.ucrReceiverExtremeTmaxIndicator.strNcFilePath = ""
-        Me.ucrReceiverExtremeTmaxIndicator.TabIndex = 87
-        Me.ucrReceiverExtremeTmaxIndicator.ucrSelector = Nothing
-        '
-        'lblExtremeTminIndicator
-        '
-        Me.lblExtremeTminIndicator.AutoSize = True
-        Me.lblExtremeTminIndicator.Location = New System.Drawing.Point(488, 416)
-        Me.lblExtremeTminIndicator.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblExtremeTminIndicator.Name = "lblExtremeTminIndicator"
-        Me.lblExtremeTminIndicator.Size = New System.Drawing.Size(196, 20)
-        Me.lblExtremeTminIndicator.TabIndex = 88
-        Me.lblExtremeTminIndicator.Text = "  Extreme tmin Indicator:    "
-        '
-        'ucrReceiverExtremeTminIndicator
-        '
-        Me.ucrReceiverExtremeTminIndicator.AutoSize = True
-        Me.ucrReceiverExtremeTminIndicator.frmParent = Me
-        Me.ucrReceiverExtremeTminIndicator.Location = New System.Drawing.Point(493, 440)
-        Me.ucrReceiverExtremeTminIndicator.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverExtremeTminIndicator.Name = "ucrReceiverExtremeTminIndicator"
-        Me.ucrReceiverExtremeTminIndicator.Selector = Nothing
-        Me.ucrReceiverExtremeTminIndicator.Size = New System.Drawing.Size(180, 31)
-        Me.ucrReceiverExtremeTminIndicator.strNcFilePath = ""
-        Me.ucrReceiverExtremeTminIndicator.TabIndex = 89
-        Me.ucrReceiverExtremeTminIndicator.ucrSelector = Nothing
+        Me.ucrInputComboCountryMetadata.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboCountryMetadata.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputComboCountryMetadata.GetSetSelectedIndex = -1
+        Me.ucrInputComboCountryMetadata.IsReadOnly = False
+        Me.ucrInputComboCountryMetadata.Location = New System.Drawing.Point(478, 463)
+        Me.ucrInputComboCountryMetadata.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrInputComboCountryMetadata.Name = "ucrInputComboCountryMetadata"
+        Me.ucrInputComboCountryMetadata.Size = New System.Drawing.Size(180, 32)
+        Me.ucrInputComboCountryMetadata.TabIndex = 18
         '
         'dlgExportClimaticDefinitions
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
-        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(9.0!, 20.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(688, 884)
-        Me.Controls.Add(Me.lblExtremeTminIndicator)
-        Me.Controls.Add(Me.ucrReceiverExtremeTminIndicator)
-        Me.Controls.Add(Me.lblRainIndicator)
-        Me.Controls.Add(Me.ucrReceiverRainIndicator)
-        Me.Controls.Add(Me.lblExtremRain)
-        Me.Controls.Add(Me.ucrReceiverExtremIndicator)
-        Me.Controls.Add(Me.ucrReceiverYear)
+        Me.ClientSize = New System.Drawing.Size(698, 819)
+        Me.Controls.Add(Me.grpSummaries)
+        Me.Controls.Add(Me.ucrInputComboCountryMetadata)
+        Me.Controls.Add(Me.ucrInputComboCountry)
         Me.Controls.Add(Me.lblExport)
         Me.Controls.Add(Me.cmdChooseFile)
         Me.Controls.Add(Me.ucrInputTokenPath)
@@ -732,20 +601,9 @@ Partial Class dlgExportClimaticDefinitions
         Me.Controls.Add(Me.cmdDefine)
         Me.Controls.Add(Me.lblStation)
         Me.Controls.Add(Me.lblCountry)
-        Me.Controls.Add(Me.ucrInputCountry)
-        Me.Controls.Add(Me.lblMonth)
-        Me.Controls.Add(Me.lblYear)
-        Me.Controls.Add(Me.ucrReceiverMonth)
         Me.Controls.Add(Me.ucrChkIncludeSummaryData)
-        Me.Controls.Add(Me.grpSummaries)
-        Me.Controls.Add(Me.lblCropData)
-        Me.Controls.Add(Me.lblDataByYear)
-        Me.Controls.Add(Me.lblRain)
-        Me.Controls.Add(Me.ucrReceiverRain)
         Me.Controls.Add(Me.ucrSelectorExportDefinitions)
         Me.Controls.Add(Me.ucrBase)
-        Me.Controls.Add(Me.ucrReceiverDataYear)
-        Me.Controls.Add(Me.ucrReceiverCropData)
         Me.Controls.Add(Me.lblDistrict)
         Me.Controls.Add(Me.lblElavation)
         Me.Controls.Add(Me.lblLatitude)
@@ -757,11 +615,6 @@ Partial Class dlgExportClimaticDefinitions
         Me.Controls.Add(Me.ucrReceiverStationName)
         Me.Controls.Add(Me.lblStationName)
         Me.Controls.Add(Me.lblCountryMetada)
-        Me.Controls.Add(Me.ucrInputCountryMetadata)
-        Me.Controls.Add(Me.lblExtremeTmaxIndicator)
-        Me.Controls.Add(Me.ucrReceiverExtremeTmaxIndicator)
-        Me.Controls.Add(Me.lblDataByYearMonth)
-        Me.Controls.Add(Me.ucrReceiverDataYearMonth)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
         Me.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.MaximizeBox = False
@@ -773,10 +626,8 @@ Partial Class dlgExportClimaticDefinitions
         Me.grpSummaries.PerformLayout()
         Me.ResumeLayout(False)
         Me.PerformLayout()
-
     End Sub
 
-    Friend WithEvents ucrReceiverYear As ucrReceiverSingle
     Friend WithEvents lblExport As Label
     Friend WithEvents cmdChooseFile As Button
     Friend WithEvents ucrInputTokenPath As ucrInputTextBox
@@ -789,23 +640,16 @@ Partial Class dlgExportClimaticDefinitions
     Friend WithEvents cmdDefine As Button
     Friend WithEvents lblStation As Label
     Friend WithEvents lblCountry As Label
-    Friend WithEvents ucrInputCountry As ucrInputTextBox
-    Friend WithEvents lblMonth As Label
-    Friend WithEvents lblYear As Label
-    Friend WithEvents ucrReceiverMonth As ucrReceiverSingle
     Friend WithEvents ucrChkIncludeSummaryData As ucrCheck
     Friend WithEvents grpSummaries As GroupBox
     Friend WithEvents ucrChkMonthlyTemp As ucrCheck
     Friend WithEvents ucrChkSeasonStartProp As ucrCheck
-    Friend WithEvents ucrChkExtremes As ucrCheck
     Friend WithEvents ucrChkCropSuccessProp As ucrCheck
     Friend WithEvents ucrChkAnnualTemp As ucrCheck
     Friend WithEvents ucrChkAnnualRainfall As ucrCheck
     Friend WithEvents lblCropData As Label
     Friend WithEvents lblDataByYearMonth As Label
     Friend WithEvents lblDataByYear As Label
-    Friend WithEvents lblRain As Label
-    Friend WithEvents ucrReceiverRain As ucrReceiverSingle
     Friend WithEvents ucrSelectorExportDefinitions As ucrSelectorByDataFrameAddRemove
     Friend WithEvents ucrBase As ucrButtons
     Friend WithEvents ucrReceiverDataYear As ucrReceiverSingle
@@ -822,13 +666,10 @@ Partial Class dlgExportClimaticDefinitions
     Friend WithEvents ucrReceiverStationName As ucrReceiverSingle
     Friend WithEvents lblStationName As Label
     Friend WithEvents lblCountryMetada As Label
-    Friend WithEvents ucrInputCountryMetadata As ucrInputTextBox
     Friend WithEvents ucrReceiverExtremIndicator As ucrReceiverSingle
     Friend WithEvents ucrReceiverRainIndicator As ucrReceiverSingle
     Friend WithEvents lblRainIndicator As Label
     Friend WithEvents lblExtremRain As Label
-    Friend WithEvents lblExtremeTminIndicator As Label
-    Friend WithEvents ucrReceiverExtremeTminIndicator As ucrReceiverSingle
-    Friend WithEvents lblExtremeTmaxIndicator As Label
-    Friend WithEvents ucrReceiverExtremeTmaxIndicator As ucrReceiverSingle
+    Friend WithEvents ucrInputComboCountryMetadata As ucrInputComboBox
+    Friend WithEvents ucrInputComboCountry As ucrInputComboBox
 End Class

--- a/instat/dlgExportClimaticDefinitions.vb
+++ b/instat/dlgExportClimaticDefinitions.vb
@@ -75,41 +75,10 @@ Public Class dlgExportClimaticDefinitions
         ucrReceiverCropData.strSelectorHeading = "Data Sets"
         ucrReceiverCropData.SetLinkedDisplayControl(lblCropData)
 
-        ucrReceiverRain.SetParameter(New RParameter("rain", 6))
-        ucrReceiverRain.Selector = ucrSelectorExportDefinitions
-        ucrReceiverRain.SetParameterIsString()
-        ucrReceiverRain.SetClimaticType("rain")
-        ucrReceiverRain.bAutoFill = True
-        ucrReceiverRain.SetLinkedDisplayControl(lblRain)
-
-        ucrReceiverYear.SetParameter(New RParameter("year", 7))
-        ucrReceiverYear.Selector = ucrSelectorExportDefinitions
-        ucrReceiverYear.SetParameterIsString()
-        ucrReceiverYear.SetClimaticType("year")
-        ucrReceiverYear.bAutoFill = True
-        ucrReceiverYear.SetLinkedDisplayControl(lblYear)
-
-        ucrReceiverMonth.SetParameter(New RParameter("month", 8))
-        ucrReceiverMonth.Selector = ucrSelectorExportDefinitions
-        ucrReceiverMonth.SetParameterIsString()
-        ucrReceiverMonth.SetClimaticType("month")
-        ucrReceiverMonth.bAutoFill = True
-        ucrReceiverMonth.SetLinkedDisplayControl(lblMonth)
-
         ucrReceiverRainIndicator.SetParameter(New RParameter("rain_days_name", 9))
         ucrReceiverRainIndicator.Selector = ucrSelectorExportDefinitions
         ucrReceiverRainIndicator.SetParameterIsString()
         ucrReceiverRainIndicator.SetLinkedDisplayControl(lblRainIndicator)
-
-        ucrReceiverExtremeTminIndicator.SetParameter(New RParameter("extreme_tmin_column", 15))
-        ucrReceiverExtremeTminIndicator.Selector = ucrSelectorExportDefinitions
-        ucrReceiverExtremeTminIndicator.SetParameterIsString()
-        ucrReceiverExtremeTminIndicator.SetLinkedDisplayControl(lblExtremeTminIndicator)
-
-        ucrReceiverExtremeTmaxIndicator.SetParameter(New RParameter("extreme_tmax_column", 16))
-        ucrReceiverExtremeTmaxIndicator.Selector = ucrSelectorExportDefinitions
-        ucrReceiverExtremeTmaxIndicator.SetParameterIsString()
-        ucrReceiverExtremeTmaxIndicator.SetLinkedDisplayControl(lblExtremeTmaxIndicator)
 
         ucrReceiverExtremIndicator.SetParameter(New RParameter("extreme_rainfall_column", 10))
         ucrReceiverExtremIndicator.Selector = ucrSelectorExportDefinitions
@@ -123,10 +92,6 @@ Public Class dlgExportClimaticDefinitions
         ucrChkAnnualTemp.SetText("Annual Temperature")
         ucrChkAnnualTemp.AddParameterValuesCondition(True, "temp", "True")
         ucrChkAnnualTemp.AddParameterValuesCondition(False, "temp", "False")
-
-        ucrChkExtremes.SetText("Extremes")
-        ucrChkExtremes.AddParameterValuesCondition(True, "extrem", "True")
-        ucrChkExtremes.AddParameterValuesCondition(False, "extrem", "False")
 
         ucrChkMonthlyTemp.SetText("Monthly Temperature")
         ucrChkMonthlyTemp.AddParameterValuesCondition(True, "monthly_temp", "True")
@@ -148,8 +113,8 @@ Public Class dlgExportClimaticDefinitions
         ucrInputDefinitionsID.SetParameter(New RParameter("definitions_id", 19))
         ucrInputDefinitionsID.SetLinkedDisplayControl(lblDefinitionsID)
 
-        ucrInputCountry.SetParameter(New RParameter("country", 20))
-        ucrInputCountry.SetLinkedDisplayControl(lblCountry)
+        ucrInputComboCountry.SetParameter(New RParameter("country", 20))
+        ucrInputComboCountry.SetLinkedDisplayControl(lblCountry)
 
         ucrInputTokenPath.SetParameter(New RParameter("filename", 0))
         ucrInputTokenPath.SetLinkedDisplayControl(lblExport)
@@ -189,12 +154,12 @@ Public Class dlgExportClimaticDefinitions
         ucrReceiverDistrict.bAutoFill = True
         ucrReceiverDistrict.SetLinkedDisplayControl(lblDistrict)
 
-        ucrInputCountryMetadata.SetParameter(New RParameter("country", 6))
-        ucrInputCountryMetadata.SetLinkedDisplayControl(lblCountryMetada)
+        ucrInputComboCountryMetadata.SetParameter(New RParameter("country", 6))
+        ucrInputComboCountryMetadata.SetLinkedDisplayControl(lblCountryMetada)
 
-        ucrPnlExportGoogle.AddToLinkedControls({ucrReceiverMonth, ucrReceiverYear, ucrReceiverStation}, {rdoUploadSummaries}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrPnlExportGoogle.AddToLinkedControls({ucrReceiverDistrict, ucrReceiverElavation, ucrReceiverLatitude, ucrInputCountryMetadata, ucrReceiverLongititude, ucrReceiverStationName}, {rdoUpdateMetadata}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
-        ucrPnlExportGoogle.AddToLinkedControls({ucrInputCountry, ucrChkIncludeSummaryData, ucrInputDefinitionsID}, {rdoUploadSummaries}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlExportGoogle.AddToLinkedControls({ucrReceiverStation}, {rdoUploadSummaries}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlExportGoogle.AddToLinkedControls({ucrReceiverDistrict, ucrReceiverElavation, ucrReceiverLatitude, ucrInputComboCountryMetadata, ucrReceiverLongititude, ucrReceiverStationName}, {rdoUpdateMetadata}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlExportGoogle.AddToLinkedControls({ucrInputComboCountry, ucrChkIncludeSummaryData, ucrInputDefinitionsID}, {rdoUploadSummaries}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True)
         DialogSize()
     End Sub
 
@@ -262,17 +227,14 @@ Public Class dlgExportClimaticDefinitions
         ucrReceiverStation.SetRCode(clsExportRinstatToBucketFunction, bReset)
         ucrReceiverDataYear.SetRCode(clsExportRinstatToBucketFunction, bReset)
         ucrReceiverDataYearMonth.SetRCode(clsExportRinstatToBucketFunction, bReset)
-        ucrReceiverMonth.SetRCode(clsExportRinstatToBucketFunction, bReset)
-        ucrReceiverRain.SetRCode(clsExportRinstatToBucketFunction, bReset)
         'ucrReceiverRainIndicator.SetRCode(clsExportRinstatToBucketFunction, bReset)
         'ucrReceiverExtremIndicator.SetRCode(clsExportRinstatToBucketFunction, bReset)
 
-        ucrReceiverYear.SetRCode(clsExportRinstatToBucketFunction, bReset)
         ucrSelectorExportDefinitions.SetRCode(clsExportRinstatToBucketFunction)
         ucrInputTokenPath.SetRCode(ClsGcsAuthFileFunction, bReset)
 
         ucrInputDefinitionsID.SetRCode(clsExportRinstatToBucketFunction, bReset)
-        ucrInputCountry.SetRCode(clsExportRinstatToBucketFunction, bReset)
+        ucrInputComboCountry.SetRCode(clsExportRinstatToBucketFunction, bReset)
         ucrChkIncludeSummaryData.SetRCode(clsExportRinstatToBucketFunction, bReset)
 
         ucrReceiverDistrict.SetRCode(clsUpdateMetadataInfoFunction, bReset)
@@ -280,13 +242,12 @@ Public Class dlgExportClimaticDefinitions
         ucrReceiverLatitude.SetRCode(clsUpdateMetadataInfoFunction, bReset)
         ucrReceiverLongititude.SetRCode(clsUpdateMetadataInfoFunction, bReset)
         ucrReceiverStationName.SetRCode(clsUpdateMetadataInfoFunction, bReset)
-        ucrInputCountryMetadata.SetRCode(clsUpdateMetadataInfoFunction, bReset)
+        ucrInputComboCountryMetadata.SetRCode(clsUpdateMetadataInfoFunction, bReset)
 
         If bReset Then
             ucrChkAnnualRainfall.SetRCode(clsDummyFunction, bReset)
             ucrChkAnnualTemp.SetRCode(clsDummyFunction, bReset)
             ucrChkCropSuccessProp.SetRCode(clsDummyFunction, bReset)
-            ucrChkExtremes.SetRCode(clsDummyFunction, bReset)
             ucrChkMonthlyTemp.SetRCode(clsDummyFunction, bReset)
             ucrChkSeasonStartProp.SetRCode(clsDummyFunction, bReset)
             ucrPnlExportGoogle.SetRCode(clsDummyFunction, bReset)
@@ -299,10 +260,9 @@ Public Class dlgExportClimaticDefinitions
         If rdoUploadSummaries.Checked Then
             ' Basic required fields
             Dim bRequiredFieldsFilled As Boolean = Not ucrReceiverStation.IsEmpty AndAlso
-                                               Not ucrReceiverYear.IsEmpty AndAlso
-                                               Not ucrInputCountry.IsEmpty AndAlso
-                                               Not ucrInputDefinitionsID.IsEmpty AndAlso
-                                               Not ucrInputTokenPath.IsEmpty
+                                           Not ucrInputComboCountry.IsEmpty AndAlso
+                                           Not ucrInputDefinitionsID.IsEmpty AndAlso
+                                           Not ucrInputTokenPath.IsEmpty
 
             If bRequiredFieldsFilled Then
                 ' Individual validity checks
@@ -310,13 +270,13 @@ Public Class dlgExportClimaticDefinitions
                 Dim bCropOK As Boolean = Not bCropChecked OrElse Not ucrReceiverCropData.IsEmpty
 
                 Dim bAnnualRainOK As Boolean = Not ucrChkAnnualRainfall.Checked OrElse
-                                           (Not ucrReceiverRain.IsEmpty AndAlso Not ucrReceiverDataYear.IsEmpty)
+                                       (Not ucrReceiverDataYear.IsEmpty)
 
                 Dim bAnnualTempOK As Boolean = Not ucrChkAnnualTemp.Checked OrElse
-                                           Not ucrReceiverDataYear.IsEmpty
+                                       Not ucrReceiverDataYear.IsEmpty
 
                 Dim bMonthlyTempOK As Boolean = Not ucrChkMonthlyTemp.Checked OrElse
-                                            (Not ucrReceiverMonth.IsEmpty AndAlso Not ucrReceiverDataYearMonth.IsEmpty)
+                                        (Not ucrReceiverDataYearMonth.IsEmpty)
 
                 ' Final OK decision
                 If bCropOK AndAlso bAnnualRainOK AndAlso bAnnualTempOK AndAlso bMonthlyTempOK Then
@@ -331,8 +291,8 @@ Public Class dlgExportClimaticDefinitions
         Else
             ' Non-upload mode (metadata)
             If Not ucrReceiverStationName.IsEmpty AndAlso
-           Not ucrInputTokenPath.IsEmpty AndAlso
-           Not ucrInputCountryMetadata.IsEmpty Then
+       Not ucrInputTokenPath.IsEmpty AndAlso
+       Not ucrInputComboCountryMetadata.IsEmpty Then
                 ucrBase.OKEnabled(True)
             Else
                 ucrBase.OKEnabled(False)
@@ -342,7 +302,7 @@ Public Class dlgExportClimaticDefinitions
 
 
     Private Sub AddRemoveSummary()
-        If ucrChkAnnualRainfall.Checked OrElse ucrChkAnnualTemp.Checked OrElse ucrChkCropSuccessProp.Checked OrElse ucrChkExtremes.Checked OrElse ucrChkMonthlyTemp.Checked OrElse ucrChkSeasonStartProp.Checked Then
+        If ucrChkAnnualRainfall.Checked OrElse ucrChkAnnualTemp.Checked OrElse ucrChkCropSuccessProp.Checked OrElse ucrChkMonthlyTemp.Checked OrElse ucrChkSeasonStartProp.Checked Then
             clsExportRinstatToBucketFunction.AddParameter("summaries", clsRFunctionParameter:=clsSummariesFunction, iPosition:=0)
         Else
             clsExportRinstatToBucketFunction.RemoveParameterByName("summaries")
@@ -358,7 +318,7 @@ Public Class dlgExportClimaticDefinitions
 
     Private Sub cmdDefine_Click(sender As Object, e As EventArgs) Handles cmdDefine.Click
         sdgDefineAnnualRainfall.SetRCode(clsNewReformatCropSuccessFunction:=clsReformatCropSuccessFunction, clsNewReformatSeasonStartFunction:=clsReformatSeasonStartFunction, clsNewReformatMonthlyTempSummaries:=clsReformatMonthlyTempSummaries,
-                                      clsNewReforMattAnnualSummaries:=clsReforMattAnnualSummariesFunction, clsNewReformatTempSummariesFunction:=clsReformatTempSummariesFunction, clsNewExportRinstatToBucketFunction:=clsExportRinstatToBucketFunction, bReset:=bResetSubdialog)
+                                  clsNewReforMattAnnualSummaries:=clsReforMattAnnualSummariesFunction, clsNewReformatTempSummariesFunction:=clsReformatTempSummariesFunction, clsNewExportRinstatToBucketFunction:=clsExportRinstatToBucketFunction, bReset:=bResetSubdialog)
         sdgDefineAnnualRainfall.ShowDialog()
         bResetSubdialog = False
     End Sub
@@ -371,8 +331,6 @@ Public Class dlgExportClimaticDefinitions
         End If
         AddRemoveSummary()
         EnableDisableDefineButton()
-        AddExtremeTminIndicatorParam()
-        AddExtremeTmaxIndicatorParam()
         AddExtremeRainParameter()
         TestOkEnabled()
     End Sub
@@ -399,16 +357,6 @@ Public Class dlgExportClimaticDefinitions
         TestOkEnabled()
     End Sub
 
-    Private Sub ucrChkExtremes_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkExtremes.ControlValueChanged
-        If ucrChkExtremes.Checked Then
-            clsSummariesFunction.AddParameter("extreme", Chr(34) & "extremes" & Chr(34), iPosition:=3, bIncludeArgumentName:=False)
-        Else
-            clsSummariesFunction.RemoveParameterByName("extreme")
-        End If
-        AddRemoveSummary()
-        EnableDisableDefineButton()
-    End Sub
-
     Private Sub ucrChkMonthlyTemp_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkMonthlyTemp.ControlValueChanged
         If ucrChkMonthlyTemp.Checked Then
             clsSummariesFunction.AddParameter("month_temp", Chr(34) & "monthly_temperature" & Chr(34), iPosition:=4, bIncludeArgumentName:=False)
@@ -431,9 +379,9 @@ Public Class dlgExportClimaticDefinitions
         TestOkEnabled()
     End Sub
 
-    Private Sub ucrInputCountry_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputCountry.ControlValueChanged
-        If Not ucrInputCountry.IsEmpty Then
-            clsExportRinstatToBucketFunction.AddParameter("country", Chr(34) & ucrInputCountry.GetText & Chr(34), iPosition:=20)
+    Private Sub ucrInputCountry_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputComboCountry.ControlValueChanged
+        If Not ucrInputComboCountry.IsEmpty Then
+            clsExportRinstatToBucketFunction.AddParameter("country", Chr(34) & ucrInputComboCountry.GetText & Chr(34), iPosition:=20)
         Else
             clsExportRinstatToBucketFunction.RemoveParameterByName("country")
         End If
@@ -450,26 +398,19 @@ Public Class dlgExportClimaticDefinitions
     Private Sub EnableDisableDefineButton()
         ucrReceiverDataYearMonth.Visible = False
         ucrReceiverDataYear.Visible = False
-        ucrReceiverRain.Visible = False
         ucrReceiverRainIndicator.Visible = False
         ucrReceiverExtremIndicator.Visible = False
         ucrReceiverCropData.Visible = False
         If rdoUploadSummaries.Checked Then
             ucrReceiverDataYearMonth.Visible = ucrChkMonthlyTemp.Checked
             ucrReceiverDataYear.Visible = ucrChkAnnualRainfall.Checked OrElse ucrChkAnnualTemp.Checked
-            ucrReceiverRain.Visible = ucrChkAnnualRainfall.Checked
-            ucrReceiverExtremeTminIndicator.Visible = ucrChkAnnualRainfall.Checked
-            ucrReceiverExtremeTmaxIndicator.Visible = ucrChkAnnualRainfall.Checked
             ucrReceiverExtremIndicator.Visible = ucrChkAnnualRainfall.Checked
             ucrReceiverRainIndicator.Visible = ucrChkAnnualRainfall.Checked
-            ucrReceiverCropData.Visible = ucrChkCropSuccessProp.Checked
+            ucrReceiverCropData.Visible = ucrChkCropSuccessProp.Checked OrElse ucrChkSeasonStartProp.Checked
         Else
             ucrReceiverDataYearMonth.Visible = False
             ucrReceiverDataYear.Visible = False
-            ucrReceiverRain.Visible = False
             ucrReceiverRainIndicator.Visible = False
-            ucrReceiverExtremeTminIndicator.Visible = False
-            ucrReceiverExtremeTmaxIndicator.Visible = False
             ucrReceiverExtremIndicator.Visible = False
             ucrReceiverCropData.Visible = False
         End If
@@ -517,11 +458,11 @@ Public Class dlgExportClimaticDefinitions
 
     Private Sub DialogSize()
         If rdoUpdateMetadata.Checked Then
-            Me.Size = New Size(475, 465)
-            Me.ucrBase.Location = New Point(4, 370)
+            Me.Size = New Size(475, 455)
+            Me.ucrBase.Location = New Point(14, 360)
         Else
-            Me.Size = New Size(475, 610)
-            Me.ucrBase.Location = New Point(5, 520)
+            Me.Size = New Size(475, 570)
+            Me.ucrBase.Location = New Point(14, 475)
         End If
     End Sub
 
@@ -531,50 +472,17 @@ Public Class dlgExportClimaticDefinitions
         clsUpdateMetadataInfoFunction.AddParameter("metadata_data", clsRFunctionParameter:=clsGetDataFrameFunction, iPosition:=0)
     End Sub
 
-    Private Sub ucrReceiverData_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverRain.ControlContentsChanged, ucrReceiverCropData.ControlContentsChanged, ucrReceiverDataYearMonth.ControlContentsChanged, ucrReceiverDataYear.ControlContentsChanged, ucrReceiverStation.ControlContentsChanged, ucrInputTokenPath.ControlContentsChanged, ucrInputCountryMetadata.ControlContentsChanged,
-            ucrReceiverMonth.ControlContentsChanged, ucrReceiverYear.ControlContentsChanged, ucrChkSeasonStartProp.ControlContentsChanged, ucrInputCountry.ControlContentsChanged, ucrInputDefinitionsID.ControlContentsChanged, ucrChkIncludeSummaryData.ControlContentsChanged, ucrReceiverLongititude.ControlContentsChanged, ucrReceiverLatitude.ControlContentsChanged,
-            ucrChkMonthlyTemp.ControlContentsChanged, ucrChkCropSuccessProp.ControlContentsChanged, ucrChkAnnualTemp.ControlContentsChanged, ucrChkAnnualRainfall.ControlContentsChanged, ucrSelectorExportDefinitions.ControlContentsChanged, ucrReceiverElavation.ControlContentsChanged, ucrReceiverDistrict.ControlContentsChanged, ucrReceiverStationName.ControlContentsChanged
+    Private Sub ucrReceiverData_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverCropData.ControlContentsChanged, ucrReceiverDataYearMonth.ControlContentsChanged, ucrReceiverDataYear.ControlContentsChanged, ucrReceiverStation.ControlContentsChanged, ucrInputTokenPath.ControlContentsChanged, ucrChkSeasonStartProp.ControlContentsChanged, ucrInputDefinitionsID.ControlContentsChanged, ucrChkIncludeSummaryData.ControlContentsChanged, ucrReceiverLongititude.ControlContentsChanged, ucrReceiverLatitude.ControlContentsChanged, ucrInputComboCountryMetadata.ControlContentsChanged, ucrInputComboCountry.ControlContentsChanged,
+        ucrChkMonthlyTemp.ControlContentsChanged, ucrChkCropSuccessProp.ControlContentsChanged, ucrChkAnnualTemp.ControlContentsChanged, ucrChkAnnualRainfall.ControlContentsChanged, ucrSelectorExportDefinitions.ControlContentsChanged, ucrReceiverElavation.ControlContentsChanged, ucrReceiverDistrict.ControlContentsChanged, ucrReceiverStationName.ControlContentsChanged
         TestOkEnabled()
     End Sub
 
-    Private Sub ucrInputCountryMetadata_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputCountryMetadata.ControlValueChanged
-        If Not ucrInputCountryMetadata.IsEmpty Then
-            clsUpdateMetadataInfoFunction.AddParameter("country", Chr(34) & ucrInputCountryMetadata.GetText & Chr(34), iPosition:=6)
+    Private Sub ucrInputCountryMetadata_ControlValueChanged(ucrChangedControl As ucrCore)
+        If Not ucrInputComboCountryMetadata.IsEmpty Then
+            clsUpdateMetadataInfoFunction.AddParameter("country", Chr(34) & ucrInputComboCountryMetadata.GetText & Chr(34), iPosition:=6)
         Else
             clsUpdateMetadataInfoFunction.RemoveParameterByName("country")
         End If
-    End Sub
-
-    Private Sub AddExtremeTminIndicatorParam()
-        If ucrChkAnnualRainfall.Checked Then
-            If Not ucrReceiverExtremeTminIndicator.IsEmpty() Then
-                clsExportRinstatToBucketFunction.AddParameter("extreme_tmin_column", ucrReceiverExtremeTminIndicator.GetVariableNames(), iPosition:=15)
-            Else
-                clsExportRinstatToBucketFunction.RemoveParameterByName("extreme_tmin_column")
-            End If
-        Else
-            clsExportRinstatToBucketFunction.RemoveParameterByName("extreme_tmin_column")
-        End If
-    End Sub
-
-    Private Sub AddExtremeTmaxIndicatorParam()
-        If ucrChkAnnualRainfall.Checked Then
-            If Not ucrReceiverExtremeTmaxIndicator.IsEmpty() Then
-                clsExportRinstatToBucketFunction.AddParameter("extreme_tmax_column", ucrReceiverExtremeTmaxIndicator.GetVariableNames(), iPosition:=16)
-            Else
-                clsExportRinstatToBucketFunction.RemoveParameterByName("extreme_tmax_column")
-            End If
-        Else
-            clsExportRinstatToBucketFunction.RemoveParameterByName("extreme_tmax_column")
-        End If
-    End Sub
-
-    Private Sub ucrReceiverExtremeTminIndicator_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverExtremeTminIndicator.ControlValueChanged
-        AddExtremeTminIndicatorParam()
-    End Sub
-
-    Private Sub ucrReceiverExtremeTmaxIndicator_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverExtremeTmaxIndicator.ControlValueChanged
-        AddExtremeTmaxIndicatorParam()
     End Sub
 
     Private Sub AddExtremeRainParameter()

--- a/instat/sdgDefineAnnualRainfall.Designer.vb
+++ b/instat/sdgDefineAnnualRainfall.Designer.vb
@@ -20,7 +20,7 @@ Partial Class sdgDefineAnnualRainfall
     'NOTE: The following procedure is required by the Windows Form Designer
     'It can be modified using the Windows Form Designer.  
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         Me.lblSeasonPlantingDay = New System.Windows.Forms.Label()
         Me.tbSummaries = New System.Windows.Forms.TabControl()
@@ -122,16 +122,6 @@ Partial Class sdgDefineAnnualRainfall
         Me.ucrReceiverMonthlyTemp = New instat.ucrReceiverSingle()
         Me.ucrSelecetorMonthlyTemp = New instat.ucrSelectorByDataFrame()
         Me.ucrBase = New instat.ucrButtonsSubdialogue()
-        Me.lblExtremeMinTemp = New System.Windows.Forms.Label()
-        Me.ucrReceiverExtremeMinTemp = New instat.ucrReceiverSingle()
-        Me.lblExtremeMaxTemp = New System.Windows.Forms.Label()
-        Me.ucrReceiverExtremeMaxTemp = New instat.ucrReceiverSingle()
-        Me.lblLongestRainfallSpell = New System.Windows.Forms.Label()
-        Me.ucrReceiverLongestRainfallSpell = New instat.ucrReceiverSingle()
-        Me.lblLongestMinTempSpell = New System.Windows.Forms.Label()
-        Me.ucrReceiverLongestMinTempSpell = New instat.ucrReceiverSingle()
-        Me.lblLongestMaxTempSpell = New System.Windows.Forms.Label()
-        Me.ucrReceiverLongestMaxTempSpell = New instat.ucrReceiverSingle()
         Me.tbSummaries.SuspendLayout()
         Me.tbAnnualRainfall.SuspendLayout()
         Me.tbCropSuccessProp.SuspendLayout()
@@ -166,16 +156,6 @@ Partial Class sdgDefineAnnualRainfall
         '
         'tbAnnualRainfall
         '
-        Me.tbAnnualRainfall.Controls.Add(Me.lblLongestMaxTempSpell)
-        Me.tbAnnualRainfall.Controls.Add(Me.ucrReceiverLongestMaxTempSpell)
-        Me.tbAnnualRainfall.Controls.Add(Me.lblLongestMinTempSpell)
-        Me.tbAnnualRainfall.Controls.Add(Me.ucrReceiverLongestMinTempSpell)
-        Me.tbAnnualRainfall.Controls.Add(Me.lblLongestRainfallSpell)
-        Me.tbAnnualRainfall.Controls.Add(Me.ucrReceiverLongestRainfallSpell)
-        Me.tbAnnualRainfall.Controls.Add(Me.lblExtremeMaxTemp)
-        Me.tbAnnualRainfall.Controls.Add(Me.ucrReceiverExtremeMaxTemp)
-        Me.tbAnnualRainfall.Controls.Add(Me.lblExtremeMinTemp)
-        Me.tbAnnualRainfall.Controls.Add(Me.ucrReceiverExtremeMinTemp)
         Me.tbAnnualRainfall.Controls.Add(Me.lblExtremRain)
         Me.tbAnnualRainfall.Controls.Add(Me.ucrReceiverExtremRian)
         Me.tbAnnualRainfall.Controls.Add(Me.lblStartRainStatus)
@@ -246,7 +226,7 @@ Partial Class sdgDefineAnnualRainfall
         'lblStartRainStatus
         '
         Me.lblStartRainStatus.AutoSize = True
-        Me.lblStartRainStatus.Location = New System.Drawing.Point(280, 502)
+        Me.lblStartRainStatus.Location = New System.Drawing.Point(396, 502)
         Me.lblStartRainStatus.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblStartRainStatus.Name = "lblStartRainStatus"
         Me.lblStartRainStatus.Size = New System.Drawing.Size(144, 20)
@@ -257,7 +237,7 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverStartRainStatus.AutoSize = True
         Me.ucrReceiverStartRainStatus.frmParent = Nothing
-        Me.ucrReceiverStartRainStatus.Location = New System.Drawing.Point(280, 528)
+        Me.ucrReceiverStartRainStatus.Location = New System.Drawing.Point(396, 528)
         Me.ucrReceiverStartRainStatus.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverStartRainStatus.Name = "ucrReceiverStartRainStatus"
         Me.ucrReceiverStartRainStatus.Selector = Nothing
@@ -269,7 +249,7 @@ Partial Class sdgDefineAnnualRainfall
         'lblEndRainStatus
         '
         Me.lblEndRainStatus.AutoSize = True
-        Me.lblEndRainStatus.Location = New System.Drawing.Point(280, 565)
+        Me.lblEndRainStatus.Location = New System.Drawing.Point(396, 565)
         Me.lblEndRainStatus.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblEndRainStatus.Name = "lblEndRainStatus"
         Me.lblEndRainStatus.Size = New System.Drawing.Size(138, 20)
@@ -280,7 +260,7 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverEndRainStatus.AutoSize = True
         Me.ucrReceiverEndRainStatus.frmParent = Nothing
-        Me.ucrReceiverEndRainStatus.Location = New System.Drawing.Point(280, 589)
+        Me.ucrReceiverEndRainStatus.Location = New System.Drawing.Point(396, 589)
         Me.ucrReceiverEndRainStatus.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverEndRainStatus.Name = "ucrReceiverEndRainStatus"
         Me.ucrReceiverEndRainStatus.Selector = Nothing
@@ -292,7 +272,7 @@ Partial Class sdgDefineAnnualRainfall
         'lblEndSeasonStatus
         '
         Me.lblEndSeasonStatus.AutoSize = True
-        Me.lblEndSeasonStatus.Location = New System.Drawing.Point(280, 628)
+        Me.lblEndSeasonStatus.Location = New System.Drawing.Point(396, 628)
         Me.lblEndSeasonStatus.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblEndSeasonStatus.Name = "lblEndSeasonStatus"
         Me.lblEndSeasonStatus.Size = New System.Drawing.Size(152, 20)
@@ -303,7 +283,7 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverEndSeasonStatus.AutoSize = True
         Me.ucrReceiverEndSeasonStatus.frmParent = Nothing
-        Me.ucrReceiverEndSeasonStatus.Location = New System.Drawing.Point(276, 649)
+        Me.ucrReceiverEndSeasonStatus.Location = New System.Drawing.Point(392, 649)
         Me.ucrReceiverEndSeasonStatus.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverEndSeasonStatus.Name = "ucrReceiverEndSeasonStatus"
         Me.ucrReceiverEndSeasonStatus.Selector = Nothing
@@ -315,7 +295,7 @@ Partial Class sdgDefineAnnualRainfall
         'lblRainyDaysYear
         '
         Me.lblRainyDaysYear.AutoSize = True
-        Me.lblRainyDaysYear.Location = New System.Drawing.Point(280, 132)
+        Me.lblRainyDaysYear.Location = New System.Drawing.Point(396, 132)
         Me.lblRainyDaysYear.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblRainyDaysYear.Name = "lblRainyDaysYear"
         Me.lblRainyDaysYear.Size = New System.Drawing.Size(151, 20)
@@ -326,7 +306,7 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverRainDaysYear.AutoSize = True
         Me.ucrReceiverRainDaysYear.frmParent = Nothing
-        Me.ucrReceiverRainDaysYear.Location = New System.Drawing.Point(280, 155)
+        Me.ucrReceiverRainDaysYear.Location = New System.Drawing.Point(396, 155)
         Me.ucrReceiverRainDaysYear.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverRainDaysYear.Name = "ucrReceiverRainDaysYear"
         Me.ucrReceiverRainDaysYear.Selector = Nothing
@@ -338,7 +318,7 @@ Partial Class sdgDefineAnnualRainfall
         'lblNoRainDaysSeason
         '
         Me.lblNoRainDaysSeason.AutoSize = True
-        Me.lblNoRainDaysSeason.Location = New System.Drawing.Point(280, 63)
+        Me.lblNoRainDaysSeason.Location = New System.Drawing.Point(396, 63)
         Me.lblNoRainDaysSeason.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblNoRainDaysSeason.Name = "lblNoRainDaysSeason"
         Me.lblNoRainDaysSeason.Size = New System.Drawing.Size(172, 20)
@@ -348,7 +328,7 @@ Partial Class sdgDefineAnnualRainfall
         'lblSeasonalLength
         '
         Me.lblSeasonalLength.AutoSize = True
-        Me.lblSeasonalLength.Location = New System.Drawing.Point(280, 191)
+        Me.lblSeasonalLength.Location = New System.Drawing.Point(396, 191)
         Me.lblSeasonalLength.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblSeasonalLength.Name = "lblSeasonalLength"
         Me.lblSeasonalLength.Size = New System.Drawing.Size(134, 20)
@@ -378,7 +358,7 @@ Partial Class sdgDefineAnnualRainfall
         'lblEndSeasonDate
         '
         Me.lblEndSeasonDate.AutoSize = True
-        Me.lblEndSeasonDate.Location = New System.Drawing.Point(280, 438)
+        Me.lblEndSeasonDate.Location = New System.Drawing.Point(396, 438)
         Me.lblEndSeasonDate.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblEndSeasonDate.Name = "lblEndSeasonDate"
         Me.lblEndSeasonDate.Size = New System.Drawing.Size(146, 20)
@@ -388,7 +368,7 @@ Partial Class sdgDefineAnnualRainfall
         'lblEndSeasonDOY
         '
         Me.lblEndSeasonDOY.AutoSize = True
-        Me.lblEndSeasonDOY.Location = New System.Drawing.Point(280, 385)
+        Me.lblEndSeasonDOY.Location = New System.Drawing.Point(396, 385)
         Me.lblEndSeasonDOY.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblEndSeasonDOY.Name = "lblEndSeasonDOY"
         Me.lblEndSeasonDOY.Size = New System.Drawing.Size(146, 20)
@@ -398,7 +378,7 @@ Partial Class sdgDefineAnnualRainfall
         'lblEndRainDate
         '
         Me.lblEndRainDate.AutoSize = True
-        Me.lblEndRainDate.Location = New System.Drawing.Point(280, 318)
+        Me.lblEndRainDate.Location = New System.Drawing.Point(396, 318)
         Me.lblEndRainDate.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblEndRainDate.Name = "lblEndRainDate"
         Me.lblEndRainDate.Size = New System.Drawing.Size(124, 20)
@@ -408,7 +388,7 @@ Partial Class sdgDefineAnnualRainfall
         'lblEndRainsDOY
         '
         Me.lblEndRainsDOY.AutoSize = True
-        Me.lblEndRainsDOY.Location = New System.Drawing.Point(280, 257)
+        Me.lblEndRainsDOY.Location = New System.Drawing.Point(396, 257)
         Me.lblEndRainsDOY.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblEndRainsDOY.Name = "lblEndRainsDOY"
         Me.lblEndRainsDOY.Size = New System.Drawing.Size(124, 20)
@@ -511,7 +491,7 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverEndSeasonDate.AutoSize = True
         Me.ucrReceiverEndSeasonDate.frmParent = Nothing
-        Me.ucrReceiverEndSeasonDate.Location = New System.Drawing.Point(280, 465)
+        Me.ucrReceiverEndSeasonDate.Location = New System.Drawing.Point(396, 465)
         Me.ucrReceiverEndSeasonDate.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverEndSeasonDate.Name = "ucrReceiverEndSeasonDate"
         Me.ucrReceiverEndSeasonDate.Selector = Nothing
@@ -524,7 +504,7 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverEndSeasonDOY.AutoSize = True
         Me.ucrReceiverEndSeasonDOY.frmParent = Nothing
-        Me.ucrReceiverEndSeasonDOY.Location = New System.Drawing.Point(280, 405)
+        Me.ucrReceiverEndSeasonDOY.Location = New System.Drawing.Point(396, 405)
         Me.ucrReceiverEndSeasonDOY.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverEndSeasonDOY.Name = "ucrReceiverEndSeasonDOY"
         Me.ucrReceiverEndSeasonDOY.Selector = Nothing
@@ -537,7 +517,7 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverEndRainsDOY.AutoSize = True
         Me.ucrReceiverEndRainsDOY.frmParent = Nothing
-        Me.ucrReceiverEndRainsDOY.Location = New System.Drawing.Point(280, 283)
+        Me.ucrReceiverEndRainsDOY.Location = New System.Drawing.Point(396, 283)
         Me.ucrReceiverEndRainsDOY.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverEndRainsDOY.Name = "ucrReceiverEndRainsDOY"
         Me.ucrReceiverEndRainsDOY.Selector = Nothing
@@ -550,7 +530,7 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverEndRainsDate.AutoSize = True
         Me.ucrReceiverEndRainsDate.frmParent = Nothing
-        Me.ucrReceiverEndRainsDate.Location = New System.Drawing.Point(280, 346)
+        Me.ucrReceiverEndRainsDate.Location = New System.Drawing.Point(396, 346)
         Me.ucrReceiverEndRainsDate.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverEndRainsDate.Name = "ucrReceiverEndRainsDate"
         Me.ucrReceiverEndRainsDate.Selector = Nothing
@@ -563,7 +543,7 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverSeasonalLength.AutoSize = True
         Me.ucrReceiverSeasonalLength.frmParent = Nothing
-        Me.ucrReceiverSeasonalLength.Location = New System.Drawing.Point(280, 218)
+        Me.ucrReceiverSeasonalLength.Location = New System.Drawing.Point(396, 218)
         Me.ucrReceiverSeasonalLength.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverSeasonalLength.Name = "ucrReceiverSeasonalLength"
         Me.ucrReceiverSeasonalLength.Selector = Nothing
@@ -576,7 +556,7 @@ Partial Class sdgDefineAnnualRainfall
         '
         Me.ucrReceiverRainDaysSeason.AutoSize = True
         Me.ucrReceiverRainDaysSeason.frmParent = Nothing
-        Me.ucrReceiverRainDaysSeason.Location = New System.Drawing.Point(280, 89)
+        Me.ucrReceiverRainDaysSeason.Location = New System.Drawing.Point(396, 89)
         Me.ucrReceiverRainDaysSeason.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverRainDaysSeason.Name = "ucrReceiverRainDaysSeason"
         Me.ucrReceiverRainDaysSeason.Selector = Nothing
@@ -1393,121 +1373,6 @@ Partial Class sdgDefineAnnualRainfall
         Me.ucrBase.Size = New System.Drawing.Size(336, 46)
         Me.ucrBase.TabIndex = 35
         '
-        'lblExtremeMinTemp
-        '
-        Me.lblExtremeMinTemp.AutoSize = True
-        Me.lblExtremeMinTemp.Location = New System.Drawing.Point(503, 63)
-        Me.lblExtremeMinTemp.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblExtremeMinTemp.Name = "lblExtremeMinTemp"
-        Me.lblExtremeMinTemp.Size = New System.Drawing.Size(234, 20)
-        Me.lblExtremeMinTemp.TabIndex = 35
-        Me.lblExtremeMinTemp.Text = "Extreme Minimum Temperature:"
-        '
-        'ucrReceiverExtremeMinTemp
-        '
-        Me.ucrReceiverExtremeMinTemp.AutoSize = True
-        Me.ucrReceiverExtremeMinTemp.frmParent = Me
-        Me.ucrReceiverExtremeMinTemp.Location = New System.Drawing.Point(503, 89)
-        Me.ucrReceiverExtremeMinTemp.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverExtremeMinTemp.Name = "ucrReceiverExtremeMinTemp"
-        Me.ucrReceiverExtremeMinTemp.Selector = Nothing
-        Me.ucrReceiverExtremeMinTemp.Size = New System.Drawing.Size(180, 38)
-        Me.ucrReceiverExtremeMinTemp.strNcFilePath = ""
-        Me.ucrReceiverExtremeMinTemp.TabIndex = 36
-        Me.ucrReceiverExtremeMinTemp.ucrSelector = Nothing
-        '
-        'lblExtremeMaxTemp
-        '
-        Me.lblExtremeMaxTemp.AutoSize = True
-        Me.lblExtremeMaxTemp.Location = New System.Drawing.Point(503, 128)
-        Me.lblExtremeMaxTemp.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblExtremeMaxTemp.Name = "lblExtremeMaxTemp"
-        Me.lblExtremeMaxTemp.Size = New System.Drawing.Size(238, 20)
-        Me.lblExtremeMaxTemp.TabIndex = 37
-        Me.lblExtremeMaxTemp.Text = "Extreme Maximum Temperature:"
-        '
-        'ucrReceiverExtremeMaxTemp
-        '
-        Me.ucrReceiverExtremeMaxTemp.AutoSize = True
-        Me.ucrReceiverExtremeMaxTemp.frmParent = Me
-        Me.ucrReceiverExtremeMaxTemp.Location = New System.Drawing.Point(503, 154)
-        Me.ucrReceiverExtremeMaxTemp.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverExtremeMaxTemp.Name = "ucrReceiverExtremeMaxTemp"
-        Me.ucrReceiverExtremeMaxTemp.Selector = Nothing
-        Me.ucrReceiverExtremeMaxTemp.Size = New System.Drawing.Size(180, 38)
-        Me.ucrReceiverExtremeMaxTemp.strNcFilePath = ""
-        Me.ucrReceiverExtremeMaxTemp.TabIndex = 38
-        Me.ucrReceiverExtremeMaxTemp.ucrSelector = Nothing
-        '
-        'lblLongestRainfallSpell
-        '
-        Me.lblLongestRainfallSpell.AutoSize = True
-        Me.lblLongestRainfallSpell.Location = New System.Drawing.Point(503, 192)
-        Me.lblLongestRainfallSpell.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblLongestRainfallSpell.Name = "lblLongestRainfallSpell"
-        Me.lblLongestRainfallSpell.Size = New System.Drawing.Size(167, 20)
-        Me.lblLongestRainfallSpell.TabIndex = 39
-        Me.lblLongestRainfallSpell.Text = "Longest Rainfall Spell:"
-        '
-        'ucrReceiverLongestRainfallSpell
-        '
-        Me.ucrReceiverLongestRainfallSpell.AutoSize = True
-        Me.ucrReceiverLongestRainfallSpell.frmParent = Me
-        Me.ucrReceiverLongestRainfallSpell.Location = New System.Drawing.Point(503, 218)
-        Me.ucrReceiverLongestRainfallSpell.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverLongestRainfallSpell.Name = "ucrReceiverLongestRainfallSpell"
-        Me.ucrReceiverLongestRainfallSpell.Selector = Nothing
-        Me.ucrReceiverLongestRainfallSpell.Size = New System.Drawing.Size(180, 38)
-        Me.ucrReceiverLongestRainfallSpell.strNcFilePath = ""
-        Me.ucrReceiverLongestRainfallSpell.TabIndex = 40
-        Me.ucrReceiverLongestRainfallSpell.ucrSelector = Nothing
-        '
-        'lblLongestMinTempSpell
-        '
-        Me.lblLongestMinTempSpell.AutoSize = True
-        Me.lblLongestMinTempSpell.Location = New System.Drawing.Point(503, 257)
-        Me.lblLongestMinTempSpell.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblLongestMinTempSpell.Name = "lblLongestMinTempSpell"
-        Me.lblLongestMinTempSpell.Size = New System.Drawing.Size(272, 20)
-        Me.lblLongestMinTempSpell.TabIndex = 41
-        Me.lblLongestMinTempSpell.Text = "Longest Minimum Temperature Spell:"
-        '
-        'ucrReceiverLongestMinTempSpell
-        '
-        Me.ucrReceiverLongestMinTempSpell.AutoSize = True
-        Me.ucrReceiverLongestMinTempSpell.frmParent = Me
-        Me.ucrReceiverLongestMinTempSpell.Location = New System.Drawing.Point(503, 283)
-        Me.ucrReceiverLongestMinTempSpell.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverLongestMinTempSpell.Name = "ucrReceiverLongestMinTempSpell"
-        Me.ucrReceiverLongestMinTempSpell.Selector = Nothing
-        Me.ucrReceiverLongestMinTempSpell.Size = New System.Drawing.Size(180, 38)
-        Me.ucrReceiverLongestMinTempSpell.strNcFilePath = ""
-        Me.ucrReceiverLongestMinTempSpell.TabIndex = 42
-        Me.ucrReceiverLongestMinTempSpell.ucrSelector = Nothing
-        '
-        'lblLongestMaxTempSpell
-        '
-        Me.lblLongestMaxTempSpell.AutoSize = True
-        Me.lblLongestMaxTempSpell.Location = New System.Drawing.Point(503, 320)
-        Me.lblLongestMaxTempSpell.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblLongestMaxTempSpell.Name = "lblLongestMaxTempSpell"
-        Me.lblLongestMaxTempSpell.Size = New System.Drawing.Size(276, 20)
-        Me.lblLongestMaxTempSpell.TabIndex = 43
-        Me.lblLongestMaxTempSpell.Text = "Longest Maximum Temperature Spell:"
-        '
-        'ucrReceiverLongestMaxTempSpell
-        '
-        Me.ucrReceiverLongestMaxTempSpell.AutoSize = True
-        Me.ucrReceiverLongestMaxTempSpell.frmParent = Me
-        Me.ucrReceiverLongestMaxTempSpell.Location = New System.Drawing.Point(503, 346)
-        Me.ucrReceiverLongestMaxTempSpell.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverLongestMaxTempSpell.Name = "ucrReceiverLongestMaxTempSpell"
-        Me.ucrReceiverLongestMaxTempSpell.Selector = Nothing
-        Me.ucrReceiverLongestMaxTempSpell.Size = New System.Drawing.Size(180, 38)
-        Me.ucrReceiverLongestMaxTempSpell.strNcFilePath = ""
-        Me.ucrReceiverLongestMaxTempSpell.TabIndex = 44
-        Me.ucrReceiverLongestMaxTempSpell.ucrSelector = Nothing
-        '
         'sdgDefineAnnualRainfall
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(9.0!, 20.0!)
@@ -1639,14 +1504,4 @@ Partial Class sdgDefineAnnualRainfall
     Friend WithEvents ucrReceiverPropSuccessNoStart As ucrReceiverSingle
     Friend WithEvents lblExtremRain As Label
     Friend WithEvents ucrReceiverExtremRian As ucrReceiverSingle
-    Friend WithEvents lblLongestMaxTempSpell As Label
-    Friend WithEvents ucrReceiverLongestMaxTempSpell As ucrReceiverSingle
-    Friend WithEvents lblLongestMinTempSpell As Label
-    Friend WithEvents ucrReceiverLongestMinTempSpell As ucrReceiverSingle
-    Friend WithEvents lblLongestRainfallSpell As Label
-    Friend WithEvents ucrReceiverLongestRainfallSpell As ucrReceiverSingle
-    Friend WithEvents lblExtremeMaxTemp As Label
-    Friend WithEvents ucrReceiverExtremeMaxTemp As ucrReceiverSingle
-    Friend WithEvents lblExtremeMinTemp As Label
-    Friend WithEvents ucrReceiverExtremeMinTemp As ucrReceiverSingle
 End Class

--- a/instat/sdgDefineAnnualRainfall.vb
+++ b/instat/sdgDefineAnnualRainfall.vb
@@ -45,886 +45,854 @@ Public Class sdgDefineAnnualRainfall
     End Sub
 
     Public Sub InitialiseControls()
-        Dim kvpAnnualRain As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("annual_rain_col", {"annual_rainfall", "annual_rain", "annual_precip", "annual_precipitation", "annual_rr", "annual_prec", "annual_prcp", "sum_rainfall", "sum_rain", "sum_precip", "sum_precipitation", "sum_rr", "sum_pre", "sum_prcp"}.ToList())
-        Dim kvpSeasonalRain As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("seasonal_rain_col", {"seasonal_rainfall", "seasonal_rain", "seasonal_precip", "seasonal_precipitation", "seasonal_rr", "seasonal_prec", "seasonal_prcp"}.ToList())
-        Dim kvpRainDaysYear As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("n_rain_col", {"annual_rainday", "sum_rainday"}.ToList())
-        Dim kvpRainDaysSeason As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("n_seasonal_rain_col", {"seasonal_rainday"}.ToList())
-        Dim kvpSeasonalLength As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("season_length_col", {"length"}.ToList())
-        Dim kvpStartRainDOY As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("start_rains_doy_col", {"start_rain"}.ToList())
-        Dim kvpStartRainDate As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("start_rains_date_col", {"start_rain_date"}.ToList())
-        Dim kvpEndRainDOY As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_rains_doy_col", {"end_rains"}.ToList())
-        Dim kvpEndRainDate As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_rains_date_col", {"end_rains_date"}.ToList())
-        Dim kvpEndSeasonDOY As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_season_doy_col", {"end_season"}.ToList())
-        Dim kvpEndSeasonDate As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_season_date_col", {"end_season_date"}.ToList())
-        Dim kvpStartRainStatus As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("start_rains_status_column", {"start_rain_status"}.ToList())
-        Dim kvpEndRainStatus As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_rains_status_column", {"end_rains_status"}.ToList())
-        Dim kvpEndSeasonStatus As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_season_status_column", {"end_season_status"}.ToList())
+            Dim kvpAnnualRain As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("annual_rain_col", {"annual_rainfall", "annual_rain", "annual_precip", "annual_precipitation", "annual_rr", "annual_prec", "annual_prcp", "sum_rainfall", "sum_rain", "sum_precip", "sum_precipitation", "sum_rr", "sum_pre", "sum_prcp"}.ToList())
+            Dim kvpSeasonalRain As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("seasonal_rain_col", {"seasonal_rainfall", "seasonal_rain", "seasonal_precip", "seasonal_precipitation", "seasonal_rr", "seasonal_prec", "seasonal_prcp"}.ToList())
+            Dim kvpRainDaysYear As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("n_rain_col", {"annual_rainday", "sum_rainday"}.ToList())
+            Dim kvpRainDaysSeason As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("n_seasonal_rain_col", {"seasonal_rainday"}.ToList())
+            Dim kvpSeasonalLength As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("season_length_col", {"length"}.ToList())
+            Dim kvpStartRainDOY As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("start_rains_doy_col", {"start_rain"}.ToList())
+            Dim kvpStartRainDate As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("start_rains_date_col", {"start_rain_date"}.ToList())
+            Dim kvpEndRainDOY As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_rains_doy_col", {"end_rains"}.ToList())
+            Dim kvpEndRainDate As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_rains_date_col", {"end_rains_date"}.ToList())
+            Dim kvpEndSeasonDOY As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_season_doy_col", {"end_season"}.ToList())
+            Dim kvpEndSeasonDate As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_season_date_col", {"end_season_date"}.ToList())
+            Dim kvpStartRainStatus As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("start_rains_status_column", {"start_rain_status"}.ToList())
+            Dim kvpEndRainStatus As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_rains_status_column", {"end_rains_status"}.ToList())
+            Dim kvpEndSeasonStatus As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_season_status_column", {"end_season_status"}.ToList())
 
-        Dim kvpMeanMinTemp As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("mean_tmin_col", {"mean_tmin", "mean_tn", "mean_tempmin", "mean_tmp_min", "mean_tmpmin", "mean_temperature_min", "mean_min_temperature"}.ToList())
-        Dim kvpMinMinTemp As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("min_tmin_col", {"min_tmin", "min_tn", "min_tempmin", "min_tmp_min", "min_tmpmin", "min_temperature_min", "min_min_temperature"}.ToList())
-        Dim kvpMaxMinTemp As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("max_tmin_col", {"max_tmin", "max_tn", "max_tempmin", "max_tmp_min", "max_tmpmin", "max_temperature_min", "max_min_temperature"}.ToList())
-        Dim kvpMeanMaxTemp As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("mean_tmax_col", {"mean_tmax", "mean_tx", "mean_tempmax", "mean_tmp_max", "mean_tmpmax", "mean_temperature_max", "mean_max_temperature"}.ToList())
-        Dim kvpMinMaxTemp As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("min_tmax_col", {"min_tmax", "min_tx", "min_tempmax", "min_tmp_max", "min_tmpmax", "min_temperature_max", "min_max_temperature"}.ToList())
-        Dim kvpMaxMaxTemp As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("max_tmax_col", {"max_tmax", "max_tx", "max_tempmax", "max_tmp_max", "max_tmpmax", "max_temperature_max", "max_max_temperature"}.ToList())
+            Dim kvpMeanMinTemp As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("mean_tmin_col", {"mean_tmin", "mean_tn", "mean_tempmin", "mean_tmp_min", "mean_tmpmin", "mean_temperature_min", "mean_min_temperature"}.ToList())
+            Dim kvpMinMinTemp As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("min_tmin_col", {"min_tmin", "min_tn", "min_tempmin", "min_tmp_min", "min_tmpmin", "min_temperature_min", "min_min_temperature"}.ToList())
+            Dim kvpMaxMinTemp As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("max_tmin_col", {"max_tmin", "max_tn", "max_tempmin", "max_tmp_min", "max_tmpmin", "max_temperature_min", "max_min_temperature"}.ToList())
+            Dim kvpMeanMaxTemp As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("mean_tmax_col", {"mean_tmax", "mean_tx", "mean_tempmax", "mean_tmp_max", "mean_tmpmax", "mean_temperature_max", "mean_max_temperature"}.ToList())
+            Dim kvpMinMaxTemp As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("min_tmax_col", {"min_tmax", "min_tx", "min_tempmax", "min_tmp_max", "min_tmpmax", "min_temperature_max", "min_max_temperature"}.ToList())
+            Dim kvpMaxMaxTemp As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("max_tmax_col", {"max_tmax", "max_tx", "max_tempmax", "max_tmp_max", "max_tmpmax", "max_temperature_max", "max_max_temperature"}.ToList())
 
-        Dim kvpTotalRain As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("total_rain_col", {"rain_total"}.ToList())
-        Dim kvpPlantDay As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("plant_day_col", {"plant_day"}.ToList())
-        Dim kvpPlantLength As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("plant_length_col", {"plant_length"}.ToList())
-        Dim kvpPropSuccess As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("prop_success_col", {"prop_success", "prop_success_with_start"}.ToList())
-        Dim kvpPropSuccessNoStart As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("prop_success_no_start_col", {"prop_success", "prop_success_no_start"}.ToList())
-        Dim kvpStationCrop As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("station", {"station", "id", "name"}.ToList())
+            Dim kvpTotalRain As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("total_rain_col", {"rain_total"}.ToList())
+            Dim kvpPlantDay As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("plant_day_col", {"plant_day"}.ToList())
+            Dim kvpPlantLength As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("plant_length_col", {"plant_length"}.ToList())
+            Dim kvpPropSuccess As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("prop_success_col", {"prop_success", "prop_success_with_start"}.ToList())
+            Dim kvpPropSuccessNoStart As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("prop_success_no_start_col", {"prop_success", "prop_success_no_start"}.ToList())
+            Dim kvpStationCrop As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("station", {"station", "id", "name"}.ToList())
 
-        Dim kvpPlantingDay As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("plant_day_col", {"plant_day"}.ToList())
-        Dim kvpPlantDayCond As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("plant_day_cond_col", {"plant_day_cond"}.ToList())
-        Dim kvpStationProb As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("station", {"station", "id", "name"}.ToList())
-        Dim kvpYear As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("year", {"year", "s_year"}.ToList())
+            Dim kvpPlantingDay As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("plant_day_col", {"plant_day"}.ToList())
+            Dim kvpPlantDayCond As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("plant_day_cond_col", {"plant_day_cond"}.ToList())
+            Dim kvpStationProb As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("station", {"station", "id", "name"}.ToList())
+            Dim kvpYear As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("year", {"year", "s_year"}.ToList())
 
-        lstRecognisedTypes.AddRange({kvpAnnualRain, kvpEndRainDate, kvpEndRainDOY, kvpEndRainStatus, kvpEndSeasonDate, kvpEndSeasonDOY, kvpEndSeasonStatus,
+            lstRecognisedTypes.AddRange({kvpAnnualRain, kvpEndRainDate, kvpEndRainDOY, kvpEndRainStatus, kvpEndSeasonDate, kvpEndSeasonDOY, kvpEndSeasonStatus,
                                      kvpRainDaysSeason, kvpRainDaysYear, kvpSeasonalLength, kvpSeasonalRain, kvpStartRainDate,
                                     kvpStartRainDOY, kvpStartRainStatus})
-        lstRecognisedCropTypes.AddRange({kvpTotalRain, kvpStationCrop, kvpPlantDay, kvpPlantLength, kvpPropSuccess, kvpPropSuccessNoStart})
-        lstRecognisedPropTypes.AddRange({kvpPlantingDay, kvpYear, kvpStationProb, kvpPlantDayCond})
-        lstRecognisedMonthTempTypes.AddRange({kvpMeanMinTemp, kvpMinMinTemp, kvpMaxMinTemp, kvpMeanMaxTemp, kvpMinMaxTemp, kvpMaxMaxTemp})
-        lstRecognisedAnnTempTypes.AddRange({kvpMeanMinTemp, kvpMinMinTemp, kvpMaxMinTemp, kvpMeanMaxTemp, kvpMinMaxTemp, kvpMaxMaxTemp})
-
-        lstReceivers.AddRange({ucrReceiverAnnualRain, ucrReceiverEndRainsDate, ucrReceiverEndRainsDOY, ucrReceiverEndRainStatus, ucrReceiverEndSeasonDate, ucrReceiverEndSeasonDOY, ucrReceiverEndSeasonStatus, ucrReceiverRainDaysSeason, ucrReceiverRainDaysYear, ucrReceiverSeasonalLength, ucrReceiverSeasonalRain, ucrReceiverStartRainDate, ucrReceiverStartRainDOY, ucrReceiverStartRainStatus})
-        lstReceiversAnnualTemp.AddRange({ucrReceiverMaxMaxAnnual, ucrReceiverMaxMaxMonthly, ucrReceiverMaxMinAnnual, ucrReceiverMaxMinMonthly, ucrReceiverMeanAnnual, ucrReceiverMeanMaxAnnual, ucrReceiverMeanmaxMonthly, ucrReceiverMeanminMontly, ucrReceiverMinMaxAnnual, ucrReceiverMinMaxMonthly, ucrReceiverMinMinAnnual, ucrReceiverMinMinMonthly})
-        lstReceiversMonthTemp.AddRange({ucrReceiverMaxMaxAnnual, ucrReceiverMaxMaxMonthly, ucrReceiverMaxMinAnnual, ucrReceiverMaxMinMonthly, ucrReceiverMeanAnnual, ucrReceiverMeanMaxAnnual, ucrReceiverMeanmaxMonthly, ucrReceiverMeanminMontly, ucrReceiverMinMaxAnnual, ucrReceiverMinMaxMonthly, ucrReceiverMinMinAnnual, ucrReceiverMinMinMonthly})
-        lstReceiversCrop.AddRange({ucrReceiverPlantingDay, ucrReceiverStationCrop, ucrReceiverPlantingLenghth, ucrReceiverPropSuccess, ucrReceiverPropSuccessNoStart, ucrReceiverTotalRain})
-        lstReceiversProp.AddRange({ucrReceiverPlantingDayCondition, ucrReceiverSeasonYear, ucrReceiverSeasonStationProb, ucrReceiverSeasonPlantingDay})
-
-        ucrSelectorDefineAnnualRain.SetParameter(New RParameter("data", 0))
-        ucrSelectorDefineAnnualRain.SetParameterIsrfunction()
-
-        ucrSelectorAnnualTemp.SetParameter(New RParameter("data", 0))
-        ucrSelectorAnnualTemp.SetParameterIsrfunction()
-
-        ucrSelectorCropProp.SetParameter(New RParameter("data", 0))
-        ucrSelectorCropProp.SetParameterIsrfunction()
-
-        ucrSelectorSeasonStartProp.SetParameter(New RParameter("data", 0))
-        ucrSelectorSeasonStartProp.SetParameterIsrfunction()
-
-        ucrSelecetorMonthlyTemp.SetParameter(New RParameter("data", 0))
-        ucrSelecetorMonthlyTemp.SetParameterIsrfunction()
-
-        ucrReceiverStation.SetParameter(New RParameter("station_col", 1))
-        ucrReceiverStation.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverStation.SetParameterIsString()
-        ucrReceiverStation.SetClimaticType("station")
-        ucrReceiverStation.bAutoFill = True
-        ucrReceiverStation.bExcludeFromSelector = True
-
-        ucrReceiverYear.SetParameter(New RParameter("year_col", 2))
-        ucrReceiverYear.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverYear.SetParameterIsString()
-        ucrReceiverYear.SetClimaticType("year")
-        ucrReceiverYear.bAutoFill = True
-        ucrReceiverYear.bExcludeFromSelector = True
-
-        ucrReceiverStartRainDOY.SetParameter(New RParameter("start_rains_doy_col", 3))
-        ucrReceiverStartRainDOY.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverStartRainDOY.SetParameterIsString()
-        ucrReceiverStartRainDOY.Tag = "start_rains_doy_col"
-        ucrReceiverStartRainDOY.bExcludeFromSelector = True
-
-        ucrReceiverStartRainDate.SetParameter(New RParameter("start_rains_date_col", 4))
-        ucrReceiverStartRainDate.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverStartRainDate.SetParameterIsString()
-        ucrReceiverStartRainDate.Tag = "start_rains_date_col"
-        ucrReceiverStartRainDate.bExcludeFromSelector = True
-
-        ucrReceiverEndRainsDOY.SetParameter(New RParameter("end_rains_doy_col", 5))
-        ucrReceiverEndRainsDOY.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverEndRainsDOY.SetParameterIsString()
-        ucrReceiverEndRainsDOY.Tag = "end_rains_doy_col"
-        ucrReceiverEndRainsDOY.bExcludeFromSelector = True
-
-        ucrReceiverEndRainsDate.SetParameter(New RParameter("end_rains_date_col", 6))
-        ucrReceiverEndRainsDate.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverEndRainsDate.SetParameterIsString()
-        ucrReceiverEndRainsDate.Tag = "end_rains_date_col"
-        ucrReceiverEndRainsDate.bExcludeFromSelector = True
-
-        ucrReceiverEndSeasonDOY.SetParameter(New RParameter("end_season_doy_col", 7))
-        ucrReceiverEndSeasonDOY.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverEndSeasonDOY.SetParameterIsString()
-        ucrReceiverEndSeasonDOY.Tag = "end_season_doy_col"
-        ucrReceiverEndSeasonDOY.bExcludeFromSelector = True
-
-        ucrReceiverEndSeasonDate.SetParameter(New RParameter("end_season_date_col", 8))
-        ucrReceiverEndSeasonDate.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverEndSeasonDate.SetParameterIsString()
-        ucrReceiverEndSeasonDate.Tag = "end_season_date_col"
-        ucrReceiverEndSeasonDate.bExcludeFromSelector = True
-
-        ucrReceiverSeasonalRain.SetParameter(New RParameter("seasonal_rain_col", 9))
-        ucrReceiverSeasonalRain.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverSeasonalRain.SetParameterIsString()
-        ucrReceiverSeasonalRain.Tag = "seasonal_rain_col"
-        ucrReceiverSeasonalRain.bExcludeFromSelector = True
-
-        ucrReceiverRainDaysSeason.SetParameter(New RParameter("n_seasonal_rain_col", 10))
-        ucrReceiverRainDaysSeason.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverRainDaysSeason.SetParameterIsString()
-        ucrReceiverRainDaysSeason.Tag = "n_seasonal_rain_col"
-        ucrReceiverRainDaysSeason.bExcludeFromSelector = True
-
-        ucrReceiverRainDaysYear.SetParameter(New RParameter("n_rain_col", 11))
-        ucrReceiverRainDaysYear.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverRainDaysYear.SetParameterIsString()
-        ucrReceiverRainDaysYear.Tag = "n_rain_col"
-        ucrReceiverRainDaysYear.bExcludeFromSelector = True
-
-        ucrReceiverSeasonalLength.SetParameter(New RParameter("season_length_col", 12))
-        ucrReceiverSeasonalLength.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverSeasonalLength.SetParameterIsString()
-        ucrReceiverSeasonalLength.Tag = "season_length_col"
-        ucrReceiverSeasonalLength.bExcludeFromSelector = True
-
-        ucrReceiverAnnualRain.SetParameter(New RParameter("annual_rain_col", 13))
-        ucrReceiverAnnualRain.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverAnnualRain.SetParameterIsString()
-        ucrReceiverAnnualRain.Tag = "annual_rain_col"
-        ucrReceiverAnnualRain.bExcludeFromSelector = True
-
-        ucrReceiverExtremRian.SetParameter(New RParameter("extreme_rain_days_col", 13))
-        ucrReceiverExtremRian.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverExtremRian.SetParameterIsString()
-        ucrReceiverExtremRian.bExcludeFromSelector = True
-
-        ucrReceiverExtremeMinTemp.SetParameter(New RParameter("extreme_tmin_days_col", 18))
-        ucrReceiverExtremeMinTemp.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverExtremeMinTemp.SetParameterIsString()
-        ucrReceiverExtremeMinTemp.bExcludeFromSelector = True
-        ucrReceiverExtremeMinTemp.SetLinkedDisplayControl(lblExtremeMinTemp)
-
-        ucrReceiverExtremeMaxTemp.SetParameter(New RParameter("extreme_tmax_days_col", 19))
-        ucrReceiverExtremeMaxTemp.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverExtremeMaxTemp.SetParameterIsString()
-        ucrReceiverExtremeMaxTemp.bExcludeFromSelector = True
-        ucrReceiverExtremeMaxTemp.SetLinkedDisplayControl(lblExtremeMaxTemp)
-
-        ucrReceiverLongestRainfallSpell.SetParameter(New RParameter("longest_rain_spell_col", 20))
-        ucrReceiverLongestRainfallSpell.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverLongestRainfallSpell.SetParameterIsString()
-        ucrReceiverLongestRainfallSpell.bExcludeFromSelector = True
-        ucrReceiverLongestRainfallSpell.SetLinkedDisplayControl(lblLongestRainfallSpell)
-
-        ucrReceiverLongestMinTempSpell.SetParameter(New RParameter("longest_tmin_spell_col", 21))
-        ucrReceiverLongestMinTempSpell.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverLongestMinTempSpell.SetParameterIsString()
-        ucrReceiverLongestMinTempSpell.bExcludeFromSelector = True
-        ucrReceiverLongestMinTempSpell.SetLinkedDisplayControl(lblLongestMinTempSpell)
-
-        ucrReceiverLongestMaxTempSpell.SetParameter(New RParameter("longest_tmax_spell_col", 22))
-        ucrReceiverLongestMaxTempSpell.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverLongestMaxTempSpell.SetParameterIsString()
-        ucrReceiverLongestMaxTempSpell.bExcludeFromSelector = True
-        ucrReceiverLongestMaxTempSpell.SetLinkedDisplayControl(lblLongestMaxTempSpell)
-
-        ucrReceiverStartRainStatus.SetParameter(New RParameter("start_rains_status_column", 14))
-        ucrReceiverStartRainStatus.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverStartRainStatus.SetParameterIsString()
-        ucrReceiverStartRainStatus.Tag = "start_rains_status_column"
-        ucrReceiverStartRainStatus.bExcludeFromSelector = True
-
-        ucrReceiverEndRainStatus.SetParameter(New RParameter("end_rains_status_column", 15))
-        ucrReceiverEndRainStatus.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverEndRainStatus.SetParameterIsString()
-        ucrReceiverEndRainStatus.Tag = "end_rains_status_column"
-        ucrReceiverEndRainStatus.bExcludeFromSelector = True
-
-        ucrReceiverEndSeasonStatus.SetParameter(New RParameter("end_season_status_column", 16))
-        ucrReceiverEndSeasonStatus.Selector = ucrSelectorDefineAnnualRain
-        ucrReceiverEndSeasonStatus.SetParameterIsString()
-        ucrReceiverEndSeasonStatus.Tag = "end_season_status_column"
-        ucrReceiverEndSeasonStatus.bExcludeFromSelector = True
-
-        ucrReceiverStationCrop.SetParameter(New RParameter("station_col", 1))
-        ucrReceiverStationCrop.Selector = ucrSelectorCropProp
-        ucrReceiverStationCrop.SetParameterIsString()
-        ucrReceiverStationCrop.Tag = "station"
-        ucrReceiverStationCrop.bExcludeFromSelector = True
-
-        ucrReceiverTotalRain.SetParameter(New RParameter("total_rain_col", 2))
-        ucrReceiverTotalRain.Selector = ucrSelectorCropProp
-        ucrReceiverTotalRain.SetParameterIsString()
-        ucrReceiverTotalRain.Tag = "total_rain_col"
-        ucrReceiverTotalRain.bExcludeFromSelector = True
-
-        ucrReceiverPlantingDay.SetParameter(New RParameter("plant_day_col", 3))
-        ucrReceiverPlantingDay.Selector = ucrSelectorCropProp
-        ucrReceiverPlantingDay.SetParameterIsString()
-        ucrReceiverPlantingDay.Tag = "plant_day_col"
-        ucrReceiverPlantingDay.bExcludeFromSelector = True
-
-        ucrReceiverPlantingLenghth.SetParameter(New RParameter("plant_length_col", 4))
-        ucrReceiverPlantingLenghth.Selector = ucrSelectorCropProp
-        ucrReceiverPlantingLenghth.SetParameterIsString()
-        ucrReceiverPlantingLenghth.Tag = "plant_length_col"
-        ucrReceiverPlantingLenghth.bExcludeFromSelector = True
-
-        ucrReceiverPropSuccess.SetParameter(New RParameter("prop_success_with_start_col", 5))
-        ucrReceiverPropSuccess.Selector = ucrSelectorCropProp
-        ucrReceiverPropSuccess.SetParameterIsString()
-        ucrReceiverPropSuccess.Tag = "prop_success_col"
-        ucrReceiverPropSuccess.bExcludeFromSelector = True
-
-        ucrReceiverPropSuccessNoStart.SetParameter(New RParameter("prop_success_no_start_col", 5))
-        ucrReceiverPropSuccessNoStart.Selector = ucrSelectorCropProp
-        ucrReceiverPropSuccessNoStart.SetParameterIsString()
-        ucrReceiverPropSuccessNoStart.Tag = "prop_success_no_start_col"
-        ucrReceiverPropSuccessNoStart.bExcludeFromSelector = True
-
-        'Season start
-        ucrReceiverSeasonStationProb.SetParameter(New RParameter("station_col", 1))
-        ucrReceiverSeasonStationProb.Selector = ucrSelectorSeasonStartProp
-        ucrReceiverSeasonStationProb.SetParameterIsString()
-        ucrReceiverSeasonStationProb.Tag = "station"
-        ucrReceiverSeasonStationProb.bExcludeFromSelector = True
-
-        ucrReceiverSeasonYear.SetParameter(New RParameter("year_col", 2))
-        ucrReceiverSeasonYear.Selector = ucrSelectorSeasonStartProp
-        ucrReceiverSeasonYear.SetParameterIsString()
-        ucrReceiverSeasonYear.Tag = "year"
-        ucrReceiverSeasonYear.bExcludeFromSelector = True
-
-        ucrReceiverSeasonPlantingDay.SetParameter(New RParameter("plant_day_col", 3))
-        ucrReceiverSeasonPlantingDay.Selector = ucrSelectorSeasonStartProp
-        ucrReceiverSeasonPlantingDay.SetParameterIsString()
-        ucrReceiverSeasonPlantingDay.Tag = "plant_day_col"
-        ucrReceiverSeasonPlantingDay.bExcludeFromSelector = True
-
-        ucrReceiverPlantingDayCondition.SetParameter(New RParameter("plant_day_cond_col", 5))
-        ucrReceiverPlantingDayCondition.Selector = ucrSelectorSeasonStartProp
-        ucrReceiverPlantingDayCondition.SetParameterIsString()
-        ucrReceiverPlantingDayCondition.Tag = "plant_day_cond_col"
-        ucrReceiverPlantingDayCondition.bExcludeFromSelector = True
-
-        'Annual Temp
-        ucrReceiverAnnualTempStation.SetParameter(New RParameter("station_col", 1))
-        ucrReceiverAnnualTempStation.Selector = ucrSelectorAnnualTemp
-        ucrReceiverAnnualTempStation.SetParameterIsString()
-        ucrReceiverAnnualTempStation.SetClimaticType("station")
-        ucrReceiverAnnualTempStation.bAutoFill = True
-        ucrReceiverAnnualTempStation.bExcludeFromSelector = True
-
-        ucrReceiverAnnualTempYr.SetParameter(New RParameter("year_col", 2))
-        ucrReceiverAnnualTempYr.Selector = ucrSelectorAnnualTemp
-        ucrReceiverAnnualTempYr.SetParameterIsString()
-        ucrReceiverAnnualTempYr.SetClimaticType("year")
-        ucrReceiverAnnualTempYr.bAutoFill = True
-        ucrReceiverAnnualTempYr.bExcludeFromSelector = True
-
-        ucrReceiverMeanAnnual.SetParameter(New RParameter("mean_tmin_col", 3))
-        ucrReceiverMeanAnnual.Selector = ucrSelectorAnnualTemp
-        ucrReceiverMeanAnnual.SetParameterIsString()
-        ucrReceiverMeanAnnual.Tag = "mean_tmin_col"
-        ucrReceiverMeanAnnual.bExcludeFromSelector = True
-
-        ucrReceiverMinMinAnnual.SetParameter(New RParameter("min_tmin_col", 4))
-        ucrReceiverMinMinAnnual.Selector = ucrSelectorAnnualTemp
-        ucrReceiverMinMinAnnual.SetParameterIsString()
-        ucrReceiverMinMinAnnual.Tag = "min_tmin_col"
-        ucrReceiverMinMinAnnual.bExcludeFromSelector = True
-
-        ucrReceiverMaxMinAnnual.SetParameter(New RParameter("max_tmin_col", 5))
-        ucrReceiverMaxMinAnnual.Selector = ucrSelectorAnnualTemp
-        ucrReceiverMaxMinAnnual.SetParameterIsString()
-        ucrReceiverMaxMinAnnual.Tag = "max_tmin_col"
-        ucrReceiverMaxMinAnnual.bExcludeFromSelector = True
-
-        ucrReceiverMeanMaxAnnual.SetParameter(New RParameter("mean_tmax_col", 6))
-        ucrReceiverMeanMaxAnnual.Selector = ucrSelectorAnnualTemp
-        ucrReceiverMeanMaxAnnual.SetParameterIsString()
-        ucrReceiverMeanMaxAnnual.Tag = "mean_tmax_col"
-        ucrReceiverMeanMaxAnnual.bExcludeFromSelector = True
-
-        ucrReceiverMinMaxAnnual.SetParameter(New RParameter("min_tmax_col", 7))
-        ucrReceiverMinMaxAnnual.Selector = ucrSelectorAnnualTemp
-        ucrReceiverMinMaxAnnual.SetParameterIsString()
-        ucrReceiverMinMaxAnnual.Tag = "min_tmax_col"
-        ucrReceiverMinMaxAnnual.bExcludeFromSelector = True
-
-        ucrReceiverMaxMaxAnnual.SetParameter(New RParameter("max_tmax_col", 8))
-        ucrReceiverMaxMaxAnnual.Selector = ucrSelectorAnnualTemp
-        ucrReceiverMaxMaxAnnual.SetParameterIsString()
-        ucrReceiverMaxMaxAnnual.Tag = "max_tmax_col"
-        ucrReceiverMaxMaxAnnual.bExcludeFromSelector = True
-
-        'Monthly Temp
-        ucrReceiverMonthlyTemp.SetParameter(New RParameter("station_col", 1))
-        ucrReceiverMonthlyTemp.Selector = ucrSelecetorMonthlyTemp
-        ucrReceiverMonthlyTemp.SetParameterIsString()
-        ucrReceiverMonthlyTemp.SetClimaticType("station")
-        ucrReceiverMonthlyTemp.bAutoFill = True
-        ucrReceiverMonthlyTemp.bExcludeFromSelector = True
-
-        ucrReceiverYearMonthly.SetParameter(New RParameter("year_col", 2))
-        ucrReceiverYearMonthly.Selector = ucrSelecetorMonthlyTemp
-        ucrReceiverYearMonthly.SetParameterIsString()
-        ucrReceiverYearMonthly.SetClimaticType("year")
-        ucrReceiverYearMonthly.bAutoFill = True
-        ucrReceiverYearMonthly.bExcludeFromSelector = True
-
-        ucrReceiverMonthMonthly.SetParameter(New RParameter("month_col", 3))
-        ucrReceiverMonthMonthly.Selector = ucrSelecetorMonthlyTemp
-        ucrReceiverMonthMonthly.SetParameterIsString()
-        ucrReceiverMonthMonthly.SetClimaticType("month")
-        ucrReceiverMonthMonthly.bAutoFill = True
-        ucrReceiverMonthMonthly.bExcludeFromSelector = True
-
-        ucrReceiverMeanminMontly.SetParameter(New RParameter("mean_tmin_col", 4))
-        ucrReceiverMeanminMontly.Selector = ucrSelecetorMonthlyTemp
-        ucrReceiverMeanminMontly.SetParameterIsString()
-        ucrReceiverMeanminMontly.Tag = "mean_tmin_col"
-        ucrReceiverMeanminMontly.bExcludeFromSelector = True
-
-        ucrReceiverMinMinMonthly.SetParameter(New RParameter("min_tmin_col", 5))
-        ucrReceiverMinMinMonthly.Selector = ucrSelecetorMonthlyTemp
-        ucrReceiverMinMinMonthly.SetParameterIsString()
-        ucrReceiverMinMinMonthly.Tag = "min_tmin_col"
-        ucrReceiverMinMinMonthly.bExcludeFromSelector = True
-
-        ucrReceiverMaxMinMonthly.SetParameter(New RParameter("max_tmin_col", 6))
-        ucrReceiverMaxMinMonthly.Selector = ucrSelecetorMonthlyTemp
-        ucrReceiverMaxMinMonthly.SetParameterIsString()
-        ucrReceiverMaxMinMonthly.Tag = "max_tmin_col"
-        ucrReceiverMaxMinMonthly.bExcludeFromSelector = True
-
-        ucrReceiverMeanmaxMonthly.SetParameter(New RParameter("mean_tmax_col", 7))
-        ucrReceiverMeanmaxMonthly.Selector = ucrSelecetorMonthlyTemp
-        ucrReceiverMeanmaxMonthly.SetParameterIsString()
-        ucrReceiverMeanmaxMonthly.Tag = "mean_tmax_col"
-        ucrReceiverMeanmaxMonthly.bExcludeFromSelector = True
-
-        ucrReceiverMinMaxMonthly.SetParameter(New RParameter("min_tmax_col", 8))
-        ucrReceiverMinMaxMonthly.Selector = ucrSelecetorMonthlyTemp
-        ucrReceiverMinMaxMonthly.SetParameterIsString()
-        ucrReceiverMinMaxMonthly.Tag = "min_tmax_col"
-        ucrReceiverMinMaxMonthly.bExcludeFromSelector = True
-
-        ucrReceiverMaxMaxMonthly.SetParameter(New RParameter("max_tmax_col", 9))
-        ucrReceiverMaxMaxMonthly.Selector = ucrSelecetorMonthlyTemp
-        ucrReceiverMaxMaxMonthly.SetParameterIsString()
-        ucrReceiverMaxMaxMonthly.Tag = "max_tmax_col"
-        ucrReceiverMaxMaxMonthly.bExcludeFromSelector = True
-        bControlsInitialised = True
-
-    End Sub
-    Public Sub SetRCode(clsNewReforMattAnnualSummaries As RFunction, clsNewExportRinstatToBucketFunction As RFunction, clsNewReformatCropSuccessFunction As RFunction, clsNewReformatMonthlyTempSummaries As RFunction, clsNewReformatSeasonStartFunction As RFunction, clsNewReformatTempSummariesFunction As RFunction, Optional bReset As Boolean = False)
-        If Not bControlsInitialised Then
-            InitialiseControls()
-        End If
-
-        clsReforMattAnnualSummariesFunction = clsNewReforMattAnnualSummaries
-        clsReformatCropSuccessFunction = clsNewReformatCropSuccessFunction
-        clsReformatMonthlyTempSummaries = clsNewReformatMonthlyTempSummaries
-        clsReformatSeasonStartFunction = clsNewReformatSeasonStartFunction
-        clsReformatTempSummariesFunction = clsNewReformatTempSummariesFunction
-        clsExportRinstatToBucketFunction = clsNewExportRinstatToBucketFunction
-
-        ucrReceiverSeasonalLength.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("seasonal_length_column", 12), iAdditionalPairNo:=1)
-        ucrReceiverEndSeasonDOY.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("end_season_column", 7), iAdditionalPairNo:=1)
-        ucrReceiverStartRainDOY.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("start_rains_column", 3), iAdditionalPairNo:=1)
-        ucrReceiverEndRainsDOY.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("end_rains_column", 6), iAdditionalPairNo:=1)
-
-        ucrReceiverMinMaxAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("min_tmax_column", 7), iAdditionalPairNo:=1)
-        ucrReceiverMaxMaxAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("max_tmax_column", 8), iAdditionalPairNo:=1)
-        ucrReceiverMeanMaxAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("mean_tmax_column", 6), iAdditionalPairNo:=1)
-        ucrReceiverMeanAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("mean_tmin_column", 3), iAdditionalPairNo:=1)
-        ucrReceiverMinMinAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("min_tmin_column", 4), iAdditionalPairNo:=1)
-        ucrReceiverMaxMinAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("max_tmin_column", 5), iAdditionalPairNo:=1)
-        ucrReceiverLongestRainfallSpell.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("longest_rain_spell_col", 20), iAdditionalPairNo:=1)
-        ucrReceiverLongestMinTempSpell.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("longest_tmin_spell_col", 21), iAdditionalPairNo:=1)
-        ucrReceiverLongestMaxTempSpell.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("longest_tmax_spell_col", 22), iAdditionalPairNo:=1)
-
-        ucrReceiverAnnualRain.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverExtremRian.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverExtremeMinTemp.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverExtremeMaxTemp.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverLongestRainfallSpell.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverLongestMinTempSpell.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverLongestMaxTempSpell.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-
-        ucrReceiverEndRainsDate.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverEndRainsDOY.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverEndSeasonDate.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverEndSeasonDOY.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverRainDaysSeason.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverRainDaysYear.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverSeasonalLength.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverSeasonalRain.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverStartRainDate.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverStartRainDOY.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverStation.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverYear.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrSelectorDefineAnnualRain.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
-        ucrReceiverStartRainStatus.SetRCode(clsExportRinstatToBucketFunction, bReset)
-        ucrReceiverEndRainStatus.SetRCode(clsExportRinstatToBucketFunction, bReset)
-        ucrReceiverEndSeasonStatus.SetRCode(clsExportRinstatToBucketFunction, bReset)
-
-        ucrReceiverStationCrop.SetRCode(clsReformatCropSuccessFunction, bReset)
-        ucrReceiverTotalRain.SetRCode(clsReformatCropSuccessFunction, bReset)
-        ucrReceiverPlantingDay.SetRCode(clsReformatCropSuccessFunction, bReset)
-        ucrReceiverPlantingLenghth.SetRCode(clsReformatCropSuccessFunction, bReset)
-        ucrReceiverPropSuccess.SetRCode(clsReformatCropSuccessFunction, bReset)
-        ucrReceiverPropSuccessNoStart.SetRCode(clsReformatCropSuccessFunction, bReset)
-        ucrSelectorCropProp.SetRCode(clsReformatCropSuccessFunction, bReset)
-
-        ucrReceiverSeasonStationProb.SetRCode(clsReformatSeasonStartFunction, bReset)
-        ucrReceiverSeasonYear.SetRCode(clsReformatSeasonStartFunction, bReset)
-        ucrReceiverSeasonPlantingDay.SetRCode(clsReformatSeasonStartFunction, bReset)
-        ucrReceiverPlantingDayCondition.SetRCode(clsReformatSeasonStartFunction, bReset)
-        ucrSelectorSeasonStartProp.SetRCode(clsReformatSeasonStartFunction, bReset)
-
-        ucrReceiverAnnualTempStation.SetRCode(clsReformatTempSummariesFunction, bReset)
-        ucrReceiverAnnualTempYr.SetRCode(clsReformatTempSummariesFunction, bReset)
-        ucrReceiverMeanAnnual.SetRCode(clsReformatTempSummariesFunction, bReset)
-        ucrReceiverMinMaxAnnual.SetRCode(clsReformatTempSummariesFunction, bReset)
-        ucrReceiverMaxMinAnnual.SetRCode(clsReformatTempSummariesFunction, bReset)
-        ucrReceiverMaxMaxAnnual.SetRCode(clsReformatTempSummariesFunction, bReset)
-        ucrReceiverMinMinAnnual.SetRCode(clsReformatTempSummariesFunction, bReset)
-        ucrReceiverMeanMaxAnnual.SetRCode(clsReformatTempSummariesFunction, bReset)
-        ucrSelectorAnnualTemp.SetRCode(clsReformatTempSummariesFunction, bReset)
-
-        ucrReceiverMonthlyTemp.SetRCode(clsReformatMonthlyTempSummaries, bReset)
-        ucrReceiverYearMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
-        ucrReceiverMonthMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
-        ucrReceiverMeanmaxMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
-        ucrReceiverMinMaxMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
-        ucrReceiverMaxMinMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
-        ucrReceiverMaxMaxMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
-        ucrReceiverMinMinMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
-        ucrReceiverMeanminMontly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
-        ucrSelecetorMonthlyTemp.SetRCode(clsReformatMonthlyTempSummaries, bReset)
-        AutoFillReceivers()
-        AutoFillReceiversCrop()
-        AutoFillReceiversForAnnualTemp()
-        AutoFillReceiversForMonthlyTemp()
-        AutoFillReceiversForSeasonsStart()
-    End Sub
-
-    Private Sub ucrReceiverAnnualRain_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverAnnualRain.ControlValueChanged, ucrReceiverEndRainsDate.ControlValueChanged, ucrReceiverEndRainsDOY.ControlValueChanged, ucrReceiverEndSeasonDate.ControlValueChanged,
+            lstRecognisedCropTypes.AddRange({kvpTotalRain, kvpStationCrop, kvpPlantDay, kvpPlantLength, kvpPropSuccess, kvpPropSuccessNoStart})
+            lstRecognisedPropTypes.AddRange({kvpPlantingDay, kvpYear, kvpStationProb, kvpPlantDayCond})
+            lstRecognisedMonthTempTypes.AddRange({kvpMeanMinTemp, kvpMinMinTemp, kvpMaxMinTemp, kvpMeanMaxTemp, kvpMinMaxTemp, kvpMaxMaxTemp})
+            lstRecognisedAnnTempTypes.AddRange({kvpMeanMinTemp, kvpMinMinTemp, kvpMaxMinTemp, kvpMeanMaxTemp, kvpMinMaxTemp, kvpMaxMaxTemp})
+
+            lstReceivers.AddRange({ucrReceiverAnnualRain, ucrReceiverEndRainsDate, ucrReceiverEndRainsDOY, ucrReceiverEndRainStatus, ucrReceiverEndSeasonDate, ucrReceiverEndSeasonDOY, ucrReceiverEndSeasonStatus, ucrReceiverRainDaysSeason, ucrReceiverRainDaysYear, ucrReceiverSeasonalLength, ucrReceiverSeasonalRain, ucrReceiverStartRainDate, ucrReceiverStartRainDOY, ucrReceiverStartRainStatus})
+            lstReceiversAnnualTemp.AddRange({ucrReceiverMaxMaxAnnual, ucrReceiverMaxMaxMonthly, ucrReceiverMaxMinAnnual, ucrReceiverMaxMinMonthly, ucrReceiverMeanAnnual, ucrReceiverMeanMaxAnnual, ucrReceiverMeanmaxMonthly, ucrReceiverMeanminMontly, ucrReceiverMinMaxAnnual, ucrReceiverMinMaxMonthly, ucrReceiverMinMinAnnual, ucrReceiverMinMinMonthly})
+            lstReceiversMonthTemp.AddRange({ucrReceiverMaxMaxAnnual, ucrReceiverMaxMaxMonthly, ucrReceiverMaxMinAnnual, ucrReceiverMaxMinMonthly, ucrReceiverMeanAnnual, ucrReceiverMeanMaxAnnual, ucrReceiverMeanmaxMonthly, ucrReceiverMeanminMontly, ucrReceiverMinMaxAnnual, ucrReceiverMinMaxMonthly, ucrReceiverMinMinAnnual, ucrReceiverMinMinMonthly})
+            lstReceiversCrop.AddRange({ucrReceiverPlantingDay, ucrReceiverStationCrop, ucrReceiverPlantingLenghth, ucrReceiverPropSuccess, ucrReceiverPropSuccessNoStart, ucrReceiverTotalRain})
+            lstReceiversProp.AddRange({ucrReceiverPlantingDayCondition, ucrReceiverSeasonYear, ucrReceiverSeasonStationProb, ucrReceiverSeasonPlantingDay})
+
+            ucrSelectorDefineAnnualRain.SetParameter(New RParameter("data", 0))
+            ucrSelectorDefineAnnualRain.SetParameterIsrfunction()
+
+            ucrSelectorAnnualTemp.SetParameter(New RParameter("data", 0))
+            ucrSelectorAnnualTemp.SetParameterIsrfunction()
+
+            ucrSelectorCropProp.SetParameter(New RParameter("data", 0))
+            ucrSelectorCropProp.SetParameterIsrfunction()
+
+            ucrSelectorSeasonStartProp.SetParameter(New RParameter("data", 0))
+            ucrSelectorSeasonStartProp.SetParameterIsrfunction()
+
+            ucrSelecetorMonthlyTemp.SetParameter(New RParameter("data", 0))
+            ucrSelecetorMonthlyTemp.SetParameterIsrfunction()
+
+            ucrReceiverStation.SetParameter(New RParameter("station_col", 1))
+            ucrReceiverStation.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverStation.SetParameterIsString()
+            ucrReceiverStation.SetClimaticType("station")
+            ucrReceiverStation.bAutoFill = True
+            ucrReceiverStation.bExcludeFromSelector = True
+
+            ucrReceiverYear.SetParameter(New RParameter("year_col", 2))
+            ucrReceiverYear.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverYear.SetParameterIsString()
+            ucrReceiverYear.SetClimaticType("year")
+            ucrReceiverYear.bAutoFill = True
+            ucrReceiverYear.bExcludeFromSelector = True
+
+            ucrReceiverStartRainDOY.SetParameter(New RParameter("start_rains_doy_col", 3))
+            ucrReceiverStartRainDOY.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverStartRainDOY.SetParameterIsString()
+            ucrReceiverStartRainDOY.Tag = "start_rains_doy_col"
+            ucrReceiverStartRainDOY.bExcludeFromSelector = True
+
+            ucrReceiverStartRainDate.SetParameter(New RParameter("start_rains_date_col", 4))
+            ucrReceiverStartRainDate.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverStartRainDate.SetParameterIsString()
+            ucrReceiverStartRainDate.Tag = "start_rains_date_col"
+            ucrReceiverStartRainDate.bExcludeFromSelector = True
+
+            ucrReceiverEndRainsDOY.SetParameter(New RParameter("end_rains_doy_col", 5))
+            ucrReceiverEndRainsDOY.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverEndRainsDOY.SetParameterIsString()
+            ucrReceiverEndRainsDOY.Tag = "end_rains_doy_col"
+            ucrReceiverEndRainsDOY.bExcludeFromSelector = True
+
+            ucrReceiverEndRainsDate.SetParameter(New RParameter("end_rains_date_col", 6))
+            ucrReceiverEndRainsDate.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverEndRainsDate.SetParameterIsString()
+            ucrReceiverEndRainsDate.Tag = "end_rains_date_col"
+            ucrReceiverEndRainsDate.bExcludeFromSelector = True
+
+            ucrReceiverEndSeasonDOY.SetParameter(New RParameter("end_season_doy_col", 7))
+            ucrReceiverEndSeasonDOY.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverEndSeasonDOY.SetParameterIsString()
+            ucrReceiverEndSeasonDOY.Tag = "end_season_doy_col"
+            ucrReceiverEndSeasonDOY.bExcludeFromSelector = True
+
+            ucrReceiverEndSeasonDate.SetParameter(New RParameter("end_season_date_col", 8))
+            ucrReceiverEndSeasonDate.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverEndSeasonDate.SetParameterIsString()
+            ucrReceiverEndSeasonDate.Tag = "end_season_date_col"
+            ucrReceiverEndSeasonDate.bExcludeFromSelector = True
+
+            ucrReceiverSeasonalRain.SetParameter(New RParameter("seasonal_rain_col", 9))
+            ucrReceiverSeasonalRain.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverSeasonalRain.SetParameterIsString()
+            ucrReceiverSeasonalRain.Tag = "seasonal_rain_col"
+            ucrReceiverSeasonalRain.bExcludeFromSelector = True
+
+            ucrReceiverRainDaysSeason.SetParameter(New RParameter("n_seasonal_rain_col", 10))
+            ucrReceiverRainDaysSeason.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverRainDaysSeason.SetParameterIsString()
+            ucrReceiverRainDaysSeason.Tag = "n_seasonal_rain_col"
+            ucrReceiverRainDaysSeason.bExcludeFromSelector = True
+
+            ucrReceiverRainDaysYear.SetParameter(New RParameter("n_rain_col", 11))
+            ucrReceiverRainDaysYear.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverRainDaysYear.SetParameterIsString()
+            ucrReceiverRainDaysYear.Tag = "n_rain_col"
+            ucrReceiverRainDaysYear.bExcludeFromSelector = True
+
+            ucrReceiverSeasonalLength.SetParameter(New RParameter("season_length_col", 12))
+            ucrReceiverSeasonalLength.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverSeasonalLength.SetParameterIsString()
+            ucrReceiverSeasonalLength.Tag = "season_length_col"
+            ucrReceiverSeasonalLength.bExcludeFromSelector = True
+
+            ucrReceiverAnnualRain.SetParameter(New RParameter("annual_rain_col", 13))
+            ucrReceiverAnnualRain.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverAnnualRain.SetParameterIsString()
+            ucrReceiverAnnualRain.Tag = "annual_rain_col"
+            ucrReceiverAnnualRain.bExcludeFromSelector = True
+
+            ucrReceiverExtremRian.SetParameter(New RParameter("extreme_rain_days_col", 13))
+            ucrReceiverExtremRian.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverExtremRian.SetParameterIsString()
+            ucrReceiverExtremRian.bExcludeFromSelector = True
+
+            ucrReceiverStartRainStatus.SetParameter(New RParameter("start_rains_status_column", 14))
+            ucrReceiverStartRainStatus.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverStartRainStatus.SetParameterIsString()
+            ucrReceiverStartRainStatus.Tag = "start_rains_status_column"
+            ucrReceiverStartRainStatus.bExcludeFromSelector = True
+
+            ucrReceiverEndRainStatus.SetParameter(New RParameter("end_rains_status_column", 15))
+            ucrReceiverEndRainStatus.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverEndRainStatus.SetParameterIsString()
+            ucrReceiverEndRainStatus.Tag = "end_rains_status_column"
+            ucrReceiverEndRainStatus.bExcludeFromSelector = True
+
+            ucrReceiverEndSeasonStatus.SetParameter(New RParameter("end_season_status_column", 16))
+            ucrReceiverEndSeasonStatus.Selector = ucrSelectorDefineAnnualRain
+            ucrReceiverEndSeasonStatus.SetParameterIsString()
+            ucrReceiverEndSeasonStatus.Tag = "end_season_status_column"
+            ucrReceiverEndSeasonStatus.bExcludeFromSelector = True
+
+            ucrReceiverStationCrop.SetParameter(New RParameter("station_col", 1))
+            ucrReceiverStationCrop.Selector = ucrSelectorCropProp
+            ucrReceiverStationCrop.SetParameterIsString()
+            ucrReceiverStationCrop.Tag = "station"
+            ucrReceiverStationCrop.bExcludeFromSelector = True
+
+            ucrReceiverTotalRain.SetParameter(New RParameter("total_rain_col", 2))
+            ucrReceiverTotalRain.Selector = ucrSelectorCropProp
+            ucrReceiverTotalRain.SetParameterIsString()
+            ucrReceiverTotalRain.Tag = "total_rain_col"
+            ucrReceiverTotalRain.bExcludeFromSelector = True
+
+            ucrReceiverPlantingDay.SetParameter(New RParameter("plant_day_col", 3))
+            ucrReceiverPlantingDay.Selector = ucrSelectorCropProp
+            ucrReceiverPlantingDay.SetParameterIsString()
+            ucrReceiverPlantingDay.Tag = "plant_day_col"
+            ucrReceiverPlantingDay.bExcludeFromSelector = True
+
+            ucrReceiverPlantingLenghth.SetParameter(New RParameter("plant_length_col", 4))
+            ucrReceiverPlantingLenghth.Selector = ucrSelectorCropProp
+            ucrReceiverPlantingLenghth.SetParameterIsString()
+            ucrReceiverPlantingLenghth.Tag = "plant_length_col"
+            ucrReceiverPlantingLenghth.bExcludeFromSelector = True
+
+            ucrReceiverPropSuccess.SetParameter(New RParameter("prop_success_with_start_col", 5))
+            ucrReceiverPropSuccess.Selector = ucrSelectorCropProp
+            ucrReceiverPropSuccess.SetParameterIsString()
+            ucrReceiverPropSuccess.Tag = "prop_success_col"
+            ucrReceiverPropSuccess.bExcludeFromSelector = True
+
+            ucrReceiverPropSuccessNoStart.SetParameter(New RParameter("prop_success_no_start_col", 5))
+            ucrReceiverPropSuccessNoStart.Selector = ucrSelectorCropProp
+            ucrReceiverPropSuccessNoStart.SetParameterIsString()
+            ucrReceiverPropSuccessNoStart.Tag = "prop_success_no_start_col"
+            ucrReceiverPropSuccessNoStart.bExcludeFromSelector = True
+
+            'Season start
+            ucrReceiverSeasonStationProb.SetParameter(New RParameter("station_col", 1))
+            ucrReceiverSeasonStationProb.Selector = ucrSelectorSeasonStartProp
+            ucrReceiverSeasonStationProb.SetParameterIsString()
+            ucrReceiverSeasonStationProb.Tag = "station"
+            ucrReceiverSeasonStationProb.bExcludeFromSelector = True
+
+            ucrReceiverSeasonYear.SetParameter(New RParameter("year_col", 2))
+            ucrReceiverSeasonYear.Selector = ucrSelectorSeasonStartProp
+            ucrReceiverSeasonYear.SetParameterIsString()
+            ucrReceiverSeasonYear.Tag = "year"
+            ucrReceiverSeasonYear.bExcludeFromSelector = True
+
+            ucrReceiverSeasonPlantingDay.SetParameter(New RParameter("plant_day_col", 3))
+            ucrReceiverSeasonPlantingDay.Selector = ucrSelectorSeasonStartProp
+            ucrReceiverSeasonPlantingDay.SetParameterIsString()
+            ucrReceiverSeasonPlantingDay.Tag = "plant_day_col"
+            ucrReceiverSeasonPlantingDay.bExcludeFromSelector = True
+
+            ucrReceiverPlantingDayCondition.SetParameter(New RParameter("plant_day_cond_col", 5))
+            ucrReceiverPlantingDayCondition.Selector = ucrSelectorSeasonStartProp
+            ucrReceiverPlantingDayCondition.SetParameterIsString()
+            ucrReceiverPlantingDayCondition.Tag = "plant_day_cond_col"
+            ucrReceiverPlantingDayCondition.bExcludeFromSelector = True
+
+            'Annual Temp
+            ucrReceiverAnnualTempStation.SetParameter(New RParameter("station_col", 1))
+            ucrReceiverAnnualTempStation.Selector = ucrSelectorAnnualTemp
+            ucrReceiverAnnualTempStation.SetParameterIsString()
+            ucrReceiverAnnualTempStation.SetClimaticType("station")
+            ucrReceiverAnnualTempStation.bAutoFill = True
+            ucrReceiverAnnualTempStation.bExcludeFromSelector = True
+
+            ucrReceiverAnnualTempYr.SetParameter(New RParameter("year_col", 2))
+            ucrReceiverAnnualTempYr.Selector = ucrSelectorAnnualTemp
+            ucrReceiverAnnualTempYr.SetParameterIsString()
+            ucrReceiverAnnualTempYr.SetClimaticType("year")
+            ucrReceiverAnnualTempYr.bAutoFill = True
+            ucrReceiverAnnualTempYr.bExcludeFromSelector = True
+
+            ucrReceiverMeanAnnual.SetParameter(New RParameter("mean_tmin_col", 3))
+            ucrReceiverMeanAnnual.Selector = ucrSelectorAnnualTemp
+            ucrReceiverMeanAnnual.SetParameterIsString()
+            ucrReceiverMeanAnnual.Tag = "mean_tmin_col"
+            ucrReceiverMeanAnnual.bExcludeFromSelector = True
+
+            ucrReceiverMinMinAnnual.SetParameter(New RParameter("min_tmin_col", 4))
+            ucrReceiverMinMinAnnual.Selector = ucrSelectorAnnualTemp
+            ucrReceiverMinMinAnnual.SetParameterIsString()
+            ucrReceiverMinMinAnnual.Tag = "min_tmin_col"
+            ucrReceiverMinMinAnnual.bExcludeFromSelector = True
+
+            ucrReceiverMaxMinAnnual.SetParameter(New RParameter("max_tmin_col", 5))
+            ucrReceiverMaxMinAnnual.Selector = ucrSelectorAnnualTemp
+            ucrReceiverMaxMinAnnual.SetParameterIsString()
+            ucrReceiverMaxMinAnnual.Tag = "max_tmin_col"
+            ucrReceiverMaxMinAnnual.bExcludeFromSelector = True
+
+            ucrReceiverMeanMaxAnnual.SetParameter(New RParameter("mean_tmax_col", 6))
+            ucrReceiverMeanMaxAnnual.Selector = ucrSelectorAnnualTemp
+            ucrReceiverMeanMaxAnnual.SetParameterIsString()
+            ucrReceiverMeanMaxAnnual.Tag = "mean_tmax_col"
+            ucrReceiverMeanMaxAnnual.bExcludeFromSelector = True
+
+            ucrReceiverMinMaxAnnual.SetParameter(New RParameter("min_tmax_col", 7))
+            ucrReceiverMinMaxAnnual.Selector = ucrSelectorAnnualTemp
+            ucrReceiverMinMaxAnnual.SetParameterIsString()
+            ucrReceiverMinMaxAnnual.Tag = "min_tmax_col"
+            ucrReceiverMinMaxAnnual.bExcludeFromSelector = True
+
+            ucrReceiverMaxMaxAnnual.SetParameter(New RParameter("max_tmax_col", 8))
+            ucrReceiverMaxMaxAnnual.Selector = ucrSelectorAnnualTemp
+            ucrReceiverMaxMaxAnnual.SetParameterIsString()
+            ucrReceiverMaxMaxAnnual.Tag = "max_tmax_col"
+            ucrReceiverMaxMaxAnnual.bExcludeFromSelector = True
+
+            'Monthly Temp
+            ucrReceiverMonthlyTemp.SetParameter(New RParameter("station_col", 1))
+            ucrReceiverMonthlyTemp.Selector = ucrSelecetorMonthlyTemp
+            ucrReceiverMonthlyTemp.SetParameterIsString()
+            ucrReceiverMonthlyTemp.SetClimaticType("station")
+            ucrReceiverMonthlyTemp.bAutoFill = True
+            ucrReceiverMonthlyTemp.bExcludeFromSelector = True
+
+            ucrReceiverYearMonthly.SetParameter(New RParameter("year_col", 2))
+            ucrReceiverYearMonthly.Selector = ucrSelecetorMonthlyTemp
+            ucrReceiverYearMonthly.SetParameterIsString()
+            ucrReceiverYearMonthly.SetClimaticType("year")
+            ucrReceiverYearMonthly.bAutoFill = True
+            ucrReceiverYearMonthly.bExcludeFromSelector = True
+
+            ucrReceiverMonthMonthly.SetParameter(New RParameter("month_col", 3))
+            ucrReceiverMonthMonthly.Selector = ucrSelecetorMonthlyTemp
+            ucrReceiverMonthMonthly.SetParameterIsString()
+            ucrReceiverMonthMonthly.SetClimaticType("month")
+            ucrReceiverMonthMonthly.bAutoFill = True
+            ucrReceiverMonthMonthly.bExcludeFromSelector = True
+
+            ucrReceiverMeanminMontly.SetParameter(New RParameter("mean_tmin_col", 4))
+            ucrReceiverMeanminMontly.Selector = ucrSelecetorMonthlyTemp
+            ucrReceiverMeanminMontly.SetParameterIsString()
+            ucrReceiverMeanminMontly.Tag = "mean_tmin_col"
+            ucrReceiverMeanminMontly.bExcludeFromSelector = True
+
+            ucrReceiverMinMinMonthly.SetParameter(New RParameter("min_tmin_col", 5))
+            ucrReceiverMinMinMonthly.Selector = ucrSelecetorMonthlyTemp
+            ucrReceiverMinMinMonthly.SetParameterIsString()
+            ucrReceiverMinMinMonthly.Tag = "min_tmin_col"
+            ucrReceiverMinMinMonthly.bExcludeFromSelector = True
+
+            ucrReceiverMaxMinMonthly.SetParameter(New RParameter("max_tmin_col", 6))
+            ucrReceiverMaxMinMonthly.Selector = ucrSelecetorMonthlyTemp
+            ucrReceiverMaxMinMonthly.SetParameterIsString()
+            ucrReceiverMaxMinMonthly.Tag = "max_tmin_col"
+            ucrReceiverMaxMinMonthly.bExcludeFromSelector = True
+
+            ucrReceiverMeanmaxMonthly.SetParameter(New RParameter("mean_tmax_col", 7))
+            ucrReceiverMeanmaxMonthly.Selector = ucrSelecetorMonthlyTemp
+            ucrReceiverMeanmaxMonthly.SetParameterIsString()
+            ucrReceiverMeanmaxMonthly.Tag = "mean_tmax_col"
+            ucrReceiverMeanmaxMonthly.bExcludeFromSelector = True
+
+            ucrReceiverMinMaxMonthly.SetParameter(New RParameter("min_tmax_col", 8))
+            ucrReceiverMinMaxMonthly.Selector = ucrSelecetorMonthlyTemp
+            ucrReceiverMinMaxMonthly.SetParameterIsString()
+            ucrReceiverMinMaxMonthly.Tag = "min_tmax_col"
+            ucrReceiverMinMaxMonthly.bExcludeFromSelector = True
+
+            ucrReceiverMaxMaxMonthly.SetParameter(New RParameter("max_tmax_col", 9))
+            ucrReceiverMaxMaxMonthly.Selector = ucrSelecetorMonthlyTemp
+            ucrReceiverMaxMaxMonthly.SetParameterIsString()
+            ucrReceiverMaxMaxMonthly.Tag = "max_tmax_col"
+            ucrReceiverMaxMaxMonthly.bExcludeFromSelector = True
+            bControlsInitialised = True
+
+        End Sub
+        Public Sub SetRCode(clsNewReforMattAnnualSummaries As RFunction, clsNewExportRinstatToBucketFunction As RFunction, clsNewReformatCropSuccessFunction As RFunction, clsNewReformatMonthlyTempSummaries As RFunction, clsNewReformatSeasonStartFunction As RFunction, clsNewReformatTempSummariesFunction As RFunction, Optional bReset As Boolean = False)
+            If Not bControlsInitialised Then
+                InitialiseControls()
+            End If
+
+            clsReforMattAnnualSummariesFunction = clsNewReforMattAnnualSummaries
+            clsReformatCropSuccessFunction = clsNewReformatCropSuccessFunction
+            clsReformatMonthlyTempSummaries = clsNewReformatMonthlyTempSummaries
+            clsReformatSeasonStartFunction = clsNewReformatSeasonStartFunction
+            clsReformatTempSummariesFunction = clsNewReformatTempSummariesFunction
+            clsExportRinstatToBucketFunction = clsNewExportRinstatToBucketFunction
+
+            ucrReceiverSeasonalLength.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("seasonal_length_column", 12), iAdditionalPairNo:=1)
+            ucrReceiverEndSeasonDOY.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("end_season_column", 7), iAdditionalPairNo:=1)
+            ucrReceiverStartRainDOY.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("start_rains_column", 3), iAdditionalPairNo:=1)
+            ucrReceiverEndRainsDOY.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("end_rains_column", 6), iAdditionalPairNo:=1)
+
+            ucrReceiverMinMaxAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("min_tmax_column", 7), iAdditionalPairNo:=1)
+            ucrReceiverMaxMaxAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("max_tmax_column", 8), iAdditionalPairNo:=1)
+            ucrReceiverMeanMaxAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("mean_tmax_column", 6), iAdditionalPairNo:=1)
+            ucrReceiverMeanAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("mean_tmin_column", 3), iAdditionalPairNo:=1)
+            ucrReceiverMinMinAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("min_tmin_column", 4), iAdditionalPairNo:=1)
+            ucrReceiverMaxMinAnnual.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("max_tmin_column", 5), iAdditionalPairNo:=1)
+
+            ucrReceiverMeanmaxMonthly.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("mean_monthly_tmax_column", 5), iAdditionalPairNo:=1)
+            ucrReceiverMinMaxMonthly.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("min_monthly_tmax_column", 6), iAdditionalPairNo:=1)
+            ucrReceiverMaxMaxMonthly.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("max_monthly_tmax_column", 7), iAdditionalPairNo:=1)
+            ucrReceiverMaxMinMonthly.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("max_monthly_tmin_column", 8), iAdditionalPairNo:=1)
+            ucrReceiverMinMinMonthly.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("min_monthly_tmin_column", 9), iAdditionalPairNo:=1)
+            ucrReceiverMeanminMontly.AddAdditionalCodeParameterPair(clsExportRinstatToBucketFunction, New RParameter("mean_monthly_tmin_column", 10), iAdditionalPairNo:=1)
+
+            ucrReceiverAnnualRain.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrReceiverExtremRian.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+
+            ucrReceiverEndRainsDate.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrReceiverEndRainsDOY.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrReceiverEndSeasonDate.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrReceiverEndSeasonDOY.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrReceiverRainDaysSeason.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrReceiverRainDaysYear.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrReceiverSeasonalLength.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrReceiverSeasonalRain.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrReceiverStartRainDate.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrReceiverStartRainDOY.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrReceiverStation.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrReceiverYear.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrSelectorDefineAnnualRain.SetRCode(clsReforMattAnnualSummariesFunction, bReset)
+            ucrReceiverStartRainStatus.SetRCode(clsExportRinstatToBucketFunction, bReset)
+            ucrReceiverEndRainStatus.SetRCode(clsExportRinstatToBucketFunction, bReset)
+            ucrReceiverEndSeasonStatus.SetRCode(clsExportRinstatToBucketFunction, bReset)
+
+            ucrReceiverStationCrop.SetRCode(clsReformatCropSuccessFunction, bReset)
+            ucrReceiverTotalRain.SetRCode(clsReformatCropSuccessFunction, bReset)
+            ucrReceiverPlantingDay.SetRCode(clsReformatCropSuccessFunction, bReset)
+            ucrReceiverPlantingLenghth.SetRCode(clsReformatCropSuccessFunction, bReset)
+            ucrReceiverPropSuccess.SetRCode(clsReformatCropSuccessFunction, bReset)
+            ucrReceiverPropSuccessNoStart.SetRCode(clsReformatCropSuccessFunction, bReset)
+            ucrSelectorCropProp.SetRCode(clsReformatCropSuccessFunction, bReset)
+
+            ucrReceiverSeasonStationProb.SetRCode(clsReformatSeasonStartFunction, bReset)
+            ucrReceiverSeasonYear.SetRCode(clsReformatSeasonStartFunction, bReset)
+            ucrReceiverSeasonPlantingDay.SetRCode(clsReformatSeasonStartFunction, bReset)
+            ucrReceiverPlantingDayCondition.SetRCode(clsReformatSeasonStartFunction, bReset)
+            ucrSelectorSeasonStartProp.SetRCode(clsReformatSeasonStartFunction, bReset)
+
+            ucrReceiverAnnualTempStation.SetRCode(clsReformatTempSummariesFunction, bReset)
+            ucrReceiverAnnualTempYr.SetRCode(clsReformatTempSummariesFunction, bReset)
+            ucrReceiverMeanAnnual.SetRCode(clsReformatTempSummariesFunction, bReset)
+            ucrReceiverMinMaxAnnual.SetRCode(clsReformatTempSummariesFunction, bReset)
+            ucrReceiverMaxMinAnnual.SetRCode(clsReformatTempSummariesFunction, bReset)
+            ucrReceiverMaxMaxAnnual.SetRCode(clsReformatTempSummariesFunction, bReset)
+            ucrReceiverMinMinAnnual.SetRCode(clsReformatTempSummariesFunction, bReset)
+            ucrReceiverMeanMaxAnnual.SetRCode(clsReformatTempSummariesFunction, bReset)
+            ucrSelectorAnnualTemp.SetRCode(clsReformatTempSummariesFunction, bReset)
+
+            ucrReceiverMonthlyTemp.SetRCode(clsReformatMonthlyTempSummaries, bReset)
+            ucrReceiverYearMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
+            ucrReceiverMonthMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
+            ucrReceiverMeanmaxMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
+            ucrReceiverMinMaxMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
+            ucrReceiverMaxMinMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
+            ucrReceiverMaxMaxMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
+            ucrReceiverMinMinMonthly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
+            ucrReceiverMeanminMontly.SetRCode(clsReformatMonthlyTempSummaries, bReset)
+            ucrSelecetorMonthlyTemp.SetRCode(clsReformatMonthlyTempSummaries, bReset)
+            AutoFillReceivers()
+            AutoFillReceiversCrop()
+            AutoFillReceiversForAnnualTemp()
+            AutoFillReceiversForMonthlyTemp()
+            AutoFillReceiversForSeasonsStart()
+        End Sub
+
+        Private Sub ucrReceiverAnnualRain_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverAnnualRain.ControlValueChanged, ucrReceiverEndRainsDate.ControlValueChanged, ucrReceiverEndRainsDOY.ControlValueChanged, ucrReceiverEndSeasonDate.ControlValueChanged,
             ucrReceiverEndSeasonDOY.ControlValueChanged, ucrReceiverRainDaysSeason.ControlValueChanged, ucrReceiverRainDaysYear.ControlValueChanged, ucrReceiverSeasonalLength.ControlValueChanged, ucrReceiverSeasonalRain.ControlValueChanged,
-            ucrReceiverStartRainDate.ControlValueChanged, ucrReceiverStartRainDOY.ControlValueChanged, ucrReceiverStation.ControlValueChanged, ucrReceiverYear.ControlValueChanged, ucrReceiverExtremRian.ControlValueChanged, ucrReceiverLongestRainfallSpell.ControlValueChanged,
-            ucrReceiverExtremeMaxTemp.ControlValueChanged, ucrReceiverExtremeMinTemp.ControlValueChanged, ucrReceiverLongestMinTempSpell.ControlValueChanged, ucrReceiverLongestMaxTempSpell.ControlValueChanged
+            ucrReceiverStartRainDate.ControlValueChanged, ucrReceiverStartRainDOY.ControlValueChanged, ucrReceiverStation.ControlValueChanged, ucrReceiverYear.ControlValueChanged, ucrReceiverExtremRian.ControlValueChanged
 
-        If dlgExportClimaticDefinitions.ucrChkAnnualRainfall.Checked Then
-            If Not ucrReceiverStation.IsEmpty AndAlso Not ucrReceiverYear.IsEmpty AndAlso (Not ucrReceiverAnnualRain.IsEmpty OrElse Not ucrReceiverEndRainsDate.IsEmpty OrElse Not ucrReceiverEndRainsDOY.IsEmpty OrElse Not ucrReceiverSeasonalLength.IsEmpty OrElse Not ucrReceiverExtremRian.IsEmpty OrElse Not ucrReceiverSeasonalRain.IsEmpty OrElse
+            If dlgExportClimaticDefinitions.ucrChkAnnualRainfall.Checked Then
+                If Not ucrReceiverStation.IsEmpty AndAlso Not ucrReceiverYear.IsEmpty AndAlso (Not ucrReceiverAnnualRain.IsEmpty OrElse Not ucrReceiverEndRainsDate.IsEmpty OrElse Not ucrReceiverEndRainsDOY.IsEmpty OrElse Not ucrReceiverSeasonalLength.IsEmpty OrElse Not ucrReceiverExtremRian.IsEmpty OrElse Not ucrReceiverSeasonalRain.IsEmpty OrElse
              Not ucrReceiverEndSeasonDate.IsEmpty OrElse Not ucrReceiverEndSeasonDOY.IsEmpty OrElse Not ucrReceiverRainDaysSeason.IsEmpty OrElse Not ucrReceiverRainDaysYear.IsEmpty OrElse Not ucrReceiverStartRainDate.IsEmpty OrElse
-             Not ucrReceiverStartRainDOY.IsEmpty OrElse Not ucrReceiverExtremeMinTemp.IsEmpty OrElse Not ucrReceiverExtremeMaxTemp.IsEmpty OrElse Not ucrReceiverLongestRainfallSpell.IsEmpty OrElse Not ucrReceiverLongestMinTempSpell.IsEmpty OrElse Not ucrReceiverLongestMaxTempSpell.IsEmpty) Then
+             Not ucrReceiverStartRainDOY.IsEmpty) Then
 
-                clsExportRinstatToBucketFunction.AddParameter("annual_rainfall_data", clsRFunctionParameter:=clsReforMattAnnualSummariesFunction, iPosition:=1)
+                    clsExportRinstatToBucketFunction.AddParameter("annual_rainfall_data", clsRFunctionParameter:=clsReforMattAnnualSummariesFunction, iPosition:=1)
 
+                Else
+                    clsExportRinstatToBucketFunction.RemoveParameterByName("annual_rainfall_data")
+                End If
             Else
                 clsExportRinstatToBucketFunction.RemoveParameterByName("annual_rainfall_data")
             End If
-        Else
-            clsExportRinstatToBucketFunction.RemoveParameterByName("annual_rainfall_data")
-        End If
-        AddAnnualSummariesPar()
-    End Sub
+            AddAnnualSummariesPar()
+        End Sub
 
-    Private Sub ucrReceiverStationCrop_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverStationCrop.ControlValueChanged, ucrReceiverTotalRain.ControlValueChanged, ucrReceiverPlantingDay.ControlValueChanged, ucrReceiverPlantingLenghth.ControlValueChanged,
+        Private Sub ucrReceiverStationCrop_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverStationCrop.ControlValueChanged, ucrReceiverTotalRain.ControlValueChanged, ucrReceiverPlantingDay.ControlValueChanged, ucrReceiverPlantingLenghth.ControlValueChanged,
             ucrReceiverPropSuccess.ControlValueChanged, ucrReceiverPropSuccessNoStart.ControlValueChanged
 
-        If dlgExportClimaticDefinitions.ucrChkCropSuccessProp.Checked Then
+            If dlgExportClimaticDefinitions.ucrChkCropSuccessProp.Checked Then
 
-            If Not ucrReceiverStationCrop.IsEmpty AndAlso (Not ucrReceiverTotalRain.IsEmpty OrElse Not ucrReceiverPlantingDay.IsEmpty OrElse Not ucrReceiverPlantingLenghth.IsEmpty OrElse Not ucrReceiverPropSuccess.IsEmpty OrElse Not ucrReceiverPropSuccessNoStart.IsEmpty) Then
-                clsExportRinstatToBucketFunction.AddParameter("crop_success_data", clsRFunctionParameter:=clsReformatCropSuccessFunction, iPosition:=9)
+                If Not ucrReceiverStationCrop.IsEmpty AndAlso (Not ucrReceiverTotalRain.IsEmpty OrElse Not ucrReceiverPlantingDay.IsEmpty OrElse Not ucrReceiverPlantingLenghth.IsEmpty OrElse Not ucrReceiverPropSuccess.IsEmpty OrElse Not ucrReceiverPropSuccessNoStart.IsEmpty) Then
+                    clsExportRinstatToBucketFunction.AddParameter("crop_success_data", clsRFunctionParameter:=clsReformatCropSuccessFunction, iPosition:=9)
+                Else
+                    clsExportRinstatToBucketFunction.RemoveParameterByName("crop_success_data")
+                End If
             Else
                 clsExportRinstatToBucketFunction.RemoveParameterByName("crop_success_data")
             End If
-        Else
-            clsExportRinstatToBucketFunction.RemoveParameterByName("crop_success_data")
-        End If
-    End Sub
+        End Sub
 
-    Private Sub ucrReceiverSeasonStationProb_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverSeasonStationProb.ControlValueChanged, ucrReceiverSeasonPlantingDay.ControlValueChanged, ucrReceiverPlantingDayCondition.ControlValueChanged, ucrReceiverSeasonYear.ControlValueChanged
-        If dlgExportClimaticDefinitions.ucrChkSeasonStartProp.Checked Then
-            If Not ucrReceiverSeasonStationProb.IsEmpty AndAlso Not ucrReceiverSeasonYear.IsEmpty AndAlso (Not ucrReceiverSeasonPlantingDay.IsEmpty OrElse Not ucrReceiverPlantingDayCondition.IsEmpty) Then
-                clsExportRinstatToBucketFunction.AddParameter("season_start_data", clsRFunctionParameter:=clsReformatSeasonStartFunction, iPosition:=10)
+        Private Sub ucrReceiverSeasonStationProb_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverSeasonStationProb.ControlValueChanged, ucrReceiverSeasonPlantingDay.ControlValueChanged, ucrReceiverPlantingDayCondition.ControlValueChanged, ucrReceiverSeasonYear.ControlValueChanged
+            If dlgExportClimaticDefinitions.ucrChkSeasonStartProp.Checked Then
+                If Not ucrReceiverSeasonStationProb.IsEmpty AndAlso Not ucrReceiverSeasonYear.IsEmpty AndAlso (Not ucrReceiverSeasonPlantingDay.IsEmpty OrElse Not ucrReceiverPlantingDayCondition.IsEmpty) Then
+                    clsExportRinstatToBucketFunction.AddParameter("season_start_data", clsRFunctionParameter:=clsReformatSeasonStartFunction, iPosition:=10)
+                Else
+                    clsExportRinstatToBucketFunction.RemoveParameterByName("season_start_data")
+                End If
             Else
                 clsExportRinstatToBucketFunction.RemoveParameterByName("season_start_data")
             End If
-        Else
-            clsExportRinstatToBucketFunction.RemoveParameterByName("season_start_data")
-        End If
-    End Sub
+        End Sub
 
-    Private Sub ucrReceiverAnnualTempStation_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverAnnualTempStation.ControlValueChanged, ucrReceiverAnnualTempYr.ControlValueChanged, ucrReceiverMaxMaxAnnual.ControlValueChanged, ucrReceiverMaxMinAnnual.ControlValueChanged, ucrReceiverMeanAnnual.ControlValueChanged, ucrReceiverMeanMaxAnnual.ControlValueChanged, ucrReceiverMinMaxAnnual.ControlValueChanged, ucrReceiverMinMinAnnual.ControlValueChanged
+        Private Sub ucrReceiverAnnualTempStation_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverAnnualTempStation.ControlValueChanged, ucrReceiverAnnualTempYr.ControlValueChanged, ucrReceiverMaxMaxAnnual.ControlValueChanged, ucrReceiverMaxMinAnnual.ControlValueChanged, ucrReceiverMeanAnnual.ControlValueChanged, ucrReceiverMeanMaxAnnual.ControlValueChanged, ucrReceiverMinMaxAnnual.ControlValueChanged, ucrReceiverMinMinAnnual.ControlValueChanged
 
-        If dlgExportClimaticDefinitions.ucrChkAnnualTemp.Checked Then
-            If Not ucrReceiverAnnualTempStation.IsEmpty AndAlso Not ucrReceiverAnnualTempYr.IsEmpty AndAlso (Not ucrReceiverMaxMaxAnnual.IsEmpty OrElse
+            If dlgExportClimaticDefinitions.ucrChkAnnualTemp.Checked Then
+                If Not ucrReceiverAnnualTempStation.IsEmpty AndAlso Not ucrReceiverAnnualTempYr.IsEmpty AndAlso (Not ucrReceiverMaxMaxAnnual.IsEmpty OrElse
                             Not ucrReceiverMaxMinAnnual.IsEmpty OrElse Not ucrReceiverMeanAnnual.IsEmpty OrElse Not ucrReceiverMeanMaxAnnual.IsEmpty OrElse Not ucrReceiverMinMaxAnnual.IsEmpty OrElse Not ucrReceiverMinMinAnnual.IsEmpty) Then
-                clsExportRinstatToBucketFunction.AddParameter("annual_temperature_data", clsRFunctionParameter:=clsReformatTempSummariesFunction, iPosition:=11)
+                    clsExportRinstatToBucketFunction.AddParameter("annual_temperature_data", clsRFunctionParameter:=clsReformatTempSummariesFunction, iPosition:=11)
+                Else
+                    clsExportRinstatToBucketFunction.RemoveParameterByName("annual_temperature_data")
+                End If
             Else
                 clsExportRinstatToBucketFunction.RemoveParameterByName("annual_temperature_data")
             End If
-        Else
-            clsExportRinstatToBucketFunction.RemoveParameterByName("annual_temperature_data")
-        End If
-    End Sub
+        End Sub
 
-    Private Sub ucrReceiverMonthlyTemp_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverMonthlyTemp.ControlValueChanged, ucrReceiverYearMonthly.ControlValueChanged, ucrReceiverMonthMonthly.ControlValueChanged, ucrReceiverMeanmaxMonthly.ControlValueChanged, ucrReceiverMeanminMontly.ControlValueChanged, ucrReceiverMinMaxMonthly.ControlValueChanged, ucrReceiverMinMinMonthly.ControlValueChanged, ucrReceiverMaxMinMonthly.ControlValueChanged, ucrReceiverMaxMaxMonthly.ControlValueChanged
-        If dlgExportClimaticDefinitions.ucrChkMonthlyTemp.Checked Then
-            If Not ucrReceiverMonthlyTemp.IsEmpty AndAlso Not ucrReceiverYearMonthly.IsEmpty AndAlso Not ucrReceiverMonthMonthly.IsEmpty AndAlso (Not ucrReceiverMeanmaxMonthly.IsEmpty OrElse Not ucrReceiverMeanminMontly.IsEmpty OrElse Not ucrReceiverMinMaxMonthly.IsEmpty OrElse Not ucrReceiverMinMinMonthly.IsEmpty OrElse Not ucrReceiverMaxMinMonthly.IsEmpty OrElse Not ucrReceiverMaxMaxMonthly.IsEmpty) Then
-                clsExportRinstatToBucketFunction.AddParameter("monthly_temperature_data", clsRFunctionParameter:=clsReformatMonthlyTempSummaries, iPosition:=18)
+        Private Sub ucrReceiverMonthlyTemp_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverMonthlyTemp.ControlValueChanged, ucrReceiverYearMonthly.ControlValueChanged, ucrReceiverMonthMonthly.ControlValueChanged, ucrReceiverMeanmaxMonthly.ControlValueChanged, ucrReceiverMeanminMontly.ControlValueChanged, ucrReceiverMinMaxMonthly.ControlValueChanged, ucrReceiverMinMinMonthly.ControlValueChanged, ucrReceiverMaxMinMonthly.ControlValueChanged, ucrReceiverMaxMaxMonthly.ControlValueChanged
+            If dlgExportClimaticDefinitions.ucrChkMonthlyTemp.Checked Then
+                If Not ucrReceiverMonthlyTemp.IsEmpty AndAlso Not ucrReceiverYearMonthly.IsEmpty AndAlso Not ucrReceiverMonthMonthly.IsEmpty AndAlso (Not ucrReceiverMeanmaxMonthly.IsEmpty OrElse Not ucrReceiverMeanminMontly.IsEmpty OrElse Not ucrReceiverMinMaxMonthly.IsEmpty OrElse Not ucrReceiverMinMinMonthly.IsEmpty OrElse Not ucrReceiverMaxMinMonthly.IsEmpty OrElse Not ucrReceiverMaxMaxMonthly.IsEmpty) Then
+                    clsExportRinstatToBucketFunction.AddParameter("monthly_temperature_data", clsRFunctionParameter:=clsReformatMonthlyTempSummaries, iPosition:=18)
+                Else
+                    clsExportRinstatToBucketFunction.RemoveParameterByName("monthly_temperature_data")
+                End If
             Else
                 clsExportRinstatToBucketFunction.RemoveParameterByName("monthly_temperature_data")
             End If
-        Else
-            clsExportRinstatToBucketFunction.RemoveParameterByName("monthly_temperature_data")
-        End If
-    End Sub
+        End Sub
 
-    Private Sub AutoFillReceivers()
-        If isFilling Then
-            Exit Sub
-        End If
-        isFilling = True
+        Private Sub AutoFillReceivers()
+            If isFilling Then
+                Exit Sub
+            End If
+            isFilling = True
 
-        ' Temporarily remove the event handler
-        RemoveHandler ucrSelectorDefineAnnualRain.ControlValueChanged, AddressOf AutoFillReceivers
+            ' Temporarily remove the event handler
+            RemoveHandler ucrSelectorDefineAnnualRain.ControlValueChanged, AddressOf AutoFillReceivers
 
-        Dim lstRecognisedValues As List(Of String)
-        Dim ucrCurrentReceiver As ucrReceiver
-        Dim bFound As Boolean = False
+            Dim lstRecognisedValues As List(Of String)
+            Dim ucrCurrentReceiver As ucrReceiver
+            Dim bFound As Boolean = False
 
-        ucrCurrentReceiver = ucrSelectorDefineAnnualRain.CurrentReceiver
+            ucrCurrentReceiver = ucrSelectorDefineAnnualRain.CurrentReceiver
 
-        For Each ucrTempReceiver As ucrReceiver In lstReceivers
-            ucrTempReceiver.SetMeAsReceiver()
-            lstRecognisedValues = GetRecognisedValues(ucrTempReceiver.Tag)
+            For Each ucrTempReceiver As ucrReceiver In lstReceivers
+                ucrTempReceiver.SetMeAsReceiver()
+                lstRecognisedValues = GetRecognisedValues(ucrTempReceiver.Tag)
 
-            If lstRecognisedValues.Count > 0 Then
-                For Each lviTempVariable As ListViewItem In ucrSelectorDefineAnnualRain.lstAvailableVariable.Items
-                    For Each strValue As String In lstRecognisedValues
-                        If Regex.Replace(lviTempVariable.Text.ToLower(), "[^\w]", String.Empty).Equals(strValue) Then
-                            ucrTempReceiver.Add(lviTempVariable.Text, ucrSelectorDefineAnnualRain.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
-                            bFound = True
+                If lstRecognisedValues.Count > 0 Then
+                    For Each lviTempVariable As ListViewItem In ucrSelectorDefineAnnualRain.lstAvailableVariable.Items
+                        For Each strValue As String In lstRecognisedValues
+                            If Regex.Replace(lviTempVariable.Text.ToLower(), "[^\w]", String.Empty).Equals(strValue) Then
+                                ucrTempReceiver.Add(lviTempVariable.Text, ucrSelectorDefineAnnualRain.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
+                                bFound = True
+                                Exit For
+                            End If
+                        Next
+                        If bFound Then
+                            bFound = False
                             Exit For
                         End If
                     Next
-                    If bFound Then
-                        bFound = False
-                        Exit For
-                    End If
-                Next
+                End If
+            Next
+
+            If ucrCurrentReceiver IsNot Nothing Then
+                ucrCurrentReceiver.SetMeAsReceiver()
             End If
-        Next
 
-        If ucrCurrentReceiver IsNot Nothing Then
-            ucrCurrentReceiver.SetMeAsReceiver()
-        End If
+            ' Re-enable the event handler
+            AddHandler ucrSelectorDefineAnnualRain.ControlValueChanged, AddressOf AutoFillReceivers
 
-        ' Re-enable the event handler
-        AddHandler ucrSelectorDefineAnnualRain.ControlValueChanged, AddressOf AutoFillReceivers
+            isFilling = False
+        End Sub
 
-        isFilling = False
-    End Sub
+        Private Sub AutoFillReceiversCrop()
+            If isFilling Then
+                Exit Sub
+            End If
+            isFilling = True
 
-    Private Sub AutoFillReceiversCrop()
-        If isFilling Then
-            Exit Sub
-        End If
-        isFilling = True
+            ' Temporarily remove the event handler
+            RemoveHandler ucrSelectorCropProp.ControlValueChanged, AddressOf AutoFillReceiversCrop
 
-        ' Temporarily remove the event handler
-        RemoveHandler ucrSelectorCropProp.ControlValueChanged, AddressOf AutoFillReceiversCrop
+            Dim lstRecognisedValues As List(Of String)
+            Dim ucrCurrentReceiver As ucrReceiver
+            Dim bFound As Boolean = False
 
-        Dim lstRecognisedValues As List(Of String)
-        Dim ucrCurrentReceiver As ucrReceiver
-        Dim bFound As Boolean = False
+            ucrCurrentReceiver = ucrSelectorCropProp.CurrentReceiver
 
-        ucrCurrentReceiver = ucrSelectorCropProp.CurrentReceiver
+            For Each ucrTempReceiver As ucrReceiver In lstReceiversCrop
+                ucrTempReceiver.SetMeAsReceiver()
+                lstRecognisedValues = GetRecognisedValuesCrop(ucrTempReceiver.Tag)
 
-        For Each ucrTempReceiver As ucrReceiver In lstReceiversCrop
-            ucrTempReceiver.SetMeAsReceiver()
-            lstRecognisedValues = GetRecognisedValuesCrop(ucrTempReceiver.Tag)
-
-            If lstRecognisedValues.Count > 0 Then
-                For Each lviTempVariable As ListViewItem In ucrSelectorCropProp.lstAvailableVariable.Items
-                    For Each strValue As String In lstRecognisedValues
-                        If Regex.Replace(lviTempVariable.Text.ToLower(), "[^\w]", String.Empty).Equals(strValue) Then
-                            ucrTempReceiver.Add(lviTempVariable.Text, ucrSelectorCropProp.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
-                            bFound = True
+                If lstRecognisedValues.Count > 0 Then
+                    For Each lviTempVariable As ListViewItem In ucrSelectorCropProp.lstAvailableVariable.Items
+                        For Each strValue As String In lstRecognisedValues
+                            If Regex.Replace(lviTempVariable.Text.ToLower(), "[^\w]", String.Empty).Equals(strValue) Then
+                                ucrTempReceiver.Add(lviTempVariable.Text, ucrSelectorCropProp.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
+                                bFound = True
+                                Exit For
+                            End If
+                        Next
+                        If bFound Then
+                            bFound = False
                             Exit For
                         End If
                     Next
-                    If bFound Then
-                        bFound = False
-                        Exit For
-                    End If
-                Next
+                End If
+            Next
+
+            If ucrCurrentReceiver IsNot Nothing Then
+                ucrCurrentReceiver.SetMeAsReceiver()
             End If
-        Next
 
-        If ucrCurrentReceiver IsNot Nothing Then
-            ucrCurrentReceiver.SetMeAsReceiver()
-        End If
+            ' Re-enable the event handler
+            AddHandler ucrSelectorCropProp.ControlValueChanged, AddressOf AutoFillReceiversCrop
 
-        ' Re-enable the event handler
-        AddHandler ucrSelectorCropProp.ControlValueChanged, AddressOf AutoFillReceiversCrop
+            isFilling = False
+        End Sub
 
-        isFilling = False
-    End Sub
+        Private Sub AutoFillReceiversForSeasonsStart()
+            If isFilling Then
+                Exit Sub
+            End If
+            isFilling = True
 
-    Private Sub AutoFillReceiversForSeasonsStart()
-        If isFilling Then
-            Exit Sub
-        End If
-        isFilling = True
+            ' Temporarily remove the event handler
+            RemoveHandler ucrSelectorSeasonStartProp.ControlValueChanged, AddressOf AutoFillReceiversForSeasonsStart
 
-        ' Temporarily remove the event handler
-        RemoveHandler ucrSelectorSeasonStartProp.ControlValueChanged, AddressOf AutoFillReceiversForSeasonsStart
+            Dim lstRecognisedValues As List(Of String)
+            Dim ucrCurrentReceiver As ucrReceiver
+            Dim bFound As Boolean = False
 
-        Dim lstRecognisedValues As List(Of String)
-        Dim ucrCurrentReceiver As ucrReceiver
-        Dim bFound As Boolean = False
+            ucrCurrentReceiver = ucrSelectorSeasonStartProp.CurrentReceiver
 
-        ucrCurrentReceiver = ucrSelectorSeasonStartProp.CurrentReceiver
+            For Each ucrTempReceiver As ucrReceiver In lstReceiversProp
+                ucrTempReceiver.SetMeAsReceiver()
+                lstRecognisedValues = GetRecognisedValuesProp(ucrTempReceiver.Tag)
 
-        For Each ucrTempReceiver As ucrReceiver In lstReceiversProp
-            ucrTempReceiver.SetMeAsReceiver()
-            lstRecognisedValues = GetRecognisedValuesProp(ucrTempReceiver.Tag)
-
-            If lstRecognisedValues.Count > 0 Then
-                For Each lviTempVariable As ListViewItem In ucrSelectorSeasonStartProp.lstAvailableVariable.Items
-                    For Each strValue As String In lstRecognisedValues
-                        If Regex.Replace(lviTempVariable.Text.ToLower(), "[^\w]", String.Empty).Equals(strValue) Then
-                            ucrTempReceiver.Add(lviTempVariable.Text, ucrSelectorSeasonStartProp.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
-                            bFound = True
+                If lstRecognisedValues.Count > 0 Then
+                    For Each lviTempVariable As ListViewItem In ucrSelectorSeasonStartProp.lstAvailableVariable.Items
+                        For Each strValue As String In lstRecognisedValues
+                            If Regex.Replace(lviTempVariable.Text.ToLower(), "[^\w]", String.Empty).Equals(strValue) Then
+                                ucrTempReceiver.Add(lviTempVariable.Text, ucrSelectorSeasonStartProp.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
+                                bFound = True
+                                Exit For
+                            End If
+                        Next
+                        If bFound Then
+                            bFound = False
                             Exit For
                         End If
                     Next
-                    If bFound Then
-                        bFound = False
-                        Exit For
-                    End If
-                Next
+                End If
+            Next
+
+            If ucrCurrentReceiver IsNot Nothing Then
+                ucrCurrentReceiver.SetMeAsReceiver()
             End If
-        Next
 
-        If ucrCurrentReceiver IsNot Nothing Then
-            ucrCurrentReceiver.SetMeAsReceiver()
-        End If
+            ' Re-enable the event handler
+            AddHandler ucrSelectorSeasonStartProp.ControlValueChanged, AddressOf AutoFillReceiversForSeasonsStart
 
-        ' Re-enable the event handler
-        AddHandler ucrSelectorSeasonStartProp.ControlValueChanged, AddressOf AutoFillReceiversForSeasonsStart
+            isFilling = False
+        End Sub
 
-        isFilling = False
-    End Sub
+        Private Sub AutoFillReceiversForAnnualTemp()
+            If isFilling Then
+                Exit Sub
+            End If
+            isFilling = True
 
-    Private Sub AutoFillReceiversForAnnualTemp()
-        If isFilling Then
-            Exit Sub
-        End If
-        isFilling = True
+            ' Temporarily remove the event handler
+            RemoveHandler ucrSelectorAnnualTemp.ControlValueChanged, AddressOf AutoFillReceiversForAnnualTemp
 
-        ' Temporarily remove the event handler
-        RemoveHandler ucrSelectorAnnualTemp.ControlValueChanged, AddressOf AutoFillReceiversForAnnualTemp
+            Dim lstRecognisedValues As List(Of String)
+            Dim ucrCurrentReceiver As ucrReceiver
+            Dim bFound As Boolean = False
 
-        Dim lstRecognisedValues As List(Of String)
-        Dim ucrCurrentReceiver As ucrReceiver
-        Dim bFound As Boolean = False
+            ucrCurrentReceiver = ucrSelectorAnnualTemp.CurrentReceiver
 
-        ucrCurrentReceiver = ucrSelectorAnnualTemp.CurrentReceiver
+            For Each ucrTempReceiver As ucrReceiver In lstReceiversAnnualTemp
+                ucrTempReceiver.SetMeAsReceiver()
+                lstRecognisedValues = GetRecognisedValuesAnnTemp(ucrTempReceiver.Tag)
 
-        For Each ucrTempReceiver As ucrReceiver In lstReceiversAnnualTemp
-            ucrTempReceiver.SetMeAsReceiver()
-            lstRecognisedValues = GetRecognisedValuesAnnTemp(ucrTempReceiver.Tag)
-
-            If lstRecognisedValues.Count > 0 Then
-                For Each lviTempVariable As ListViewItem In ucrSelectorAnnualTemp.lstAvailableVariable.Items
-                    For Each strValue As String In lstRecognisedValues
-                        If Regex.Replace(lviTempVariable.Text.ToLower(), "[^\w]", String.Empty).Equals(strValue) Then
-                            ucrTempReceiver.Add(lviTempVariable.Text, ucrSelectorAnnualTemp.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
-                            bFound = True
+                If lstRecognisedValues.Count > 0 Then
+                    For Each lviTempVariable As ListViewItem In ucrSelectorAnnualTemp.lstAvailableVariable.Items
+                        For Each strValue As String In lstRecognisedValues
+                            If Regex.Replace(lviTempVariable.Text.ToLower(), "[^\w]", String.Empty).Equals(strValue) Then
+                                ucrTempReceiver.Add(lviTempVariable.Text, ucrSelectorAnnualTemp.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
+                                bFound = True
+                                Exit For
+                            End If
+                        Next
+                        If bFound Then
+                            bFound = False
                             Exit For
                         End If
                     Next
-                    If bFound Then
-                        bFound = False
-                        Exit For
-                    End If
-                Next
+                End If
+            Next
+
+            If ucrCurrentReceiver IsNot Nothing Then
+                ucrCurrentReceiver.SetMeAsReceiver()
             End If
-        Next
 
-        If ucrCurrentReceiver IsNot Nothing Then
-            ucrCurrentReceiver.SetMeAsReceiver()
-        End If
+            ' Re-enable the event handler
+            AddHandler ucrSelectorAnnualTemp.ControlValueChanged, AddressOf AutoFillReceiversForAnnualTemp
 
-        ' Re-enable the event handler
-        AddHandler ucrSelectorAnnualTemp.ControlValueChanged, AddressOf AutoFillReceiversForAnnualTemp
+            isFilling = False
+        End Sub
 
-        isFilling = False
-    End Sub
+        Private Sub AutoFillReceiversForMonthlyTemp()
+            If isFilling Then
+                Exit Sub
+            End If
+            isFilling = True
 
-    Private Sub AutoFillReceiversForMonthlyTemp()
-        If isFilling Then
-            Exit Sub
-        End If
-        isFilling = True
+            Me.SuspendLayout()
+            ' Temporarily remove the event handler
+            RemoveHandler ucrSelecetorMonthlyTemp.ControlValueChanged, AddressOf AutoFillReceiversForMonthlyTemp
 
-        Me.SuspendLayout()
-        ' Temporarily remove the event handler
-        RemoveHandler ucrSelecetorMonthlyTemp.ControlValueChanged, AddressOf AutoFillReceiversForMonthlyTemp
+            Dim lstRecognisedValues As List(Of String)
+            Dim ucrCurrentReceiver As ucrReceiver
+            Dim bFound As Boolean = False
 
-        Dim lstRecognisedValues As List(Of String)
-        Dim ucrCurrentReceiver As ucrReceiver
-        Dim bFound As Boolean = False
+            ucrCurrentReceiver = ucrSelecetorMonthlyTemp.CurrentReceiver
 
-        ucrCurrentReceiver = ucrSelecetorMonthlyTemp.CurrentReceiver
+            For Each ucrTempReceiver As ucrReceiver In lstReceiversMonthTemp
+                ucrTempReceiver.SetMeAsReceiver()
+                lstRecognisedValues = GetRecognisedValuesMothTemp(ucrTempReceiver.Tag)
 
-        For Each ucrTempReceiver As ucrReceiver In lstReceiversMonthTemp
-            ucrTempReceiver.SetMeAsReceiver()
-            lstRecognisedValues = GetRecognisedValuesMothTemp(ucrTempReceiver.Tag)
-
-            If lstRecognisedValues.Count > 0 Then
-                For Each lviTempVariable As ListViewItem In ucrSelecetorMonthlyTemp.lstAvailableVariable.Items
-                    For Each strValue As String In lstRecognisedValues
-                        If Regex.Replace(lviTempVariable.Text.ToLower(), "[^\w]", String.Empty).Equals(strValue) Then
-                            ucrTempReceiver.Add(lviTempVariable.Text, ucrSelecetorMonthlyTemp.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
-                            bFound = True
+                If lstRecognisedValues.Count > 0 Then
+                    For Each lviTempVariable As ListViewItem In ucrSelecetorMonthlyTemp.lstAvailableVariable.Items
+                        For Each strValue As String In lstRecognisedValues
+                            If Regex.Replace(lviTempVariable.Text.ToLower(), "[^\w]", String.Empty).Equals(strValue) Then
+                                ucrTempReceiver.Add(lviTempVariable.Text, ucrSelecetorMonthlyTemp.ucrAvailableDataFrames.cboAvailableDataFrames.Text)
+                                bFound = True
+                                Exit For
+                            End If
+                        Next
+                        If bFound Then
+                            bFound = False
                             Exit For
                         End If
                     Next
-                    If bFound Then
-                        bFound = False
-                        Exit For
-                    End If
-                Next
+                End If
+            Next
+
+            If ucrCurrentReceiver IsNot Nothing Then
+                ucrCurrentReceiver.SetMeAsReceiver()
             End If
-        Next
 
-        If ucrCurrentReceiver IsNot Nothing Then
-            ucrCurrentReceiver.SetMeAsReceiver()
-        End If
+            ' Re-enable the event handler
+            AddHandler ucrSelecetorMonthlyTemp.ControlValueChanged, AddressOf AutoFillReceiversForMonthlyTemp
 
-        ' Re-enable the event handler
-        AddHandler ucrSelecetorMonthlyTemp.ControlValueChanged, AddressOf AutoFillReceiversForMonthlyTemp
+            Me.ResumeLayout()
 
-        Me.ResumeLayout()
+            isFilling = False
+        End Sub
 
-        isFilling = False
-    End Sub
+        Private Function GetRecognisedValues(strVariable As String) As List(Of String)
+            Dim lstValues As New List(Of String)
 
-    Private Function GetRecognisedValues(strVariable As String) As List(Of String)
-        Dim lstValues As New List(Of String)
+            For Each kvpTemp As KeyValuePair(Of String, List(Of String)) In lstRecognisedTypes
+                If kvpTemp.Key = strVariable Then
+                    lstValues = kvpTemp.Value
+                    Exit For
+                End If
+            Next
+            Return lstValues
+        End Function
 
-        For Each kvpTemp As KeyValuePair(Of String, List(Of String)) In lstRecognisedTypes
-            If kvpTemp.Key = strVariable Then
-                lstValues = kvpTemp.Value
-                Exit For
-            End If
-        Next
-        Return lstValues
-    End Function
+        Private Function GetRecognisedValuesCrop(strVariable As String) As List(Of String)
+            Dim lstValues As New List(Of String)
 
-    Private Function GetRecognisedValuesCrop(strVariable As String) As List(Of String)
-        Dim lstValues As New List(Of String)
+            For Each kvpTemp As KeyValuePair(Of String, List(Of String)) In lstRecognisedCropTypes
+                If kvpTemp.Key = strVariable Then
+                    lstValues = kvpTemp.Value
+                    Exit For
+                End If
+            Next
+            Return lstValues
+        End Function
 
-        For Each kvpTemp As KeyValuePair(Of String, List(Of String)) In lstRecognisedCropTypes
-            If kvpTemp.Key = strVariable Then
-                lstValues = kvpTemp.Value
-                Exit For
-            End If
-        Next
-        Return lstValues
-    End Function
+        Private Function GetRecognisedValuesProp(strVariable As String) As List(Of String)
+            Dim lstValues As New List(Of String)
 
-    Private Function GetRecognisedValuesProp(strVariable As String) As List(Of String)
-        Dim lstValues As New List(Of String)
+            For Each kvpTemp As KeyValuePair(Of String, List(Of String)) In lstRecognisedPropTypes
+                If kvpTemp.Key = strVariable Then
+                    lstValues = kvpTemp.Value
+                    Exit For
+                End If
+            Next
+            Return lstValues
+        End Function
 
-        For Each kvpTemp As KeyValuePair(Of String, List(Of String)) In lstRecognisedPropTypes
-            If kvpTemp.Key = strVariable Then
-                lstValues = kvpTemp.Value
-                Exit For
-            End If
-        Next
-        Return lstValues
-    End Function
+        Private Function GetRecognisedValuesAnnTemp(strVariable As String) As List(Of String)
+            Dim lstValues As New List(Of String)
 
-    Private Function GetRecognisedValuesAnnTemp(strVariable As String) As List(Of String)
-        Dim lstValues As New List(Of String)
+            For Each kvpTemp As KeyValuePair(Of String, List(Of String)) In lstRecognisedAnnTempTypes
+                If kvpTemp.Key = strVariable Then
+                    lstValues = kvpTemp.Value
+                    Exit For
+                End If
+            Next
+            Return lstValues
+        End Function
 
-        For Each kvpTemp As KeyValuePair(Of String, List(Of String)) In lstRecognisedAnnTempTypes
-            If kvpTemp.Key = strVariable Then
-                lstValues = kvpTemp.Value
-                Exit For
-            End If
-        Next
-        Return lstValues
-    End Function
+        Private Function GetRecognisedValuesMothTemp(strVariable As String) As List(Of String)
+            Dim lstValues As New List(Of String)
 
-    Private Function GetRecognisedValuesMothTemp(strVariable As String) As List(Of String)
-        Dim lstValues As New List(Of String)
+            For Each kvpTemp As KeyValuePair(Of String, List(Of String)) In lstRecognisedMonthTempTypes
+                If kvpTemp.Key = strVariable Then
+                    lstValues = kvpTemp.Value
+                    Exit For
+                End If
+            Next
+            Return lstValues
+        End Function
+        Private Sub ucrSelecetorMonthlyTemp_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelecetorMonthlyTemp.ControlValueChanged
+            AutoFillReceiversForMonthlyTemp()
+        End Sub
 
-        For Each kvpTemp As KeyValuePair(Of String, List(Of String)) In lstRecognisedMonthTempTypes
-            If kvpTemp.Key = strVariable Then
-                lstValues = kvpTemp.Value
-                Exit For
-            End If
-        Next
-        Return lstValues
-    End Function
-    Private Sub ucrSelecetorMonthlyTemp_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelecetorMonthlyTemp.ControlValueChanged
-        AutoFillReceiversForMonthlyTemp()
-    End Sub
+        Private Sub ucrSelectorAnnualTemp_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorAnnualTemp.ControlValueChanged
+            AutoFillReceiversForAnnualTemp()
+        End Sub
 
-    Private Sub ucrSelectorAnnualTemp_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorAnnualTemp.ControlValueChanged
-        AutoFillReceiversForAnnualTemp()
-    End Sub
+        Private Sub ucrSelectorCropProp_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorCropProp.ControlValueChanged
+            AutoFillReceiversCrop()
+        End Sub
 
-    Private Sub ucrSelectorCropProp_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorCropProp.ControlValueChanged
-        AutoFillReceiversCrop()
-    End Sub
+        Private Sub ucrSelectorDefineAnnualRain_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorDefineAnnualRain.ControlValueChanged
+            AutoFillReceivers()
+        End Sub
 
-    Private Sub ucrSelectorDefineAnnualRain_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorDefineAnnualRain.ControlValueChanged
-        AutoFillReceivers()
-    End Sub
+        Private Sub ucrSelectorSeasonStartProp_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorSeasonStartProp.ControlValueChanged
+            AutoFillReceiversForSeasonsStart()
+        End Sub
 
-    Private Sub ucrSelectorSeasonStartProp_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorSeasonStartProp.ControlValueChanged
-        AutoFillReceiversForSeasonsStart()
-    End Sub
+        Private Sub AddAnnualSummariesPar()
+            ' Always handle all 4 parameters regardless of checkbox state
+            If dlgExportClimaticDefinitions.ucrChkAnnualRainfall.Checked Then
+                If Not ucrReceiverAnnualRain.IsEmpty Then
+                    clsExportRinstatToBucketFunction.AddParameter("annual_total_rain_col", ucrReceiverAnnualRain.GetVariableNames)
+                Else
+                    clsExportRinstatToBucketFunction.RemoveParameterByName("annual_total_rain_col")
+                End If
 
-    Private Sub AddAnnualSummariesPar()
-        ' Always handle all 4 parameters regardless of checkbox state
-        If dlgExportClimaticDefinitions.ucrChkAnnualRainfall.Checked Then
-            If Not ucrReceiverAnnualRain.IsEmpty Then
-                clsExportRinstatToBucketFunction.AddParameter("annual_total_rain_col", ucrReceiverAnnualRain.GetVariableNames)
+                If Not ucrReceiverSeasonalRain.IsEmpty Then
+                    clsExportRinstatToBucketFunction.AddParameter("seasonal_total_rain_col", ucrReceiverSeasonalRain.GetVariableNames)
+                Else
+                    clsExportRinstatToBucketFunction.RemoveParameterByName("seasonal_total_rain_col")
+                End If
+
+                If Not ucrReceiverRainDaysYear.IsEmpty Then
+                    clsExportRinstatToBucketFunction.AddParameter("annual_rainday_col", ucrReceiverRainDaysYear.GetVariableNames)
+                Else
+                    clsExportRinstatToBucketFunction.RemoveParameterByName("annual_rainday_col")
+                End If
+
+                If Not ucrReceiverRainDaysSeason.IsEmpty Then
+                    clsExportRinstatToBucketFunction.AddParameter("seasonal_rainday_col", ucrReceiverRainDaysSeason.GetVariableNames)
+                Else
+                    clsExportRinstatToBucketFunction.RemoveParameterByName("seasonal_rainday_col")
+                End If
             Else
+                ' Remove all 4 parameters if the checkbox is not checked
                 clsExportRinstatToBucketFunction.RemoveParameterByName("annual_total_rain_col")
-            End If
-
-            If Not ucrReceiverSeasonalRain.IsEmpty Then
-                clsExportRinstatToBucketFunction.AddParameter("seasonal_total_rain_col", ucrReceiverSeasonalRain.GetVariableNames)
-            Else
                 clsExportRinstatToBucketFunction.RemoveParameterByName("seasonal_total_rain_col")
-            End If
-
-            If Not ucrReceiverRainDaysYear.IsEmpty Then
-                clsExportRinstatToBucketFunction.AddParameter("annual_rainday_col", ucrReceiverRainDaysYear.GetVariableNames)
-            Else
                 clsExportRinstatToBucketFunction.RemoveParameterByName("annual_rainday_col")
-            End If
-
-            If Not ucrReceiverRainDaysSeason.IsEmpty Then
-                clsExportRinstatToBucketFunction.AddParameter("seasonal_rainday_col", ucrReceiverRainDaysSeason.GetVariableNames)
-            Else
                 clsExportRinstatToBucketFunction.RemoveParameterByName("seasonal_rainday_col")
             End If
-        Else
-            ' Remove all 4 parameters if the checkbox is not checked
-            clsExportRinstatToBucketFunction.RemoveParameterByName("annual_total_rain_col")
-            clsExportRinstatToBucketFunction.RemoveParameterByName("seasonal_total_rain_col")
-            clsExportRinstatToBucketFunction.RemoveParameterByName("annual_rainday_col")
-            clsExportRinstatToBucketFunction.RemoveParameterByName("seasonal_rainday_col")
-        End If
-    End Sub
+        End Sub
 
-End Class
+    End Class


### PR DESCRIPTION
As outlined in #9926


1. Removing the "Year" and "Month" receivers from the main dialog
2. Removing the "Rain" receiver from the main dialog
3. Setting up tab order correctly
4. Amending the layout to be more intuitive for the user
5. Removing the option for extremes as this is part of the annual summaries
6. Changing "Country" inputs to drop downs
7. Setting up correctly the parameter values for "Monthly Temperature Summaries" in the sdg for export_r_instat_to_buckets function