### PR TITLE
Block date columns from Start/End receivers in PICSA Crops dialog

### DIFF
--- a/instat/dlgPICSACrops.vb
+++ b/instat/dlgPICSACrops.vb
@@ -60,7 +60,7 @@ Public Class dlgPICSACrops
         cmdOptions.Visible = False
 
         Dim kvpEnd As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_season", {"end_season", "end_rains", "end_rain_filled", "end_season_filled", "end_dry"}.ToList())
-        Dim kvpStart As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("start_rain", {"start_rain", "start_dry"}.ToList())
+        Dim kvpStart As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("start_rain", {"start_rain", "start", "start_dry"}.ToList())
 
         lstRecognisedTypes.AddRange({kvpEnd, kvpStart})
 

--- a/instat/dlgPICSACrops.vb
+++ b/instat/dlgPICSACrops.vb
@@ -58,8 +58,8 @@ Public Class dlgPICSACrops
         ' Sub dialog not yet created.
         cmdOptions.Visible = False
 
-        Dim kvpEnd As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_season", {"end_season", "end_rains", "end_rain_filled", "end_season_filled"}.ToList())
-        Dim kvpStart As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("start_rain", {"start_rain"}.ToList())
+        Dim kvpEnd As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("end_season", {"end_season", "end_rains", "end_rain_filled", "end_season_filled", "end_dry"}.ToList())
+        Dim kvpStart As KeyValuePair(Of String, List(Of String)) = New KeyValuePair(Of String, List(Of String))("start_rain", {"start_rain", "start_dry"}.ToList())
 
         lstRecognisedTypes.AddRange({kvpEnd, kvpStart})
 
@@ -108,13 +108,16 @@ Public Class dlgPICSACrops
         ucrReceiverStart.SetParameter(New RParameter("start_day", 8))
         ucrReceiverStart.SetParameterIsString()
         ucrReceiverStart.SetDataType("numeric")
+        ucrReceiverStart.SetExcludedDataTypes({"Date", "POSIXct", "POSIXlt"})
         ucrReceiverStart.Tag = "start_rain"
 
         'End Receiver
         ucrReceiverEnd.Selector = ucrSelectorSummary
         ucrReceiverEnd.SetParameter(New RParameter("end_day", 9))
         ucrReceiverEnd.SetParameterIsString()
+        ucrChkDataCrops.AddToLinkedControls(ucrSaveDefinitionCrops, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedDisabledIfParameterMissing:=True)
         ucrReceiverEnd.SetDataType("numeric")
+        ucrReceiverEnd.SetExcludedDataTypes({"Date", "POSIXct", "POSIXlt"})
         ucrReceiverEnd.Tag = "end_season"
 
         ucrPnlStartCheck.AddRadioButton(rdoYes)
@@ -216,7 +219,6 @@ Public Class dlgPICSACrops
         ucrChkDataCrops.SetText("Return Crops Data")
         ucrChkDataCrops.SetParameter(New RParameter("return_crops_table", 11), bNewChangeParameterValue:=True, strNewValueIfChecked:="TRUE", strNewValueIfUnchecked:="FALSE")
         ucrChkDataCrops.SetRDefault("TRUE")
-        ucrChkDataCrops.AddToLinkedControls(ucrSaveDefinitionCrops, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedDisabledIfParameterMissing:=True)
 
         ucrChkDataProp.SetText("Calculate Proportions")
         ucrChkDataProp.SetParameter(New RParameter("definition_props", 12), bNewChangeParameterValue:=True, strNewValueIfChecked:="TRUE", strNewValueIfUnchecked:="FALSE")

--- a/instat/dlgPICSACrops.vb
+++ b/instat/dlgPICSACrops.vb
@@ -34,6 +34,7 @@ Public Class dlgPICSACrops
     Private lstEndReceivers As New List(Of ucrReceiverSingle)
     Private lstStartReceivers As New List(Of ucrReceiverSingle)
     Private bisFilling As Boolean = False
+    Private ReadOnly ExcludedDateTypes As String() = {"Date", "POSIXct", "POSIXlt"}
 
     Dim lstRecognisedTypes As New List(Of KeyValuePair(Of String, List(Of String)))
 
@@ -108,16 +109,15 @@ Public Class dlgPICSACrops
         ucrReceiverStart.SetParameter(New RParameter("start_day", 8))
         ucrReceiverStart.SetParameterIsString()
         ucrReceiverStart.SetDataType("numeric")
-        ucrReceiverStart.SetExcludedDataTypes({"Date", "POSIXct", "POSIXlt"})
+        ucrReceiverStart.SetExcludedDataTypes(ExcludedDateTypes)
         ucrReceiverStart.Tag = "start_rain"
 
         'End Receiver
         ucrReceiverEnd.Selector = ucrSelectorSummary
         ucrReceiverEnd.SetParameter(New RParameter("end_day", 9))
         ucrReceiverEnd.SetParameterIsString()
-        ucrChkDataCrops.AddToLinkedControls(ucrSaveDefinitionCrops, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedDisabledIfParameterMissing:=True)
         ucrReceiverEnd.SetDataType("numeric")
-        ucrReceiverEnd.SetExcludedDataTypes({"Date", "POSIXct", "POSIXlt"})
+        ucrReceiverEnd.SetExcludedDataTypes(ExcludedDateTypes)
         ucrReceiverEnd.Tag = "end_season"
 
         ucrPnlStartCheck.AddRadioButton(rdoYes)
@@ -223,6 +223,7 @@ Public Class dlgPICSACrops
         ucrChkDataProp.SetText("Calculate Proportions")
         ucrChkDataProp.SetParameter(New RParameter("definition_props", 12), bNewChangeParameterValue:=True, strNewValueIfChecked:="TRUE", strNewValueIfUnchecked:="FALSE")
         ucrChkDataProp.SetRDefault("TRUE")
+        ucrChkDataCrops.AddToLinkedControls(ucrSaveDefinitionCrops, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedDisabledIfParameterMissing:=True)
 
         ucrSaveDefinitionCrops.SetPrefix("crops_data_definition")
         ucrSaveDefinitionCrops.SetSaveType(strRObjectType:=RObjectTypeLabel.StructureLabel, strRObjectFormat:=RObjectFormat.Text)


### PR DESCRIPTION
@berylwaswa @lilyclements @rdstern 
Fixes #9875 
I went for option 1 where We only allow DOY variables here

The Start and End receivers in the dialog were not restricting date columns from being selected. 
A user could pick a date column such as start_d_dry instead of a DOY column such as start_dry, which would cause the R calculation to fail silently.
The fix was to **add SetExcludedDataTypes** to both receivers so that date columns are filtered out and cannot be selected:

<img width="605" height="730" alt="image" src="https://github.com/user-attachments/assets/c26ea44b-f422-4180-a4ec-f453d26b9f50" />
<img width="286" height="237" alt="image" src="https://github.com/user-attachments/assets/4ae5a9e4-a2b1-478e-b10e-40fbed4ee633" />


