### PR TITLE
Refactor dialog layout for improved compactness

### DIFF
--- a/instat/dlgBoxPlot.designer.vb
+++ b/instat/dlgBoxPlot.designer.vb
@@ -90,10 +90,9 @@ Partial Class dlgBoxplot
         '
         Me.lblByFactors.AutoSize = True
         Me.lblByFactors.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblByFactors.Location = New System.Drawing.Point(408, 308)
-        Me.lblByFactors.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblByFactors.Location = New System.Drawing.Point(272, 205)
         Me.lblByFactors.Name = "lblByFactors"
-        Me.lblByFactors.Size = New System.Drawing.Size(124, 20)
+        Me.lblByFactors.Size = New System.Drawing.Size(83, 13)
         Me.lblByFactors.TabIndex = 6
         Me.lblByFactors.Tag = "By_Factor:"
         Me.lblByFactors.Text = "Factor (Usually):"
@@ -102,10 +101,9 @@ Partial Class dlgBoxplot
         '
         Me.lblBySecondFactor.AutoSize = True
         Me.lblBySecondFactor.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblBySecondFactor.Location = New System.Drawing.Point(408, 374)
-        Me.lblBySecondFactor.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblBySecondFactor.Location = New System.Drawing.Point(272, 249)
         Me.lblBySecondFactor.Name = "lblBySecondFactor"
-        Me.lblBySecondFactor.Size = New System.Drawing.Size(191, 20)
+        Me.lblBySecondFactor.Size = New System.Drawing.Size(128, 13)
         Me.lblBySecondFactor.TabIndex = 8
         Me.lblBySecondFactor.Tag = "By_Second_Factor:"
         Me.lblBySecondFactor.Text = "Second Factor (Optional):"
@@ -118,10 +116,9 @@ Partial Class dlgBoxplot
         Me.rdoBoxplotTufte.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
         Me.rdoBoxplotTufte.FlatStyle = System.Windows.Forms.FlatStyle.Flat
         Me.rdoBoxplotTufte.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.rdoBoxplotTufte.Location = New System.Drawing.Point(26, 20)
-        Me.rdoBoxplotTufte.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.rdoBoxplotTufte.Location = New System.Drawing.Point(17, 13)
         Me.rdoBoxplotTufte.Name = "rdoBoxplotTufte"
-        Me.rdoBoxplotTufte.Size = New System.Drawing.Size(200, 40)
+        Me.rdoBoxplotTufte.Size = New System.Drawing.Size(133, 27)
         Me.rdoBoxplotTufte.TabIndex = 1
         Me.rdoBoxplotTufte.TabStop = True
         Me.rdoBoxplotTufte.Text = "Boxplot"
@@ -136,10 +133,9 @@ Partial Class dlgBoxplot
         Me.rdoJitter.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
         Me.rdoJitter.FlatStyle = System.Windows.Forms.FlatStyle.Flat
         Me.rdoJitter.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.rdoJitter.Location = New System.Drawing.Point(222, 20)
-        Me.rdoJitter.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.rdoJitter.Location = New System.Drawing.Point(148, 13)
         Me.rdoJitter.Name = "rdoJitter"
-        Me.rdoJitter.Size = New System.Drawing.Size(194, 40)
+        Me.rdoJitter.Size = New System.Drawing.Size(129, 27)
         Me.rdoJitter.TabIndex = 2
         Me.rdoJitter.TabStop = True
         Me.rdoJitter.Text = "Jitter Plot"
@@ -154,10 +150,9 @@ Partial Class dlgBoxplot
         Me.rdoViolin.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
         Me.rdoViolin.FlatStyle = System.Windows.Forms.FlatStyle.Flat
         Me.rdoViolin.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.rdoViolin.Location = New System.Drawing.Point(412, 20)
-        Me.rdoViolin.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.rdoViolin.Location = New System.Drawing.Point(275, 13)
         Me.rdoViolin.Name = "rdoViolin"
-        Me.rdoViolin.Size = New System.Drawing.Size(202, 40)
+        Me.rdoViolin.Size = New System.Drawing.Size(135, 27)
         Me.rdoViolin.TabIndex = 3
         Me.rdoViolin.TabStop = True
         Me.rdoViolin.Text = "Violin Plot"
