### PR TITLE
Added the Import from E-PICSA dialog.

### DIFF
--- a/instat/dlgImportFromEPicsa.Designer.vb
+++ b/instat/dlgImportFromEPicsa.Designer.vb
@@ -22,21 +22,242 @@ Partial Class dlgImportFromEPicsa
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
+        Me.ucrPnlImportFromEPicsa = New instat.UcrPanel()
+        Me.rdoDefinitions = New System.Windows.Forms.RadioButton()
+        Me.rdoData = New System.Windows.Forms.RadioButton()
+        Me.rdoStation = New System.Windows.Forms.RadioButton()
+        Me.ucrInputTokenPath = New instat.ucrInputTextBox()
+        Me.lblToken = New System.Windows.Forms.Label()
+        Me.cmdChooseFile = New System.Windows.Forms.Button()
+        Me.ucrInputComboCountry = New instat.ucrInputComboBox()
+        Me.lblCountry = New System.Windows.Forms.Label()
+        Me.ucrInputDefinitionsID = New instat.ucrInputTextBox()
+        Me.lblDefinitionsID = New System.Windows.Forms.Label()
+        Me.cmdFindFiles = New System.Windows.Forms.Button()
+        Me.ucrInputComboFindFiles = New instat.ucrInputComboBox()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.ucrSaveDefinitions = New instat.ucrSave()
         Me.SuspendLayout()
