### PR TITLE
Fixes a problem in Describe >Graph>General Graphic Dialog sub-dialog

### DIFF
--- a/instat/dlgGeneralForGraphics.vb
+++ b/instat/dlgGeneralForGraphics.vb
@@ -380,7 +380,7 @@ Public Class dlgGeneralForGraphics
                         clsNewXScaleDateFunction:=clsXScaleDateFunction, clsNewYScaleDateFunction:=clsYScaleDateFunction, ucrNewBaseSelector:=sdgLayerOptions.ucrGeomWithAes.ucrGeomWithAesSelector, clsNewAnnotateFunction:=clsAnnotateFunction,
                         clsNewCoordPolarFunction:=clsCoordPolarFunction, clsNewCoordPolarStartOperator:=clsCoordPolarStartOperator, clsNewFacetVariablesOperator:=clsFacetVariablesOperator, bReset:=bResetSubdialog)
         sdgPlots.tbpPlotsOptions.SelectedIndex = 1
-        sdgPlots.ShowDialog()
+        sdgPlots.ShowDialog(Me) 'pass the parent so that the layers dialog is always on top of the general for graphics dialog  & <- specify the owner of the dialog
         sdgPlots.tbpPlotsOptions.SelectedIndex = 0
         sdgPlots.EnableLayersTab()
         ucrAdditionalLayers.SetRCodeForControl(clsNewBaseOperator:=ucrBase.clsRsyntax.clsBaseOperator, clsNewAesFunc:=clsGlobalAesFunction, bReset:=True)


### PR DESCRIPTION
Ensured sdgPlots dialog stays on top of parent dialog

Updated the ShowDialog() method to pass `Me` as the parent form, ensuring the sdgPlots dialog remains on top of the dlgGeneralForGraphics dialog. Added a comment to clarify the purpose of this change.
@derekagorhom @berylwaswa @rdstern @lilyclements, 
This PR partialy fixes issue #9891