@@ -168,10 +163,9 @@ Partial Class dlgBoxplot
         '
         Me.lblJitter.AutoSize = True
         Me.lblJitter.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblJitter.Location = New System.Drawing.Point(192, 540)
-        Me.lblJitter.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblJitter.Location = New System.Drawing.Point(128, 360)
         Me.lblJitter.Name = "lblJitter"
-        Me.lblJitter.Size = New System.Drawing.Size(48, 20)
+        Me.lblJitter.Size = New System.Drawing.Size(32, 13)
         Me.lblJitter.TabIndex = 18
         Me.lblJitter.Tag = "By_Factor:"
         Me.lblJitter.Text = "Jitter:"
@@ -180,10 +174,9 @@ Partial Class dlgBoxplot
         '
         Me.lblTransparency.AutoSize = True
         Me.lblTransparency.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblTransparency.Location = New System.Drawing.Point(334, 538)
-        Me.lblTransparency.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblTransparency.Location = New System.Drawing.Point(223, 359)
         Me.lblTransparency.Name = "lblTransparency"
-        Me.lblTransparency.Size = New System.Drawing.Size(109, 20)
+        Me.lblTransparency.Size = New System.Drawing.Size(75, 13)
         Me.lblTransparency.TabIndex = 20
         Me.lblTransparency.Tag = "By_Factor:"
         Me.lblTransparency.Text = "Transparency:"
@@ -193,58 +186,57 @@ Partial Class dlgBoxplot
         Me.contextMenuStripOptions.ImageScalingSize = New System.Drawing.Size(24, 24)
         Me.contextMenuStripOptions.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.toolStripMenuItemPlotOptions, Me.toolStripMenuItemBoxOptions, Me.toolStripMenuItemJitterOptions, Me.toolStripMenuItemSummaryOptions, Me.toolStripMenuItemTufteOptions, Me.toolStripMenuItemViolinOptions, Me.ToolStripMenuItemTextOptions})
         Me.contextMenuStripOptions.Name = "contextMenuStripOk"
-        Me.contextMenuStripOptions.Size = New System.Drawing.Size(230, 228)
+        Me.contextMenuStripOptions.Size = New System.Drawing.Size(171, 158)
         '
         'toolStripMenuItemPlotOptions
         '
         Me.toolStripMenuItemPlotOptions.Name = "toolStripMenuItemPlotOptions"
-        Me.toolStripMenuItemPlotOptions.Size = New System.Drawing.Size(229, 32)
+        Me.toolStripMenuItemPlotOptions.Size = New System.Drawing.Size(170, 22)
         Me.toolStripMenuItemPlotOptions.Text = "Plot Options"
         '
         'toolStripMenuItemBoxOptions
         '
         Me.toolStripMenuItemBoxOptions.Name = "toolStripMenuItemBoxOptions"
-        Me.toolStripMenuItemBoxOptions.Size = New System.Drawing.Size(229, 32)
+        Me.toolStripMenuItemBoxOptions.Size = New System.Drawing.Size(170, 22)
         Me.toolStripMenuItemBoxOptions.Text = "Boxplot Options"
         '
         'toolStripMenuItemJitterOptions
         '
         Me.toolStripMenuItemJitterOptions.Name = "toolStripMenuItemJitterOptions"
-        Me.toolStripMenuItemJitterOptions.Size = New System.Drawing.Size(229, 32)
+        Me.toolStripMenuItemJitterOptions.Size = New System.Drawing.Size(170, 22)
         Me.toolStripMenuItemJitterOptions.Text = "Jitter Options"
         '
         'toolStripMenuItemSummaryOptions
         '
         Me.toolStripMenuItemSummaryOptions.Name = "toolStripMenuItemSummaryOptions"
-        Me.toolStripMenuItemSummaryOptions.Size = New System.Drawing.Size(229, 32)
+        Me.toolStripMenuItemSummaryOptions.Size = New System.Drawing.Size(170, 22)
         Me.toolStripMenuItemSummaryOptions.Text = "Summary Options"
         '
         'toolStripMenuItemTufteOptions
         '
         Me.toolStripMenuItemTufteOptions.Name = "toolStripMenuItemTufteOptions"