+        '
+        'ucrPnlImportFromEPicsa
+        '
+        Me.ucrPnlImportFromEPicsa.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrPnlImportFromEPicsa.Location = New System.Drawing.Point(17, 18)
+        Me.ucrPnlImportFromEPicsa.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrPnlImportFromEPicsa.Name = "ucrPnlImportFromEPicsa"
+        Me.ucrPnlImportFromEPicsa.Size = New System.Drawing.Size(429, 46)
+        Me.ucrPnlImportFromEPicsa.TabIndex = 1
+        '
+        'rdoDefinitions
+        '
+        Me.rdoDefinitions.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoDefinitions.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoDefinitions.FlatAppearance.BorderSize = 2
+        Me.rdoDefinitions.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoDefinitions.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoDefinitions.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoDefinitions.Location = New System.Drawing.Point(63, 28)
+        Me.rdoDefinitions.Name = "rdoDefinitions"
+        Me.rdoDefinitions.Size = New System.Drawing.Size(116, 27)
+        Me.rdoDefinitions.TabIndex = 2
+        Me.rdoDefinitions.Text = "Definitions"
+        Me.rdoDefinitions.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoDefinitions.UseVisualStyleBackColor = True
+        '
+        'rdoData
+        '
+        Me.rdoData.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoData.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoData.FlatAppearance.BorderSize = 2
+        Me.rdoData.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoData.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoData.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoData.Location = New System.Drawing.Point(290, 28)
+        Me.rdoData.Name = "rdoData"
+        Me.rdoData.Size = New System.Drawing.Size(116, 27)
+        Me.rdoData.TabIndex = 3
+        Me.rdoData.Text = "Data"
+        Me.rdoData.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoData.UseVisualStyleBackColor = True
+        '
+        'rdoStation
+        '
+        Me.rdoStation.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoStation.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoStation.FlatAppearance.BorderSize = 2
+        Me.rdoStation.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoStation.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoStation.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoStation.Location = New System.Drawing.Point(176, 28)
+        Me.rdoStation.Name = "rdoStation"
+        Me.rdoStation.Size = New System.Drawing.Size(116, 27)
+        Me.rdoStation.TabIndex = 4
+        Me.rdoStation.Text = "Stations"
+        Me.rdoStation.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoStation.UseVisualStyleBackColor = True
+        '
+        'ucrInputTokenPath
+        '
+        Me.ucrInputTokenPath.AddQuotesIfUnrecognised = True
+        Me.ucrInputTokenPath.AutoSize = True
+        Me.ucrInputTokenPath.IsMultiline = False
+        Me.ucrInputTokenPath.IsReadOnly = False
+        Me.ucrInputTokenPath.Location = New System.Drawing.Point(117, 81)
+        Me.ucrInputTokenPath.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrInputTokenPath.Name = "ucrInputTokenPath"
+        Me.ucrInputTokenPath.Size = New System.Drawing.Size(191, 21)
+        Me.ucrInputTokenPath.TabIndex = 5
+        '
+        'lblToken
+        '
+        Me.lblToken.AutoSize = True
+        Me.lblToken.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblToken.Location = New System.Drawing.Point(73, 84)
+        Me.lblToken.Name = "lblToken"
+        Me.lblToken.Size = New System.Drawing.Size(41, 13)
+        Me.lblToken.TabIndex = 6
+        Me.lblToken.Text = "Token:"
+        '
+        'cmdChooseFile
+        '
+        Me.cmdChooseFile.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdChooseFile.Location = New System.Drawing.Point(317, 80)
+        Me.cmdChooseFile.Name = "cmdChooseFile"
+        Me.cmdChooseFile.Size = New System.Drawing.Size(80, 23)
+        Me.cmdChooseFile.TabIndex = 7
+        Me.cmdChooseFile.Text = "Browse"
+        Me.cmdChooseFile.UseVisualStyleBackColor = True
+        '
+        'ucrInputComboCountry
+        '
+        Me.ucrInputComboCountry.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboCountry.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputComboCountry.GetSetSelectedIndex = -1
+        Me.ucrInputComboCountry.IsReadOnly = False
+        Me.ucrInputComboCountry.Location = New System.Drawing.Point(76, 149)
+        Me.ucrInputComboCountry.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrInputComboCountry.Name = "ucrInputComboCountry"
+        Me.ucrInputComboCountry.Size = New System.Drawing.Size(120, 21)
+        Me.ucrInputComboCountry.TabIndex = 23
+        '
+        'lblCountry
+        '
+        Me.lblCountry.AutoSize = True
+        Me.lblCountry.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblCountry.Location = New System.Drawing.Point(11, 149)
+        Me.lblCountry.Name = "lblCountry"
+        Me.lblCountry.Size = New System.Drawing.Size(46, 13)
+        Me.lblCountry.TabIndex = 24
+        Me.lblCountry.Text = "Country:"
+        '
+        'ucrInputDefinitionsID
+        '
+        Me.ucrInputDefinitionsID.AddQuotesIfUnrecognised = True
+        Me.ucrInputDefinitionsID.AutoSize = True
+        Me.ucrInputDefinitionsID.IsMultiline = False
+        Me.ucrInputDefinitionsID.IsReadOnly = False
+        Me.ucrInputDefinitionsID.Location = New System.Drawing.Point(99, 185)
+        Me.ucrInputDefinitionsID.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrInputDefinitionsID.Name = "ucrInputDefinitionsID"
+        Me.ucrInputDefinitionsID.Size = New System.Drawing.Size(120, 21)
+        Me.ucrInputDefinitionsID.TabIndex = 25
+        '
+        'lblDefinitionsID
+        '
+        Me.lblDefinitionsID.AutoSize = True
+        Me.lblDefinitionsID.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblDefinitionsID.Location = New System.Drawing.Point(11, 185)
+        Me.lblDefinitionsID.Name = "lblDefinitionsID"
+        Me.lblDefinitionsID.Size = New System.Drawing.Size(73, 13)
+        Me.lblDefinitionsID.TabIndex = 26
+        Me.lblDefinitionsID.Text = "Definitions ID:"
+        '
+        'cmdFindFiles
+        '
+        Me.cmdFindFiles.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdFindFiles.Location = New System.Drawing.Point(14, 221)
+        Me.cmdFindFiles.Name = "cmdFindFiles"
+        Me.cmdFindFiles.Size = New System.Drawing.Size(80, 23)
+        Me.cmdFindFiles.TabIndex = 27
+        Me.cmdFindFiles.Text = "Find Files"
+        Me.cmdFindFiles.UseVisualStyleBackColor = True
+        '
+        'ucrInputComboFindFiles
+        '
+        Me.ucrInputComboFindFiles.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboFindFiles.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputComboFindFiles.GetSetSelectedIndex = -1
+        Me.ucrInputComboFindFiles.IsReadOnly = False
+        Me.ucrInputComboFindFiles.Location = New System.Drawing.Point(121, 222)
+        Me.ucrInputComboFindFiles.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrInputComboFindFiles.Name = "ucrInputComboFindFiles"
+        Me.ucrInputComboFindFiles.Size = New System.Drawing.Size(120, 21)
+        Me.ucrInputComboFindFiles.TabIndex = 28
+        '
+        'ucrBase
+        '
+        Me.ucrBase.AutoSize = True
+        Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrBase.Location = New System.Drawing.Point(14, 308)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrBase.Name = "ucrBase"
+        Me.ucrBase.Size = New System.Drawing.Size(408, 52)
+        Me.ucrBase.TabIndex = 31
+        '
+        'ucrSaveDefinitions
+        '
+        Me.ucrSaveDefinitions.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSaveDefinitions.Location = New System.Drawing.Point(14, 267)
+        Me.ucrSaveDefinitions.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrSaveDefinitions.Name = "ucrSaveDefinitions"
+        Me.ucrSaveDefinitions.Size = New System.Drawing.Size(375, 22)
+        Me.ucrSaveDefinitions.TabIndex = 32
         '
         'dlgImportFromEPicsa
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
-        Me.ClientSize = New System.Drawing.Size(533, 457)
+        Me.ClientSize = New System.Drawing.Size(464, 369)
+        Me.Controls.Add(Me.ucrSaveDefinitions)
+        Me.Controls.Add(Me.ucrBase)
+        Me.Controls.Add(Me.ucrInputComboFindFiles)
+        Me.Controls.Add(Me.cmdFindFiles)
+        Me.Controls.Add(Me.lblDefinitionsID)
+        Me.Controls.Add(Me.ucrInputDefinitionsID)
+        Me.Controls.Add(Me.lblCountry)
+        Me.Controls.Add(Me.ucrInputComboCountry)
+        Me.Controls.Add(Me.cmdChooseFile)
+        Me.Controls.Add(Me.lblToken)
+        Me.Controls.Add(Me.ucrInputTokenPath)
+        Me.Controls.Add(Me.rdoStation)
+        Me.Controls.Add(Me.rdoData)
+        Me.Controls.Add(Me.rdoDefinitions)
+        Me.Controls.Add(Me.ucrPnlImportFromEPicsa)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
-        Me.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.Margin = New System.Windows.Forms.Padding(2)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgImportFromEPicsa"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
         Me.Text = "Import from e-PICSA"
         Me.ResumeLayout(False)
