### PR TITLE
Fixed Translation Issue On Selector Control

### DIFF
--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -529,6 +529,9 @@
     <Compile Include="sdgTricotModelOptions.vb">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="ucrSelector.Translations.vb">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Include="UserTables\Cells\FootNotes\ucrCellsFootNotes.Designer.vb">
       <DependentUpon>ucrCellsFootNotes.vb</DependentUpon>
     </Compile>

--- a/instat/ucrSelector.Translations.vb
+++ b/instat/ucrSelector.Translations.vb
@@ -1,0 +1,31 @@
+﻿' Partial helpers for ucrSelector: non-invasive translation routine.
+' Place this file in the same folder as ucrSelector.vb (instat/) so it compiles as the same partial class.
+
+Imports System.Windows.Forms
+Imports instat.Translations
+
+Partial Public Class ucrSelector
+
+    ''' <summary>
+    ''' Translate a ToolStripItemCollection (and nested drop-down items) using
+    ''' the translation fallback in Translations.vb (GetTranslationWithFallback).
+    ''' This method does not handle events or designer properties to avoid duplicates.
+    ''' </summary>
+    Public Sub TranslateSelectionMenuItems(items As ToolStripItemCollection)
+        If items Is Nothing Then Return
+        For Each tsi As ToolStripItem In items
+            If tsi Is Nothing Then Continue For
+            If Not String.IsNullOrEmpty(tsi.Text) Then
+                Dim newText As String = Translations.GetTranslationWithFallback(tsi.Text)
+                If Not String.IsNullOrEmpty(newText) Then
+                    tsi.Text = newText
+                End If
+            End If
+            Dim mi = TryCast(tsi, ToolStripMenuItem)
+            If mi IsNot Nothing AndAlso mi.HasDropDownItems Then
+                TranslateSelectionMenuItems(mi.DropDownItems)
+            End If
+        Next
+    End Sub
+
+End Class

--- a/instat/ucrSelector.vb
+++ b/instat/ucrSelector.vb
@@ -14,6 +14,7 @@
 ' You should have received a copy of the GNU General Public License 
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+Imports System.Windows.Forms
 Imports instat.Translations
 
 Public Class ucrSelector
@@ -463,6 +464,20 @@ Public Class ucrSelector
 
     Private Sub SelectionMenuStrip_VisibleChanged(sender As Object, e As EventArgs) Handles SelectionMenuStrip.VisibleChanged
         If SelectionMenuStrip.Visible Then
+            ' Try to translate the menu before it is shown
+            Try
+                ' 1) library/database lookup by menu id / control name
+                Translations.autoTranslateContextMenu(SelectionMenuStrip)
+
+                ' 2) textual fallback (handles & mnemonics and nested items)
+                ' Make sure your Translations.vb contains GetTranslationWithFallback and TranslateToolStripItemsWithFallback
+                Translations.TranslateToolStripItemsWithFallback(SelectionMenuStrip.Items)
+            Catch ex As Exception
+                ' Non-fatal: do not block the UI if translation fails
+                ' Optionally log for debugging: Debug.WriteLine("Translate error: " & ex.Message)
+            End Try
+
+            ' --- existing visibility logic continues below ---
             If CurrentReceiver IsNot Nothing Then
                 AddSelectedToolStripMenuItem.Enabled = True
                 If TypeOf CurrentReceiver Is ucrReceiverSingle Then

--- a/instat/ucrSelectorByDataFrameAddRemove.vb
+++ b/instat/ucrSelectorByDataFrameAddRemove.vb
@@ -15,6 +15,7 @@
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Imports System.ComponentModel
+Imports System.Windows.Forms
 
 Public Class ucrSelectorByDataFrameAddRemove
     Private Sub btnAdd_Click(sender As Object, e As EventArgs) Handles btnAdd.Click, toolStripAddSelected.Click
@@ -92,5 +93,19 @@ Public Class ucrSelectorByDataFrameAddRemove
             toolStripAddSelected.Enabled = lstAvailableVariable.SelectedItems.Count > 0
             toolStripAddAll.Enabled = TypeOf CurrentReceiver Is ucrReceiverMultiple
         End If
+
+        ' Ensure context menu items are translated when the menu opens.
+        ' Use the dedicated helper that translates ContextMenuStrip instances.
+        Try
+            Translations.autoTranslateContextMenu(contextMenuStripAdd)
+            ' extra fallback: ensure specific items are translated if needed
+            toolStripAddSelected.Text = Translations.GetTranslation(toolStripAddSelected.Text)
+            toolStripAddAll.Text = Translations.GetTranslation(toolStripAddAll.Text)
+            toolStripHelp.Text = Translations.GetTranslation(toolStripHelp.Text)
+        Catch ex As Exception
+            ' Non-fatal: don't prevent context menu from opening if translation fails.
+            ' Optionally log the error for debugging:
+            ' MsgBox("Translation error in contextMenuStripAdd_Opening: " & ex.Message)
+        End Try
     End Sub
 End Class


### PR DESCRIPTION
Fixes #10011
@rdstern @Ag-Derek @berylwaswa I Fixed translation issue on selector control. Please have a look.

@lloyddewit Please I need your expertise here. The translation here is cut off for texts that are too long (I assume this is also the case for Russian, as the translation is often long for that language as well). I have tried to solve this problem with AI, but to no avail. I hope that, as you are more familiar with the project than I am, you will be able to help me solve this problem. Thank you.
<img width="156" height="126" alt="image" src="https://github.com/user-attachments/assets/3e1567c0-9434-4d8b-b1fa-c39ae02c3941" />
 