-        Me.toolStripMenuItemTufteOptions.Size = New System.Drawing.Size(229, 32)
+        Me.toolStripMenuItemTufteOptions.Size = New System.Drawing.Size(170, 22)
         Me.toolStripMenuItemTufteOptions.Text = "Tufte Options"
         '
         'toolStripMenuItemViolinOptions
         '
         Me.toolStripMenuItemViolinOptions.Name = "toolStripMenuItemViolinOptions"
-        Me.toolStripMenuItemViolinOptions.Size = New System.Drawing.Size(229, 32)
+        Me.toolStripMenuItemViolinOptions.Size = New System.Drawing.Size(170, 22)
         Me.toolStripMenuItemViolinOptions.Text = "Violin Options"
         '
         'ToolStripMenuItemTextOptions
         '
         Me.ToolStripMenuItemTextOptions.Name = "ToolStripMenuItemTextOptions"
-        Me.ToolStripMenuItemTextOptions.Size = New System.Drawing.Size(229, 32)
+        Me.ToolStripMenuItemTextOptions.Size = New System.Drawing.Size(170, 22)
         Me.ToolStripMenuItemTextOptions.Text = "Text Options"
         '
         'lblFacetBy
         '
         Me.lblFacetBy.AutoSize = True
         Me.lblFacetBy.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblFacetBy.Location = New System.Drawing.Point(333, 600)
-        Me.lblFacetBy.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblFacetBy.Location = New System.Drawing.Point(222, 400)
         Me.lblFacetBy.Name = "lblFacetBy"
-        Me.lblFacetBy.Size = New System.Drawing.Size(76, 20)
+        Me.lblFacetBy.Size = New System.Drawing.Size(52, 13)
         Me.lblFacetBy.TabIndex = 24
         Me.lblFacetBy.Tag = ""
         Me.lblFacetBy.Text = "Facet By:"
@@ -253,10 +245,9 @@ Partial Class dlgBoxplot
         '
         Me.lblWidth.AutoSize = True
         Me.lblWidth.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblWidth.Location = New System.Drawing.Point(188, 502)
-        Me.lblWidth.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblWidth.Location = New System.Drawing.Point(125, 335)
         Me.lblWidth.Name = "lblWidth"
-        Me.lblWidth.Size = New System.Drawing.Size(54, 20)
+        Me.lblWidth.Size = New System.Drawing.Size(38, 13)
         Me.lblWidth.TabIndex = 33
         Me.lblWidth.Tag = "By_Factor:"
         Me.lblWidth.Text = "Width:"
@@ -265,10 +256,10 @@ Partial Class dlgBoxplot
         '
         Me.ucrChkLabel.AutoSize = True
         Me.ucrChkLabel.Checked = False
-        Me.ucrChkLabel.Location = New System.Drawing.Point(15, 498)
-        Me.ucrChkLabel.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrChkLabel.Location = New System.Drawing.Point(10, 332)
+        Me.ucrChkLabel.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrChkLabel.Name = "ucrChkLabel"
-        Me.ucrChkLabel.Size = New System.Drawing.Size(182, 34)
+        Me.ucrChkLabel.Size = New System.Drawing.Size(121, 23)
         Me.ucrChkLabel.TabIndex = 34
         '
         'ucrNudBoxPlot
@@ -276,12 +267,12 @@ Partial Class dlgBoxplot
         Me.ucrNudBoxPlot.AutoSize = True
         Me.ucrNudBoxPlot.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudBoxPlot.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudBoxPlot.Location = New System.Drawing.Point(248, 498)
-        Me.ucrNudBoxPlot.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrNudBoxPlot.Location = New System.Drawing.Point(165, 332)
+        Me.ucrNudBoxPlot.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrNudBoxPlot.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
         Me.ucrNudBoxPlot.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudBoxPlot.Name = "ucrNudBoxPlot"
-        Me.ucrNudBoxPlot.Size = New System.Drawing.Size(75, 30)
+        Me.ucrNudBoxPlot.Size = New System.Drawing.Size(50, 20)
         Me.ucrNudBoxPlot.TabIndex = 32
         Me.ucrNudBoxPlot.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
@@ -289,10 +280,10 @@ Partial Class dlgBoxplot
         '
         Me.ucrChkBoxPlot.AutoSize = True
         Me.ucrChkBoxPlot.Checked = False