+        Me.PerformLayout()
 
     End Sub
+
+    Friend WithEvents ucrPnlImportFromEPicsa As UcrPanel
+    Friend WithEvents rdoDefinitions As RadioButton
+    Friend WithEvents rdoData As RadioButton
+    Friend WithEvents rdoStation As RadioButton
+    Friend WithEvents ucrInputTokenPath As ucrInputTextBox
+    Friend WithEvents lblToken As Label
+    Friend WithEvents cmdChooseFile As Button
+    Friend WithEvents ucrInputComboCountry As ucrInputComboBox
+    Friend WithEvents lblCountry As Label
+    Friend WithEvents ucrInputDefinitionsID As ucrInputTextBox
+    Friend WithEvents lblDefinitionsID As Label
+    Friend WithEvents cmdFindFiles As Button
+    Friend WithEvents ucrInputComboFindFiles As ucrInputComboBox
+    Friend WithEvents ucrBase As ucrButtons
+    Friend WithEvents ucrSaveDefinitions As ucrSave
 End Class

--- a/instat/dlgImportFromEPicsa.vb
+++ b/instat/dlgImportFromEPicsa.vb
@@ -23,7 +23,6 @@ Imports RDotNet
 Public Class dlgImportFromEPicsa
     Private bFirstLoad As Boolean = True
     Private bReset As Boolean = True
-    Private bResetSubdialog As Boolean = False
     Private clsDummyFunction, clsGcsFileFunction, clsListDefinitionsFunction, clsGetDefinitionsData, clsStationMetadataFunction As New RFunction
 
     Private Sub dlgImportFromEPicsa_Load(sender As Object, e As EventArgs) Handles MyBase.Load
@@ -109,6 +108,7 @@ Public Class dlgImportFromEPicsa
         clsStationMetadataFunction.SetRCommand("station_metadata")
         clsStationMetadataFunction.AddParameter("include_definitions", "FALSE", iPosition:=2)
 
+        ucrBase.clsRsyntax.ClearCodes()
         ucrBase.clsRsyntax.AddToBeforeCodes(clsGcsFileFunction, iPosition:=1)
         changeBaseFunctions()
     End Sub

