### PR TITLE
Preventing frmMain minimising on Import from Library

### DIFF
--- a/instat/dlgFromLibrary.vb
+++ b/instat/dlgFromLibrary.vb
@@ -34,27 +34,65 @@ Public Class dlgFromLibrary
     Private strSelectedPackage As String = ""
     Private clsImportFunction As New RFunction 'the base function that call on import R-Instat function
 
+    'Private Sub dlgFromLibrary_Load(sender As Object, e As EventArgs) Handles Me.Load
+    '    If bFirstLoad Then
+    '        InitialiseDialog()
+    '        bFirstLoad = False
+    '    End If
+    '    If bReset Then
+    '        SetDefaults()
+    '    End If
+    '    SetRCodeforControls(bReset)
+
+    '    If lstCollection.SelectedItems.Count > 0 Then
+    '        'make the listview have the focus
+    '        lstCollection.Select()
+    '        'set the selected item to be visible 
+    '        lstCollection.TopItem = lstCollection.Items(lstCollection.Items.IndexOf(lstCollection.SelectedItems.Item(0)))
+    '    End If
+
+    '    bReset = False
+    '    TestOkEnabled()
+    '    EnableHelp()
+    '    autoTranslate(Me)
+    'End Sub
+
     Private Sub dlgFromLibrary_Load(sender As Object, e As EventArgs) Handles Me.Load
         If bFirstLoad Then
-            InitialiseDialog()
-            bFirstLoad = False
-        End If
-        If bReset Then
-            SetDefaults()
-        End If
-        SetRCodeforControls(bReset)
+            Me.BeginInvoke(Sub()
+                               InitialiseDialog()
+                               bFirstLoad = False
+                               If bReset Then
+                                   SetDefaults()
+                               End If
+                               SetRCodeforControls(bReset)
 
-        If lstCollection.SelectedItems.Count > 0 Then
-            'make the listview have the focus
-            lstCollection.Select()
-            'set the selected item to be visible 
-            lstCollection.TopItem = lstCollection.Items(lstCollection.Items.IndexOf(lstCollection.SelectedItems.Item(0)))
-        End If
+                               If lstCollection.SelectedItems.Count > 0 Then
+                                   lstCollection.Select()
+                                   lstCollection.TopItem = lstCollection.Items(lstCollection.Items.IndexOf(lstCollection.SelectedItems.Item(0)))
+                               End If
 
-        bReset = False
-        TestOkEnabled()
-        EnableHelp()
-        autoTranslate(Me)
+                               bReset = False
+                               TestOkEnabled()
+                               EnableHelp()
+                               autoTranslate(Me)
+                           End Sub)
+        Else
+            If bReset Then
+                SetDefaults()
+            End If
+            SetRCodeforControls(bReset)
+
+            If lstCollection.SelectedItems.Count > 0 Then
+                lstCollection.Select()
+                lstCollection.TopItem = lstCollection.Items(lstCollection.Items.IndexOf(lstCollection.SelectedItems.Item(0)))
+            End If
+
+            bReset = False
+            TestOkEnabled()
+            EnableHelp()
+            autoTranslate(Me)
+        End If
     End Sub
 
     Private Sub InitialiseDialog()

--- a/instat/dlgFromLibrary.vb
+++ b/instat/dlgFromLibrary.vb
@@ -33,35 +33,8 @@ Public Class dlgFromLibrary
 
     Private strSelectedPackage As String = ""
     Private clsImportFunction As New RFunction 'the base function that call on import R-Instat function
-
-    'Private Sub dlgFromLibrary_Load(sender As Object, e As EventArgs) Handles Me.Load
-    '    If bFirstLoad Then
-    '        InitialiseDialog()
-    '        bFirstLoad = False
-    '    End If
-    '    If bReset Then
-    '        SetDefaults()
-    '    End If
-    '    SetRCodeforControls(bReset)
-
-    '    If lstCollection.SelectedItems.Count > 0 Then
-    '        'make the listview have the focus
-    '        lstCollection.Select()
-    '        'set the selected item to be visible 
-    '        lstCollection.TopItem = lstCollection.Items(lstCollection.Items.IndexOf(lstCollection.SelectedItems.Item(0)))
-    '    End If
-
-    '    bReset = False
-    '    TestOkEnabled()
-    '    EnableHelp()
-    '    autoTranslate(Me)
-    'End Sub
-
     Private Sub dlgFromLibrary_Load(sender As Object, e As EventArgs) Handles Me.Load