-        Me.ucrChkBoxPlot.Location = New System.Drawing.Point(15, 501)
-        Me.ucrChkBoxPlot.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrChkBoxPlot.Location = New System.Drawing.Point(10, 334)
+        Me.ucrChkBoxPlot.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrChkBoxPlot.Name = "ucrChkBoxPlot"
-        Me.ucrChkBoxPlot.Size = New System.Drawing.Size(171, 34)
+        Me.ucrChkBoxPlot.Size = New System.Drawing.Size(114, 23)
         Me.ucrChkBoxPlot.TabIndex = 31
         '
         'ucrInputWidth
@@ -301,20 +292,20 @@ Partial Class dlgBoxplot
         Me.ucrInputWidth.AutoSize = True
         Me.ucrInputWidth.IsMultiline = False
         Me.ucrInputWidth.IsReadOnly = False
-        Me.ucrInputWidth.Location = New System.Drawing.Point(195, 464)
-        Me.ucrInputWidth.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrInputWidth.Location = New System.Drawing.Point(130, 309)
+        Me.ucrInputWidth.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrInputWidth.Name = "ucrInputWidth"
-        Me.ucrInputWidth.Size = New System.Drawing.Size(104, 32)
+        Me.ucrInputWidth.Size = New System.Drawing.Size(69, 21)
         Me.ucrInputWidth.TabIndex = 30
         '
         'ucrChkWidth
         '
         Me.ucrChkWidth.AutoSize = True
         Me.ucrChkWidth.Checked = False
-        Me.ucrChkWidth.Location = New System.Drawing.Point(15, 465)
-        Me.ucrChkWidth.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrChkWidth.Location = New System.Drawing.Point(10, 310)
+        Me.ucrChkWidth.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrChkWidth.Name = "ucrChkWidth"
-        Me.ucrChkWidth.Size = New System.Drawing.Size(182, 34)
+        Me.ucrChkWidth.Size = New System.Drawing.Size(121, 23)
         Me.ucrChkWidth.TabIndex = 29
         '
         'ucrInputStation
@@ -323,21 +314,21 @@ Partial Class dlgBoxplot
         Me.ucrInputStation.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputStation.GetSetSelectedIndex = -1
         Me.ucrInputStation.IsReadOnly = False
-        Me.ucrInputStation.Location = New System.Drawing.Point(484, 621)
-        Me.ucrInputStation.Margin = New System.Windows.Forms.Padding(14, 14, 14, 14)
+        Me.ucrInputStation.Location = New System.Drawing.Point(323, 414)
+        Me.ucrInputStation.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
         Me.ucrInputStation.Name = "ucrInputStation"
-        Me.ucrInputStation.Size = New System.Drawing.Size(147, 32)
+        Me.ucrInputStation.Size = New System.Drawing.Size(98, 21)
         Me.ucrInputStation.TabIndex = 26
         '
         'ucr1stFactorReceiver
         '
         Me.ucr1stFactorReceiver.AutoSize = True
         Me.ucr1stFactorReceiver.frmParent = Me
-        Me.ucr1stFactorReceiver.Location = New System.Drawing.Point(333, 622)
+        Me.ucr1stFactorReceiver.Location = New System.Drawing.Point(222, 415)
         Me.ucr1stFactorReceiver.Margin = New System.Windows.Forms.Padding(0)
         Me.ucr1stFactorReceiver.Name = "ucr1stFactorReceiver"
         Me.ucr1stFactorReceiver.Selector = Nothing
-        Me.ucr1stFactorReceiver.Size = New System.Drawing.Size(147, 39)
+        Me.ucr1stFactorReceiver.Size = New System.Drawing.Size(98, 26)
         Me.ucr1stFactorReceiver.strNcFilePath = ""
         Me.ucr1stFactorReceiver.TabIndex = 25
         Me.ucr1stFactorReceiver.ucrSelector = Nothing
@@ -348,20 +339,20 @@ Partial Class dlgBoxplot
         Me.ucrInputLegendPosition.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputLegendPosition.GetSetSelectedIndex = -1
         Me.ucrInputLegendPosition.IsReadOnly = False