--- a/instat/dlgImportFromEPicsa.vb
+++ b/instat/dlgImportFromEPicsa.vb
@@ -52,7 +52,8 @@ Public Class dlgImportFromEPicsa
         ucrPnlImportFromEPicsa.AddParameterValuesCondition(rdoDefinitions, "checked", "definitions")
         ucrPnlImportFromEPicsa.AddParameterValuesCondition(rdoStation, "checked", "station")
         ucrPnlImportFromEPicsa.AddParameterValuesCondition(rdoData, "checked", "data")
-        ucrPnlImportFromEPicsa.AddToLinkedControls({ucrInputComboCountry, ucrInputDefinitionsID, ucrInputComboFindFiles}, {rdoDefinitions}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
+        ucrPnlImportFromEPicsa.AddToLinkedControls({ucrInputComboCountry}, {rdoDefinitions, rdoStation}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
+        ucrPnlImportFromEPicsa.AddToLinkedControls({ucrInputDefinitionsID, ucrInputComboFindFiles}, {rdoDefinitions}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
 
         rdoData.Enabled = False
 
@@ -61,7 +62,7 @@ Public Class dlgImportFromEPicsa
 
         ucrInputComboCountry.SetParameter(New RParameter("country", 1))
         ucrInputComboCountry.SetItems(dctCountry)
-        ucrInputComboCountry.SetRDefault(Chr(34) & "mw" & Chr(34))
+        ucrInputComboCountry.SetText("mw")
         ucrInputComboCountry.SetLinkedDisplayControl(lblCountry)
 
         ucrInputDefinitionsID.SetParameter(New RParameter("definitions_id", 2))
@@ -84,6 +85,7 @@ Public Class dlgImportFromEPicsa
         clsStationMetadataFunction = New RFunction
 
         rdoData.Enabled = False
+        ucrInputComboCountry.SetText("mw")
 
         clsDummyFunction.AddParameter("checked", "definitions", iPosition:=0)
 
@@ -112,9 +114,10 @@ Public Class dlgImportFromEPicsa
         ucrInputDefinitionsID.AddAdditionalCodeParameterPair(clsListDefinitionsFunction, New RParameter("definition_id", 2))
         ucrInputComboCountry.AddAdditionalCodeParameterPair(clsListDefinitionsFunction, New RParameter("country", 0), 1)
         ucrInputComboCountry.AddAdditionalCodeParameterPair(clsStationMetadataFunction, New RParameter("country", 0), 2)
+
         ucrSaveDefinitions.AddAdditionalRCode(clsStationMetadataFunction)
 
-        ucrInputComboCountry.SetRCode(clsGetDefinitionsData, bReset)
+        ucrInputComboCountry.AddAdditionalCodeParameterPair(clsGetDefinitionsData, New RParameter("country", 0), 3)
         ucrInputDefinitionsID.SetRCode(clsGetDefinitionsData, bReset)
         ucrInputComboFindFiles.SetRCode(clsGetDefinitionsData, bReset)
         ucrSaveDefinitions.SetRCode(clsGetDefinitionsData, bReset)
@@ -173,7 +176,6 @@ Public Class dlgImportFromEPicsa
     Private Sub ucrPnlImportFromEPicsa_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlImportFromEPicsa.ControlValueChanged, ucrInputTokenPath.ControlValueChanged
         If rdoStation.Checked Then
             cmdFindFiles.Visible = False
-            ucrInputComboCountry.Visible = True
             clsDummyFunction.AddParameter("checked", "station", iPosition:=0)
             'ElseIf rdoData.Checked Then
             '    cmdFindFiles.Visible = False

--- a/instat/dlgImportFromEPicsa.vb
+++ b/instat/dlgImportFromEPicsa.vb
@@ -25,6 +25,7 @@ Public Class dlgImportFromEPicsa
     Private bReset As Boolean = True
     Private bResetSubdialog As Boolean = False
     Private clsDummyFunction, clsGcsFileFunction, clsListDefinitionsFunction, clsGetDefinitionsData, clsStationMetadataFunction As New RFunction
+
     Private Sub dlgImportFromEPicsa_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
             InitialiseDialog()
@@ -41,10 +42,6 @@ Public Class dlgImportFromEPicsa
 
     Private Sub InitialiseDialog()
         Dim dctCountry As New Dictionary(Of String, String)
-        dctCountry.Add("mw", Chr(34) & "mw" & Chr(34))
-        dctCountry.Add("zm", Chr(34) & "zm" & Chr(34))
-        dctCountry.Add("zm_workshops", Chr(34) & "zm_workshops" & Chr(34))
-        dctCountry.Add("mw_workshops", Chr(34) & "mw_workshops" & Chr(34))
 
         ucrPnlImportFromEPicsa.AddRadioButton(rdoDefinitions)
         ucrPnlImportFromEPicsa.AddRadioButton(rdoStation)
@@ -52,15 +49,22 @@ Public Class dlgImportFromEPicsa
         ucrPnlImportFromEPicsa.AddParameterValuesCondition(rdoDefinitions, "checked", "definitions")
         ucrPnlImportFromEPicsa.AddParameterValuesCondition(rdoStation, "checked", "station")
         ucrPnlImportFromEPicsa.AddParameterValuesCondition(rdoData, "checked", "data")
+
         ucrPnlImportFromEPicsa.AddToLinkedControls({ucrInputComboCountry}, {rdoDefinitions, rdoStation}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
         ucrPnlImportFromEPicsa.AddToLinkedControls({ucrInputDefinitionsID, ucrInputComboFindFiles}, {rdoDefinitions}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
 
+        ' This tab is disabled for now. Will be implemented later
         rdoData.Enabled = False
+
 
         ucrInputTokenPath.SetParameter(New RParameter("filename", 0))
         ucrInputTokenPath.SetLinkedDisplayControl(lblToken)
 
         ucrInputComboCountry.SetParameter(New RParameter("country", 1))
+        dctCountry.Add("mw", Chr(34) & "mw" & Chr(34))
+        dctCountry.Add("zm", Chr(34) & "zm" & Chr(34))
+        dctCountry.Add("zm_workshops", Chr(34) & "zm_workshops" & Chr(34))
+        dctCountry.Add("mw_workshops", Chr(34) & "mw_workshops" & Chr(34))
         ucrInputComboCountry.SetItems(dctCountry)
         ucrInputComboCountry.SetText("mw")
         ucrInputComboCountry.SetLinkedDisplayControl(lblCountry)
@@ -110,15 +114,15 @@ Public Class dlgImportFromEPicsa
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
-        ucrPnlImportFromEPicsa.SetRCode(clsDummyFunction)
-        ucrInputTokenPath.SetRCode(clsGcsFileFunction, bReset)
         ucrInputDefinitionsID.AddAdditionalCodeParameterPair(clsListDefinitionsFunction, New RParameter("definition_id", 2))
         ucrInputComboCountry.AddAdditionalCodeParameterPair(clsListDefinitionsFunction, New RParameter("country", 0), 1)
         ucrInputComboCountry.AddAdditionalCodeParameterPair(clsStationMetadataFunction, New RParameter("country", 0), 2)
+        ucrInputComboCountry.AddAdditionalCodeParameterPair(clsGetDefinitionsData, New RParameter("country", 0), 3)
 
         ucrSaveDefinitions.AddAdditionalRCode(clsStationMetadataFunction)
 
-        ucrInputComboCountry.AddAdditionalCodeParameterPair(clsGetDefinitionsData, New RParameter("country", 0), 3)
+        ucrPnlImportFromEPicsa.SetRCode(clsDummyFunction)
+        ucrInputTokenPath.SetRCode(clsGcsFileFunction, bReset)
         ucrInputDefinitionsID.SetRCode(clsGetDefinitionsData, bReset)
         ucrInputComboFindFiles.SetRCode(clsGetDefinitionsData, bReset)
         ucrSaveDefinitions.SetRCode(clsGetDefinitionsData, bReset)
@@ -192,9 +196,6 @@ Public Class dlgImportFromEPicsa
         If rdoStation.Checked Then
             cmdFindFiles.Visible = False
             clsDummyFunction.AddParameter("checked", "station", iPosition:=0)
-            'ElseIf rdoData.Checked Then
-            '    cmdFindFiles.Visible = False
-            '    clsDummyFunction.AddParameter("checked", "data", iPosition:=0)
         ElseIf rdoDefinitions.Checked Then
             cmdFindFiles.Visible = True
             clsDummyFunction.AddParameter("checked", "definitions", iPosition:=0)
@@ -236,4 +237,5 @@ Public Class dlgImportFromEPicsa
             ucrBase.clsRsyntax.SetBaseRFunction(clsStationMetadataFunction)
         End If
     End Sub
+
 End Class

--- a/instat/dlgImportFromEPicsa.vb
+++ b/instat/dlgImportFromEPicsa.vb
@@ -110,7 +110,6 @@ Public Class dlgImportFromEPicsa
 
     Private Sub SetRCodeForControls(bReset As Boolean)
         ucrPnlImportFromEPicsa.SetRCode(clsDummyFunction)
-        'ucrInputComboCountry.SetRCode(clsListDefinitionsFunction, bReset)
         ucrInputTokenPath.SetRCode(clsGcsFileFunction, bReset)
         ucrInputDefinitionsID.SetRCode(clsListDefinitionsFunction, bReset)
         ucrInputComboCountry.AddAdditionalCodeParameterPair(clsListDefinitionsFunction, New RParameter("country", 0), 1)

--- a/instat/dlgImportFromEPicsa.vb
+++ b/instat/dlgImportFromEPicsa.vb
@@ -93,7 +93,7 @@ Public Class dlgImportFromEPicsa
         clsListDefinitionsFunction.SetPackageName("epicsawrap")
         clsListDefinitionsFunction.SetRCommand("list_definition_versions")
         clsListDefinitionsFunction.AddParameter("country", ucrInputComboCountry.GetText(), iPosition:=0)
-        clsListDefinitionsFunction.AddParameter("definitions_id", ucrInputDefinitionsID.GetText(), iPosition:=0)
+        clsListDefinitionsFunction.AddParameter("definition_id", ucrInputDefinitionsID.GetText(), iPosition:=0)
 
         clsGetDefinitionsData.SetPackageName("epicsawrap")
         clsGetDefinitionsData.SetRCommand("get_definitions_data")
@@ -109,7 +109,7 @@ Public Class dlgImportFromEPicsa
     Private Sub SetRCodeForControls(bReset As Boolean)
         ucrPnlImportFromEPicsa.SetRCode(clsDummyFunction)
         ucrInputTokenPath.SetRCode(clsGcsFileFunction, bReset)
-        ucrInputDefinitionsID.SetRCode(clsListDefinitionsFunction, bReset)
+        ucrInputDefinitionsID.AddAdditionalCodeParameterPair(clsListDefinitionsFunction, New RParameter("definition_id", 2))
         ucrInputComboCountry.AddAdditionalCodeParameterPair(clsListDefinitionsFunction, New RParameter("country", 0), 1)
         ucrInputComboCountry.AddAdditionalCodeParameterPair(clsStationMetadataFunction, New RParameter("country", 0), 2)
         ucrSaveDefinitions.AddAdditionalRCode(clsStationMetadataFunction)

--- a/instat/dlgImportFromEPicsa.vb
+++ b/instat/dlgImportFromEPicsa.vb
@@ -166,10 +166,12 @@ Public Class dlgImportFromEPicsa
         Dim strFormNames() As String
         Dim cleanedFileNames() As String
         Dim expTemp As SymbolicExpression
+        Dim expTemp2 As SymbolicExpression
+
 
         Cursor = Cursors.WaitCursor
         ' Running the gcs_auth_file function internally first
-        frmMain.clsRLink.RunInternalScriptGetValue(clsGcsFileFunction.ToScript(), bSeparateThread:=False, bShowWaitDialogOverride:=False)
+        expTemp2 = frmMain.clsRLink.RunInternalScriptGetValue(clsGcsFileFunction.ToScript(), bSeparateThread:=False, bShowWaitDialogOverride:=False)
         expTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsListDefinitionsFunction.ToScript(), bSeparateThread:=False, bShowWaitDialogOverride:=False)
         Cursor = Cursors.Default
         If expTemp IsNot Nothing Then

--- a/instat/dlgImportFromEPicsa.vb
+++ b/instat/dlgImportFromEPicsa.vb
@@ -37,7 +37,6 @@ Public Class dlgImportFromEPicsa
         bReset = False
         TestOkEnabled()
         autoTranslate(Me)
-        'DialogSize()
     End Sub
 
     Private Sub InitialiseDialog()
@@ -54,7 +53,6 @@ Public Class dlgImportFromEPicsa
         ucrPnlImportFromEPicsa.AddParameterValuesCondition(rdoStation, "checked", "station")
         ucrPnlImportFromEPicsa.AddParameterValuesCondition(rdoData, "checked", "data")
         ucrPnlImportFromEPicsa.AddToLinkedControls({ucrInputComboCountry, ucrInputDefinitionsID, ucrInputComboFindFiles}, {rdoDefinitions}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
-        'ucrPnlImportFromEPicsa.AddToLinkedControls({ucrInputComboCountry}, {rdoDefinitions}, bNewLinkedHideIfParameterMissing:=True, bNewLinkedAddRemoveParameter:=True)
 
         rdoData.Enabled = False
 

--- a/instat/dlgImportFromEPicsa.vb
+++ b/instat/dlgImportFromEPicsa.vb
@@ -86,6 +86,7 @@ Public Class dlgImportFromEPicsa
 
         rdoData.Enabled = False
         ucrInputComboCountry.SetText("mw")
+        ucrInputComboFindFiles.cboInput.Items.Clear()
 
         clsDummyFunction.AddParameter("checked", "definitions", iPosition:=0)
 
@@ -158,6 +159,8 @@ Public Class dlgImportFromEPicsa
         Dim expTemp As SymbolicExpression
 
         Cursor = Cursors.WaitCursor
+        ' Running the gcs_auth_file function internally first
+        frmMain.clsRLink.RunInternalScriptGetValue(clsGcsFileFunction.ToScript(), bSeparateThread:=False, bShowWaitDialogOverride:=False)
         expTemp = frmMain.clsRLink.RunInternalScriptGetValue(clsListDefinitionsFunction.ToScript(), bSeparateThread:=False, bShowWaitDialogOverride:=False)
         Cursor = Cursors.Default
         If expTemp IsNot Nothing Then

--- a/instat/dlgImportFromEPicsa.vb
+++ b/instat/dlgImportFromEPicsa.vb
@@ -154,8 +154,17 @@ Public Class dlgImportFromEPicsa
         TestOkEnabled()
     End Sub
 
+    Private Function CleanFileNames(strNamesArray As String())
+        Dim newStrNamesArray As New List(Of String)
+        For Each filePath As String In strNamesArray
+            newStrNamesArray.Add(Path.GetFileNameWithoutExtension(filePath))
+        Next
+        Return newStrNamesArray.ToArray()
+    End Function
+
     Private Sub cmdFindFiles_Click(sender As Object, e As EventArgs) Handles cmdFindFiles.Click
         Dim strFormNames() As String
+        Dim cleanedFileNames() As String
         Dim expTemp As SymbolicExpression
 
         Cursor = Cursors.WaitCursor
@@ -165,8 +174,9 @@ Public Class dlgImportFromEPicsa
         Cursor = Cursors.Default
         If expTemp IsNot Nothing Then
             strFormNames = expTemp.AsCharacter().ToArray()
-            If strFormNames.Length > 0 Then
-                ucrInputComboFindFiles.SetItems(strFormNames)
+            cleanedFileNames = CleanFileNames(strFormNames)
+            If cleanedFileNames.Length > 0 Then
+                ucrInputComboFindFiles.SetItems(cleanedFileNames)
                 ucrInputComboFindFiles.SetName(ucrInputComboFindFiles.cboInput.Items(0))
             Else
                 ucrInputComboFindFiles.cboInput.Items.Clear()


### PR DESCRIPTION
Fixes partly #9960
@lilyclements @rdstern @berylwaswa 

@lilyclements I have worked on all the things you mentioned with the exception of the `Data` tab and also the issue with the `Find Files` button on the `Definitions` tab. 

I thought I should push it so that you can check and give any feedback. Then I'll be able to work on all the needed bits once you send me your response.

For easy reference, I'll mention that problem here again.

> Please, can you help me resolve the error below?
> 
> It happens in the `list_definition_versions` function that runs internally when I click on the `Find Files` button.
> 
> <img alt="Image" width="350" height="300" src="https://private-user-images.githubusercontent.com/110286432/492758784-498cfa73-606a-43d6-a4de-d4c40c25cd29.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTg2MjY2MDcsIm5iZiI6MTc1ODYyNjMwNywicGF0aCI6Ii8xMTAyODY0MzIvNDkyNzU4Nzg0LTQ5OGNmYTczLTYwNmEtNDNkNi1hNGRlLWQ0YzQwYzI1Y2QyOS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwOTIzJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDkyM1QxMTE4MjdaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT05NmNiZTA0OTFkMDYxYjI4MTg3MjI5NGFhNTVkMDMwZTdjNDc5NTdlYThiZDJiYzk5OWU4MGM4YzhjMTg1NDkwJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.BWNeoyXcDuqy-GZ-1-Vy-SoSWTkhRv-7PZNZZS1T4Hk">

