### PR TITLE
Temporarily renaming Dataframe in the Calculator

### DIFF
--- a/instat/dlgCalculator.vb
+++ b/instat/dlgCalculator.vb
@@ -112,8 +112,8 @@ Public Class dlgCalculator
         clsRemoveLabelsFunction.AddParameter("new_val", Chr(34) & Chr(34), iPosition:=3)
 
         clsGetDataframe.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_data_frame")
+        clsGetDataframe.AddParameter("use_current_filter", "FALSE")
         clsGetDataframe.SetAssignTo("`_df`")
-        clsGetDataframe.AddParameter("data_name", Chr(34) & ucrCalc.ucrSelectorForCalculations.ucrAvailableDataFrames.cboAvailableDataFrames.Text & Chr(34))
 
         clsAttachFunction.SetRCommand("attach")
         clsDetachFunction.SetRCommand("detach")
@@ -261,7 +261,7 @@ Public Class dlgCalculator
             Dim strDataFrame As String = ucrCalc.ucrSelectorForCalculations.strCurrentDataFrame
             ucrCalc.ucrTryCalculator.ucrInputTryMessage.SetName("")
             clsScalarsDataFuntion.AddParameter("data_name", Chr(34) & strDataFrame & Chr(34))
-            'clsDetachFunction.AddParameter("name", clsRFunctionParameter:=clsGetDataframe)
+            clsGetDataframe.AddParameter("data_name", Chr(34) & strDataFrame & Chr(34), iPosition:=0)
             clsAddScalarFunction.AddParameter("data_name", Chr(34) & strDataFrame & Chr(34), iPosition:=0)
             clsRemoveLabelsFunction.AddParameter("data_name", Chr(34) & strDataFrame & Chr(34), iPosition:=0)
             SaveResults()

--- a/instat/dlgCalculator.vb
+++ b/instat/dlgCalculator.vb
@@ -24,6 +24,7 @@ Public Class dlgCalculator
         Structured
     End Enum
 
+    Private clsGetDataframe As New RFunction
     Private clsAttachFunction As New RFunction
     Private clsDetachFunction As New RFunction
     Private clsRemoveLabelsFunction As New RFunction
@@ -110,9 +111,14 @@ Public Class dlgCalculator
         clsRemoveLabelsFunction.AddParameter("property", Chr(34) & "labels" & Chr(34), iPosition:=2)
         clsRemoveLabelsFunction.AddParameter("new_val", Chr(34) & Chr(34), iPosition:=3)
 
+        clsGetDataframe.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_data_frame")
+        clsGetDataframe.SetAssignTo("df")
+        clsGetDataframe.AddParameter("data_name", Chr(34) & ucrCalc.ucrSelectorForCalculations.ucrAvailableDataFrames.cboAvailableDataFrames.Text & Chr(34))
+
         clsAttachFunction.SetRCommand("attach")
         clsDetachFunction.SetRCommand("detach")
-        clsAttachFunction.AddParameter("what", clsRFunctionParameter:=ucrCalc.ucrSelectorForCalculations.ucrAvailableDataFrames.clsCurrDataFrame)
+        clsAttachFunction.AddParameter("what", clsRFunctionParameter:=clsGetDataframe)
+        clsDetachFunction.AddParameter("name", "df")
         clsDetachFunction.AddParameter("unload", "TRUE")
 
         clsAttachScalarsFunction.SetRCommand("attach")
@@ -255,7 +261,7 @@ Public Class dlgCalculator
             Dim strDataFrame As String = ucrCalc.ucrSelectorForCalculations.strCurrentDataFrame
             ucrCalc.ucrTryCalculator.ucrInputTryMessage.SetName("")
             clsScalarsDataFuntion.AddParameter("data_name", Chr(34) & strDataFrame & Chr(34))
-            clsDetachFunction.AddParameter("name", strDataFrame)
+            'clsDetachFunction.AddParameter("name", clsRFunctionParameter:=clsGetDataframe)
             clsAddScalarFunction.AddParameter("data_name", Chr(34) & strDataFrame & Chr(34), iPosition:=0)
             clsRemoveLabelsFunction.AddParameter("data_name", Chr(34) & strDataFrame & Chr(34), iPosition:=0)
             SaveResults()

--- a/instat/dlgCalculator.vb
+++ b/instat/dlgCalculator.vb
@@ -112,13 +112,13 @@ Public Class dlgCalculator
         clsRemoveLabelsFunction.AddParameter("new_val", Chr(34) & Chr(34), iPosition:=3)
 
         clsGetDataframe.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_data_frame")
-        clsGetDataframe.SetAssignTo("df")
+        clsGetDataframe.SetAssignTo("`_df`")
         clsGetDataframe.AddParameter("data_name", Chr(34) & ucrCalc.ucrSelectorForCalculations.ucrAvailableDataFrames.cboAvailableDataFrames.Text & Chr(34))
 
         clsAttachFunction.SetRCommand("attach")
         clsDetachFunction.SetRCommand("detach")
         clsAttachFunction.AddParameter("what", clsRFunctionParameter:=clsGetDataframe)
-        clsDetachFunction.AddParameter("name", "df")
+        clsDetachFunction.AddParameter("name", "`_df`")
         clsDetachFunction.AddParameter("unload", "TRUE")
 
         clsAttachScalarsFunction.SetRCommand("attach")


### PR DESCRIPTION
Fixes #9428

@lilyclements @rdstern 
This fixes the issue with a dataset and a column in the dataset having the same name i.e `sza`

This is ready for testing.