-        Me.ucrInputLegendPosition.Location = New System.Drawing.Point(158, 621)
-        Me.ucrInputLegendPosition.Margin = New System.Windows.Forms.Padding(14, 14, 14, 14)
+        Me.ucrInputLegendPosition.Location = New System.Drawing.Point(105, 414)
+        Me.ucrInputLegendPosition.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
         Me.ucrInputLegendPosition.Name = "ucrInputLegendPosition"
-        Me.ucrInputLegendPosition.Size = New System.Drawing.Size(168, 32)
+        Me.ucrInputLegendPosition.Size = New System.Drawing.Size(112, 21)
         Me.ucrInputLegendPosition.TabIndex = 28
         '
         'ucrChkLegend
         '
         Me.ucrChkLegend.AutoSize = True
         Me.ucrChkLegend.Checked = False
-        Me.ucrChkLegend.Location = New System.Drawing.Point(15, 618)
-        Me.ucrChkLegend.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrChkLegend.Location = New System.Drawing.Point(10, 412)
+        Me.ucrChkLegend.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrChkLegend.Name = "ucrChkLegend"
-        Me.ucrChkLegend.Size = New System.Drawing.Size(147, 36)
+        Me.ucrChkLegend.Size = New System.Drawing.Size(98, 24)
         Me.ucrChkLegend.TabIndex = 27
         '
         'ucrInputSummaries
@@ -370,20 +361,19 @@ Partial Class dlgBoxplot
         Me.ucrInputSummaries.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputSummaries.GetSetSelectedIndex = -1
         Me.ucrInputSummaries.IsReadOnly = False
-        Me.ucrInputSummaries.Location = New System.Drawing.Point(195, 424)
-        Me.ucrInputSummaries.Margin = New System.Windows.Forms.Padding(14, 14, 14, 14)
+        Me.ucrInputSummaries.Location = New System.Drawing.Point(130, 283)
+        Me.ucrInputSummaries.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
         Me.ucrInputSummaries.Name = "ucrInputSummaries"
-        Me.ucrInputSummaries.Size = New System.Drawing.Size(122, 32)
+        Me.ucrInputSummaries.Size = New System.Drawing.Size(81, 21)
         Me.ucrInputSummaries.TabIndex = 16
         '
         'cmdOptions
         '
         Me.cmdOptions.AutoSize = True
         Me.cmdOptions.ContextMenuStrip = Me.contextMenuStripOptions
-        Me.cmdOptions.Location = New System.Drawing.Point(15, 354)
-        Me.cmdOptions.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.cmdOptions.Location = New System.Drawing.Point(10, 236)
         Me.cmdOptions.Name = "cmdOptions"
-        Me.cmdOptions.Size = New System.Drawing.Size(222, 38)
+        Me.cmdOptions.Size = New System.Drawing.Size(148, 25)
         Me.cmdOptions.SplitMenuStrip = Me.contextMenuStripOptions
         Me.cmdOptions.TabIndex = 12
         Me.cmdOptions.Tag = "Plot Options"
@@ -394,20 +384,20 @@ Partial Class dlgBoxplot
         '
         Me.ucrChkTufte.AutoSize = True
         Me.ucrChkTufte.Checked = False
-        Me.ucrChkTufte.Location = New System.Drawing.Point(412, 470)
-        Me.ucrChkTufte.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrChkTufte.Location = New System.Drawing.Point(275, 313)
+        Me.ucrChkTufte.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrChkTufte.Name = "ucrChkTufte"
-        Me.ucrChkTufte.Size = New System.Drawing.Size(218, 34)
+        Me.ucrChkTufte.Size = New System.Drawing.Size(145, 23)
         Me.ucrChkTufte.TabIndex = 11
         '
         'ucrChkGrouptoConnect
         '
         Me.ucrChkGrouptoConnect.AutoSize = True
         Me.ucrChkGrouptoConnect.Checked = False
-        Me.ucrChkGrouptoConnect.Location = New System.Drawing.Point(15, 428)
-        Me.ucrChkGrouptoConnect.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrChkGrouptoConnect.Location = New System.Drawing.Point(10, 285)
+        Me.ucrChkGrouptoConnect.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrChkGrouptoConnect.Name = "ucrChkGrouptoConnect"
-        Me.ucrChkGrouptoConnect.Size = New System.Drawing.Size(216, 34)
+        Me.ucrChkGrouptoConnect.Size = New System.Drawing.Size(144, 23)
         Me.ucrChkGrouptoConnect.TabIndex = 15
         '
         'ucrNudTransparency
