### PR TITLE
Update Help.ShowHelp topic IDs in metadata user controls

### DIFF
--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -453,7 +453,7 @@ Public Class ucrColumnMetadata
     End Sub
 
     Private Sub mnuHelp_Click(sender As Object, e As EventArgs) Handles mnuHelp.Click
-        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "543")
+        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "697")
     End Sub
 
     Private Sub deleteDataFrame_Click(sender As Object, e As EventArgs) Handles deleteDataFrame.Click
@@ -517,7 +517,7 @@ Public Class ucrColumnMetadata
     End Sub
 
     Private Sub mnuHelp1_Click(sender As Object, e As EventArgs) Handles mnuHelp1.Click, mnuHelp2.Click
-        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "543")
+        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "697")
     End Sub
 
     Private Sub mnuConvertToDate_Click(sender As Object, e As EventArgs) Handles mnuConvertToDate.Click

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -453,7 +453,7 @@ Public Class ucrColumnMetadata
     End Sub
 
     Private Sub mnuHelp_Click(sender As Object, e As EventArgs) Handles mnuHelp.Click
-        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "697")
+        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "134")
     End Sub
 
     Private Sub deleteDataFrame_Click(sender As Object, e As EventArgs) Handles deleteDataFrame.Click

--- a/instat/ucrDataFrameMetadata.vb
+++ b/instat/ucrDataFrameMetadata.vb
@@ -167,7 +167,7 @@ Public Class ucrDataFrameMetadata
     End Sub
 
     Private Sub mnuHelp_Click(sender As Object, e As EventArgs) Handles mnuHelp.Click
-        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "544")
+        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "697")
     End Sub
 
     Private Function GetSelectedDataframeNameFromSelectedRow() As String
@@ -214,6 +214,6 @@ Public Class ucrDataFrameMetadata
     End Sub
 
     Private Sub HelpToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles HelpToolStripMenuItem.Click
-        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "544")
+        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "134")
     End Sub
 End Class

--- a/instat/ucrDataFrameMetadata.vb
+++ b/instat/ucrDataFrameMetadata.vb
@@ -167,7 +167,7 @@ Public Class ucrDataFrameMetadata
     End Sub
 
     Private Sub mnuHelp_Click(sender As Object, e As EventArgs) Handles mnuHelp.Click
-        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "697")
+        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "134")
     End Sub
 
     Private Function GetSelectedDataframeNameFromSelectedRow() As String
@@ -214,6 +214,6 @@ Public Class ucrDataFrameMetadata
     End Sub
 
     Private Sub HelpToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles HelpToolStripMenuItem.Click
-        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "134")
+        Help.ShowHelp(Me, frmMain.strStaticPath & "\" & frmMain.strHelpFilePath, HelpNavigator.TopicId, "697")
     End Sub
 End Class


### PR DESCRIPTION
@lilyclements @derekagorhom  Updated the help topic IDs in Help.ShowHelp calls for both ucrColumnMetadata and ucrDataFrameMetadata. Changed IDs to "697" for most help menu items and to "134" for HelpToolStripMenuItem_Click in ucrDataFrameMetadata. This pull request is addressing the help id mapping on #9831 

### Before asking for review
Please confirm that you have:

- Completed the developer testing checklist below (ticking items as you go)
- Responded to all AI/bot comments (either fixed or explained)
- Added a short note in the PR describing how you tested these changes
- Noted which issue(s) this PR relates to

**Developer Testing Checklist**
- [x] Runs without errors  
- [ ] OK disabled when dialog is incomplete or invalid  
- [ ] OK enabled only when required inputs are valid
- [ ] Reset returns dialog to its default/sensible state
- [ ] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [ ] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