-        If bFirstLoad Then
-            Me.BeginInvoke(Sub()
-                               InitialiseDialog()
-                               bFirstLoad = False
+        Dim finalizeLoad = Sub()
                                If bReset Then
                                    SetDefaults()
                                End If
@@ -69,29 +42,22 @@ Public Class dlgFromLibrary
 
                                If lstCollection.SelectedItems.Count > 0 Then
                                    lstCollection.Select()
-                                   lstCollection.TopItem = lstCollection.Items(lstCollection.Items.IndexOf(lstCollection.SelectedItems.Item(0)))
+                                   lstCollection.TopItem = lstCollection.SelectedItems(0)
                                End If
 
                                bReset = False
                                TestOkEnabled()
                                EnableHelp()
                                autoTranslate(Me)
+                           End Sub
+        If bFirstLoad Then
+            bFirstLoad = False
+            Me.BeginInvoke(Sub()
+                               InitialiseDialog()
+                               finalizeLoad()
                            End Sub)
         Else
-            If bReset Then
-                SetDefaults()
-            End If
-            SetRCodeforControls(bReset)
-
-            If lstCollection.SelectedItems.Count > 0 Then
-                lstCollection.Select()
-                lstCollection.TopItem = lstCollection.Items(lstCollection.Items.IndexOf(lstCollection.SelectedItems.Item(0)))
-            End If
-
-            bReset = False
-            TestOkEnabled()
-            EnableHelp()
-            autoTranslate(Me)
+            finalizeLoad()
         End If
     End Sub
 

--- a/instat/dlgFromLibrary.vb
+++ b/instat/dlgFromLibrary.vb
@@ -51,11 +51,9 @@ Public Class dlgFromLibrary
                                autoTranslate(Me)
                            End Sub
         If bFirstLoad Then
+            InitialiseDialog()
             bFirstLoad = False
-            Me.BeginInvoke(Sub()
-                               InitialiseDialog()
-                               finalizeLoad()
-                           End Sub)
+            Me.BeginInvoke(finalizeLoad)
         Else
             finalizeLoad()
         End If

--- a/instat/dlgImportDataset.vb
+++ b/instat/dlgImportDataset.vb
@@ -70,8 +70,13 @@ Public Class dlgImportDataset
             strDirectoryPathTemp = strFileToOpenOn
             strFileToOpenOn = ""
             bStartOpenDialog = False
+            'ElseIf bStartOpenDialog Then
+            '    GetFileFromOpenDialog()
+            '    bStartOpenDialog = False
         ElseIf bStartOpenDialog Then
-            GetFileFromOpenDialog()
+            Me.BeginInvoke(Sub()
+                               GetFileFromOpenDialog()
+                           End Sub)
             bStartOpenDialog = False
         Else
             'if none of the above then try setting the displayed values from the previous contents of ucrInputFilePath.

--- a/instat/dlgImportDataset.vb
+++ b/instat/dlgImportDataset.vb
@@ -70,9 +70,6 @@ Public Class dlgImportDataset
             strDirectoryPathTemp = strFileToOpenOn
             strFileToOpenOn = ""
             bStartOpenDialog = False
-            'ElseIf bStartOpenDialog Then
-            '    GetFileFromOpenDialog()
-            '    bStartOpenDialog = False
         ElseIf bStartOpenDialog Then
             Me.BeginInvoke(Sub()
                                GetFileFromOpenDialog()


### PR DESCRIPTION
@berylwaswa @rdstern @Vitalis95 Kindly Check
Fixes #9597

When clicking "Import from Library" on the released version of R-Instat, frmMain would minimise and lose focus.

The cause was in dlgFromLibrary_Load  on first load, InitialiseDialog() is called which immediately runs a blocking R script on the UI thread
`expPackageNames = frmMain.clsRLink.RunInternalScriptGetValue(clsGetPackages.ToScript(), bSilent:=True)`

On the released version, R takes longer to respond to this call (**packages are not yet cached**) causing the UI thread to block. Windows interprets this as the application being unresponsive and pushes frmMain behind other windows, making it appear minimised. **This did not occur on the developer version because R packages are already loaded in the environment.**

I fixed this by **wrapping InitialiseDialog() in Me.BeginInvoke** so it is deferred until after dlgFromLibrary has fully loaded and is visible on screen. This keeps the UI thread free during the form load, preventing the focus conflict.

```
' Before
If bFirstLoad Then
    InitialiseDialog()
    bFirstLoad = False
End If

' After
If bFirstLoad Then
    Me.BeginInvoke(Sub() InitialiseDialog())
    bFirstLoad = False
End If
```
Also in **dlgImportDataset_Load**
T**he same BeginInvoke pattern was applied to defer GetFileFromOpenDialog()**, which opens a native Windows OpenFileDialog during the load event. 


<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/ca042726-a709-41b9-a544-cf52099f9682" />