@@ -415,12 +405,12 @@ Partial Class dlgBoxplot
         Me.ucrNudTransparency.AutoSize = True
         Me.ucrNudTransparency.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudTransparency.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudTransparency.Location = New System.Drawing.Point(452, 534)
-        Me.ucrNudTransparency.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrNudTransparency.Location = New System.Drawing.Point(301, 356)
+        Me.ucrNudTransparency.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrNudTransparency.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
         Me.ucrNudTransparency.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudTransparency.Name = "ucrNudTransparency"
-        Me.ucrNudTransparency.Size = New System.Drawing.Size(75, 30)
+        Me.ucrNudTransparency.Size = New System.Drawing.Size(50, 20)
         Me.ucrNudTransparency.TabIndex = 21
         Me.ucrNudTransparency.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
@@ -429,12 +419,12 @@ Partial Class dlgBoxplot
         Me.ucrNudJitter.AutoSize = True
         Me.ucrNudJitter.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudJitter.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudJitter.Location = New System.Drawing.Point(246, 534)
-        Me.ucrNudJitter.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrNudJitter.Location = New System.Drawing.Point(164, 356)
+        Me.ucrNudJitter.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrNudJitter.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
         Me.ucrNudJitter.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudJitter.Name = "ucrNudJitter"
-        Me.ucrNudJitter.Size = New System.Drawing.Size(75, 30)
+        Me.ucrNudJitter.Size = New System.Drawing.Size(50, 20)
         Me.ucrNudJitter.TabIndex = 19
         Me.ucrNudJitter.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
@@ -442,50 +432,50 @@ Partial Class dlgBoxplot
         '
         Me.ucrChkAddPoints.AutoSize = True
         Me.ucrChkAddPoints.Checked = False
-        Me.ucrChkAddPoints.Location = New System.Drawing.Point(15, 537)
-        Me.ucrChkAddPoints.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrChkAddPoints.Location = New System.Drawing.Point(10, 358)
+        Me.ucrChkAddPoints.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrChkAddPoints.Name = "ucrChkAddPoints"
-        Me.ucrChkAddPoints.Size = New System.Drawing.Size(172, 34)
+        Me.ucrChkAddPoints.Size = New System.Drawing.Size(115, 23)
         Me.ucrChkAddPoints.TabIndex = 17
         '
         'ucrSaveBoxplot
         '
         Me.ucrSaveBoxplot.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveBoxplot.Location = New System.Drawing.Point(15, 658)
-        Me.ucrSaveBoxplot.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrSaveBoxplot.Location = New System.Drawing.Point(10, 439)
+        Me.ucrSaveBoxplot.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrSaveBoxplot.Name = "ucrSaveBoxplot"
-        Me.ucrSaveBoxplot.Size = New System.Drawing.Size(492, 36)
+        Me.ucrSaveBoxplot.Size = New System.Drawing.Size(328, 24)
         Me.ucrSaveBoxplot.TabIndex = 22
         '
         'ucrChkHorizontalBoxplot
         '
         Me.ucrChkHorizontalBoxplot.AutoSize = True
         Me.ucrChkHorizontalBoxplot.Checked = False
-        Me.ucrChkHorizontalBoxplot.Location = New System.Drawing.Point(15, 394)
-        Me.ucrChkHorizontalBoxplot.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrChkHorizontalBoxplot.Location = New System.Drawing.Point(10, 263)
+        Me.ucrChkHorizontalBoxplot.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrChkHorizontalBoxplot.Name = "ucrChkHorizontalBoxplot"
-        Me.ucrChkHorizontalBoxplot.Size = New System.Drawing.Size(357, 34)
+        Me.ucrChkHorizontalBoxplot.Size = New System.Drawing.Size(238, 23)
         Me.ucrChkHorizontalBoxplot.TabIndex = 14
         '
         'ucrChkVarWidth
         '
         Me.ucrChkVarWidth.AutoSize = True
         Me.ucrChkVarWidth.Checked = False
-        Me.ucrChkVarWidth.Location = New System.Drawing.Point(412, 435)
-        Me.ucrChkVarWidth.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrChkVarWidth.Location = New System.Drawing.Point(275, 290)
+        Me.ucrChkVarWidth.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrChkVarWidth.Name = "ucrChkVarWidth"
-        Me.ucrChkVarWidth.Size = New System.Drawing.Size(219, 34)
+        Me.ucrChkVarWidth.Size = New System.Drawing.Size(146, 23)
         Me.ucrChkVarWidth.TabIndex = 13
         '
         'ucrVariablesAsFactorForBoxplot
         '
         Me.ucrVariablesAsFactorForBoxplot.AutoSize = True
         Me.ucrVariablesAsFactorForBoxplot.frmParent = Me
-        Me.ucrVariablesAsFactorForBoxplot.Location = New System.Drawing.Point(412, 94)
-        Me.ucrVariablesAsFactorForBoxplot.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrVariablesAsFactorForBoxplot.Location = New System.Drawing.Point(275, 63)
+        Me.ucrVariablesAsFactorForBoxplot.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrVariablesAsFactorForBoxplot.Name = "ucrVariablesAsFactorForBoxplot"
         Me.ucrVariablesAsFactorForBoxplot.Selector = Nothing
-        Me.ucrVariablesAsFactorForBoxplot.Size = New System.Drawing.Size(180, 195)
+        Me.ucrVariablesAsFactorForBoxplot.Size = New System.Drawing.Size(135, 130)
         Me.ucrVariablesAsFactorForBoxplot.strNcFilePath = ""
         Me.ucrVariablesAsFactorForBoxplot.TabIndex = 5
         Me.ucrVariablesAsFactorForBoxplot.ucrSelector = Nothing
@@ -495,11 +485,11 @@ Partial Class dlgBoxplot
         '
         Me.ucrSecondFactorReceiver.AutoSize = True
         Me.ucrSecondFactorReceiver.frmParent = Me
-        Me.ucrSecondFactorReceiver.Location = New System.Drawing.Point(412, 393)
+        Me.ucrSecondFactorReceiver.Location = New System.Drawing.Point(275, 262)
         Me.ucrSecondFactorReceiver.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSecondFactorReceiver.Name = "ucrSecondFactorReceiver"
         Me.ucrSecondFactorReceiver.Selector = Nothing
-        Me.ucrSecondFactorReceiver.Size = New System.Drawing.Size(180, 30)
+        Me.ucrSecondFactorReceiver.Size = New System.Drawing.Size(120, 20)
         Me.ucrSecondFactorReceiver.strNcFilePath = ""
         Me.ucrSecondFactorReceiver.TabIndex = 9
         Me.ucrSecondFactorReceiver.ucrSelector = Nothing
@@ -508,11 +498,11 @@ Partial Class dlgBoxplot
         '
         Me.ucrByFactorsReceiver.AutoSize = True
         Me.ucrByFactorsReceiver.frmParent = Me
-        Me.ucrByFactorsReceiver.Location = New System.Drawing.Point(412, 330)
+        Me.ucrByFactorsReceiver.Location = New System.Drawing.Point(275, 220)
         Me.ucrByFactorsReceiver.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrByFactorsReceiver.Name = "ucrByFactorsReceiver"
         Me.ucrByFactorsReceiver.Selector = Nothing
-        Me.ucrByFactorsReceiver.Size = New System.Drawing.Size(180, 30)
+        Me.ucrByFactorsReceiver.Size = New System.Drawing.Size(120, 20)
         Me.ucrByFactorsReceiver.strNcFilePath = ""
         Me.ucrByFactorsReceiver.TabIndex = 7
         Me.ucrByFactorsReceiver.ucrSelector = Nothing
@@ -521,19 +511,19 @@ Partial Class dlgBoxplot
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(15, 699)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrBase.Location = New System.Drawing.Point(10, 466)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(611, 77)
+        Me.ucrBase.Size = New System.Drawing.Size(408, 52)
         Me.ucrBase.TabIndex = 23
         '
         'ucrPnlPlots
         '
         Me.ucrPnlPlots.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlPlots.Location = New System.Drawing.Point(10, 18)
-        Me.ucrPnlPlots.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrPnlPlots.Location = New System.Drawing.Point(7, 12)
+        Me.ucrPnlPlots.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrPnlPlots.Name = "ucrPnlPlots"
-        Me.ucrPnlPlots.Size = New System.Drawing.Size(615, 52)
+        Me.ucrPnlPlots.Size = New System.Drawing.Size(410, 35)
         Me.ucrPnlPlots.TabIndex = 0
         '
         'ucrNudOutlierCoefficient
@@ -541,22 +531,21 @@ Partial Class dlgBoxplot
         Me.ucrNudOutlierCoefficient.AutoSize = True
         Me.ucrNudOutlierCoefficient.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudOutlierCoefficient.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudOutlierCoefficient.Location = New System.Drawing.Point(453, 500)
-        Me.ucrNudOutlierCoefficient.Margin = New System.Windows.Forms.Padding(9, 9, 9, 9)
+        Me.ucrNudOutlierCoefficient.Location = New System.Drawing.Point(302, 333)
+        Me.ucrNudOutlierCoefficient.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrNudOutlierCoefficient.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
         Me.ucrNudOutlierCoefficient.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudOutlierCoefficient.Name = "ucrNudOutlierCoefficient"
-        Me.ucrNudOutlierCoefficient.Size = New System.Drawing.Size(72, 30)
+        Me.ucrNudOutlierCoefficient.Size = New System.Drawing.Size(48, 20)
         Me.ucrNudOutlierCoefficient.TabIndex = 36
         Me.ucrNudOutlierCoefficient.Value = New Decimal(New Integer() {0, 0, 0, 0})
         '
         'lblOutlierCoefficient
         '
         Me.lblOutlierCoefficient.AutoSize = True
-        Me.lblOutlierCoefficient.Location = New System.Drawing.Point(192, 504)
-        Me.lblOutlierCoefficient.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblOutlierCoefficient.Location = New System.Drawing.Point(128, 336)
         Me.lblOutlierCoefficient.Name = "lblOutlierCoefficient"
-        Me.lblOutlierCoefficient.Size = New System.Drawing.Size(152, 20)
+        Me.lblOutlierCoefficient.Size = New System.Drawing.Size(102, 13)
         Me.lblOutlierCoefficient.TabIndex = 35
         Me.lblOutlierCoefficient.Text = "Outlier Coefficiennt :"
         '
@@ -566,18 +555,18 @@ Partial Class dlgBoxplot
         Me.ucrSelectorBoxPlot.bDropUnusedFilterLevels = False
         Me.ucrSelectorBoxPlot.bShowHiddenColumns = False
         Me.ucrSelectorBoxPlot.bUseCurrentFilter = True
-        Me.ucrSelectorBoxPlot.Location = New System.Drawing.Point(15, 75)
+        Me.ucrSelectorBoxPlot.Location = New System.Drawing.Point(10, 50)
         Me.ucrSelectorBoxPlot.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorBoxPlot.Name = "ucrSelectorBoxPlot"
-        Me.ucrSelectorBoxPlot.Size = New System.Drawing.Size(320, 274)
+        Me.ucrSelectorBoxPlot.Size = New System.Drawing.Size(213, 183)
         Me.ucrSelectorBoxPlot.TabIndex = 4
         '
         'dlgBoxplot
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(638, 777)
+        Me.ClientSize = New System.Drawing.Size(425, 499)
         Me.Controls.Add(Me.ucrNudOutlierCoefficient)
         Me.Controls.Add(Me.lblOutlierCoefficient)
         Me.Controls.Add(Me.ucrChkLabel)
@@ -616,7 +605,6 @@ Partial Class dlgBoxplot
         Me.Controls.Add(Me.ucrPnlPlots)
         Me.Cursor = System.Windows.Forms.Cursors.Default
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
-        Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgBoxplot"


### PR DESCRIPTION
@derekagorhom @lilyclements This pull request addresses issue number #9978, making a comprehensive update to the layout and sizing of controls in the `dlgBoxPlot` dialog (`instat/dlgBoxPlot.designer.vb`). The primary goal is to streamline and standardize the appearance and positioning of controls, resulting in a more compact and visually consistent dialog.

- Adjusted the  Size

<img width="437" height="531" alt="image" src="https://github.com/user-attachments/assets/60970979-da26-47b7-86ff-d794725c59bc" />

