### PR TITLE
Made changes to how definitions are run in Length of Season dialog

### DIFF
--- a/instat/dlgClimaticLengthOfSeason.vb
+++ b/instat/dlgClimaticLengthOfSeason.vb
@@ -346,6 +346,7 @@ Public Class dlgClimaticLengthOfSeason
         clsDefineAsClimatic.iCallType = 2
 
         clsGetSeasonLengthFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_seasonal_length_definition")
+        clsGetSeasonLengthFunction.AddParameter("data_name", Chr(34) & ucrSelectorLengthofSeason.strCurrentDataFrame & Chr(34), iPosition:=0)
 
         'Base Function
         ucrBase.clsRsyntax.ClearCodes()
@@ -494,6 +495,7 @@ Public Class dlgClimaticLengthOfSeason
         strCurrDataName = Chr(34) & ucrSelectorLengthofSeason.strCurrentDataFrame & Chr(34)
         clsDefineAsClimatic.AddParameter("data_name", strCurrDataName, iPosition:=0)
         clsConvertColumnTypeFunction.AddParameter("data_name", strCurrDataName, iPosition:=0)
+        AddDataName()
     End Sub
 
     Private Sub AddRemoveLengthmore()

--- a/instat/dlgClimaticLengthOfSeason.vb
+++ b/instat/dlgClimaticLengthOfSeason.vb
@@ -30,7 +30,7 @@ Public Class dlgClimaticLengthOfSeason
     Private bDataChanged As Boolean = False
     Private clsLengthOfSeasonFunction, clsMaxFunction, clsLengthmoreFunction, clsListFunction, clsAscharactermoreFunction, clsConvertColumnTypeFunction,
         clsElseIfMoreFunction, clsApplyInstatCalcFunction, clsAsCharacterFunction, clsCombinationCalcFunction, clsStartEndStatusFunction, clsCaseWhenFunction,
-        clsIsNAFunction, clsIsNA1Function, clsCombinationListFunction, clsDefineAsClimatic, clsVectorConcatFunction, clsGetCalculationsFunction,
+        clsIsNAFunction, clsIsNA1Function, clsCombinationListFunction, clsDefineAsClimatic, clsVectorConcatFunction,
         clsGetSeasonLengthFunction, clsDummyFunction As New RFunction
     Private clsMinusOpertor, clsAssignMoreOperator, clsMinusmoreOperator, clsAndOperator, clsOROperator, clsCaseWhenOperator, clsCaseWhen1Operator, clsCaseWhen2Operator, clsCaseWhen3Operator, clsAssignOperator, clsAssign1Operator, clsAssign2Operator, clsAssign3Operator, clsAssign4Operator, clsAnd1Operator, clsAnd2Operator As New ROperator
     Dim lstRecognisedTypes As New List(Of KeyValuePair(Of String, List(Of String)))
@@ -161,7 +161,6 @@ Public Class dlgClimaticLengthOfSeason
         clsVectorConcatFunction = New RFunction
         clsListFunction = New RFunction
         clsMaxFunction = New RFunction
-        clsGetCalculationsFunction = New RFunction
         clsGetSeasonLengthFunction = New RFunction
         clsDummyFunction = New RFunction
         clsMinusmoreOperator = New ROperator
@@ -346,11 +345,11 @@ Public Class dlgClimaticLengthOfSeason
         clsDefineAsClimatic.AddParameter("overwrite", "FALSE", iPosition:=3)
         clsDefineAsClimatic.iCallType = 2
 
-        clsGetCalculationsFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_calculations")
-        clsGetCalculationsFunction.SetAssignTo("calculations_data")
+        'clsGetCalculationsFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_calculations")
+        'clsGetCalculationsFunction.SetAssignTo("calculations_data")
 
-        clsGetSeasonLengthFunction.SetRCommand("get_seasonal_length_definition")
-        clsGetSeasonLengthFunction.AddParameter("x", clsRFunctionParameter:=clsGetCalculationsFunction, iPosition:=0, bIncludeArgumentName:=False)
+        clsGetSeasonLengthFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_seasonal_length_definition")
+        'clsGetSeasonLengthFunction.AddParameter("x", clsRFunctionParameter:=clsGetCalculationsFunction, iPosition:=0, bIncludeArgumentName:=False)
 
         'Base Function
         ucrBase.clsRsyntax.ClearCodes()
@@ -393,6 +392,7 @@ Public Class dlgClimaticLengthOfSeason
         AutoFillReceivers(lstStartStatusReceivers)
         AutoFillReceivers(lstFilledReceivers)
         AddRemoveMaxFilled()
+        UpdateDefinitionName()
     End Sub
 
     Private Sub TestOKEnabled()
@@ -434,15 +434,28 @@ Public Class dlgClimaticLengthOfSeason
         Else
             ucrBase.clsRsyntax.RemoveFromAfterCodes(clsGetSeasonLengthFunction)
         End If
+        UpdateDefinitionName()
         TestOKEnabled()
     End Sub
 
+    Private Sub UpdateDefinitionName()
+        Dim strDefinitionName As String = ucrSaveDefinition.GetText()
+        If ucrSaveDefinition.ucrChkSave.Checked AndAlso strDefinitionName <> "" Then
+            clsGetSeasonLengthFunction.AddParameter("definition_name", Chr(34) & strDefinitionName & Chr(34), iPosition:=3)
+        Else
+            clsGetSeasonLengthFunction.RemoveParameterByName("definition_name")
+        End If
+    End Sub
 
+    Private Sub AddDataName()
+        clsGetSeasonLengthFunction.AddParameter("data_name", strCurrDataName, iPosition:=0)
+    End Sub
 
     Private Sub ucrSelectorLengthofSeason_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorLengthofSeason.ControlValueChanged
         bDataChanged = True
         bUserClearedReceiver = False
         strCurrDataName = Chr(34) & ucrSelectorLengthofSeason.strCurrentDataFrame & Chr(34)
+        AddDataName()
         AutoFillReceivers(lstEndReceivers)
         AutoFillReceivers(lstStartReceivers)
         AutoFillReceivers(lstEndStatusReceivers)
@@ -483,7 +496,7 @@ Public Class dlgClimaticLengthOfSeason
 
     Private Sub ucrSelectorLengthofSeason_DataFrameChanged() Handles ucrSelectorLengthofSeason.DataFrameChanged
         strCurrDataName = Chr(34) & ucrSelectorLengthofSeason.strCurrentDataFrame & Chr(34)
-        clsGetCalculationsFunction.AddParameter("x", strCurrDataName, iPosition:=0, bIncludeArgumentName:=False)
+        'clsGetCalculationsFunction.AddParameter("x", strCurrDataName, iPosition:=0, bIncludeArgumentName:=False)
         clsDefineAsClimatic.AddParameter("data_name", strCurrDataName, iPosition:=0)
         clsConvertColumnTypeFunction.AddParameter("data_name", strCurrDataName, iPosition:=0)
     End Sub

--- a/instat/dlgClimaticLengthOfSeason.vb
+++ b/instat/dlgClimaticLengthOfSeason.vb
@@ -345,11 +345,7 @@ Public Class dlgClimaticLengthOfSeason
         clsDefineAsClimatic.AddParameter("overwrite", "FALSE", iPosition:=3)
         clsDefineAsClimatic.iCallType = 2
 
-        'clsGetCalculationsFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_calculations")
-        'clsGetCalculationsFunction.SetAssignTo("calculations_data")
-
         clsGetSeasonLengthFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_seasonal_length_definition")
-        'clsGetSeasonLengthFunction.AddParameter("x", clsRFunctionParameter:=clsGetCalculationsFunction, iPosition:=0, bIncludeArgumentName:=False)
 
         'Base Function
         ucrBase.clsRsyntax.ClearCodes()
@@ -496,7 +492,6 @@ Public Class dlgClimaticLengthOfSeason
 
     Private Sub ucrSelectorLengthofSeason_DataFrameChanged() Handles ucrSelectorLengthofSeason.DataFrameChanged
         strCurrDataName = Chr(34) & ucrSelectorLengthofSeason.strCurrentDataFrame & Chr(34)
-        'clsGetCalculationsFunction.AddParameter("x", strCurrDataName, iPosition:=0, bIncludeArgumentName:=False)
         clsDefineAsClimatic.AddParameter("data_name", strCurrDataName, iPosition:=0)
         clsConvertColumnTypeFunction.AddParameter("data_name", strCurrDataName, iPosition:=0)
     End Sub

--- a/instat/dlgClimaticLengthOfSeason.vb
+++ b/instat/dlgClimaticLengthOfSeason.vb
@@ -77,6 +77,9 @@ Public Class dlgClimaticLengthOfSeason
 
         lstFilledReceivers.AddRange({ucrReceiverEndFilled})
 
+        ucrSelectorLengthofSeason.SetParameter(New RParameter("data_name", 0))
+        ucrSelectorLengthofSeason.SetParameterIsString()
+
         ucrReceiverStartofRains.SetParameter(New RParameter("start_doy", 1, bNewIncludeArgumentName:=False))
         ucrReceiverStartofRains.SetParameterIsString()
         ucrReceiverStartofRains.bWithQuotes = False
@@ -346,7 +349,6 @@ Public Class dlgClimaticLengthOfSeason
         clsDefineAsClimatic.iCallType = 2
 
         clsGetSeasonLengthFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_seasonal_length_definition")
-        clsGetSeasonLengthFunction.AddParameter("data_name", Chr(34) & ucrSelectorLengthofSeason.strCurrentDataFrame & Chr(34), iPosition:=0)
 
         'Base Function
         ucrBase.clsRsyntax.ClearCodes()
@@ -369,6 +371,7 @@ Public Class dlgClimaticLengthOfSeason
         ucrReceiverStartofRains.AddAdditionalCodeParameterPair(clsMinusmoreOperator, New RParameter("right", 1, bNewIncludeArgumentName:=False), iAdditionalPairNo:=1)
         ucrInputLengthofSeason.AddAdditionalCodeParameterPair(clsGetSeasonLengthFunction, New RParameter("seasonal_length", 1), iAdditionalPairNo:=1)
 
+        ucrSelectorLengthofSeason.SetRCode(clsGetSeasonLengthFunction, bReset)
         ucrSaveDefinition.SetRCode(clsGetSeasonLengthFunction)
         ucrReceiverStartofRains.SetRCode(clsMinusOpertor, bReset)
         ucrReceiverEndofRains.SetRCode(clsMinusOpertor, bReset)
@@ -444,15 +447,10 @@ Public Class dlgClimaticLengthOfSeason
         End If
     End Sub
 
-    Private Sub AddDataName()
-        clsGetSeasonLengthFunction.AddParameter("data_name", strCurrDataName, iPosition:=0)
-    End Sub
-
     Private Sub ucrSelectorLengthofSeason_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorLengthofSeason.ControlValueChanged
         bDataChanged = True
         bUserClearedReceiver = False
         strCurrDataName = Chr(34) & ucrSelectorLengthofSeason.strCurrentDataFrame & Chr(34)
-        AddDataName()
         AutoFillReceivers(lstEndReceivers)
         AutoFillReceivers(lstStartReceivers)
         AutoFillReceivers(lstEndStatusReceivers)
@@ -495,7 +493,6 @@ Public Class dlgClimaticLengthOfSeason
         strCurrDataName = Chr(34) & ucrSelectorLengthofSeason.strCurrentDataFrame & Chr(34)
         clsDefineAsClimatic.AddParameter("data_name", strCurrDataName, iPosition:=0)
         clsConvertColumnTypeFunction.AddParameter("data_name", strCurrDataName, iPosition:=0)
-        AddDataName()
     End Sub
 
     Private Sub AddRemoveLengthmore()


### PR DESCRIPTION
Partly Fixes #10302
@lilyclements @rdstern @berylwaswa 

This PR implements changes outlined for the length of season dialog in the issue.

@lilyclements One little issue is that in the original version `get_seasonal_length_definition`, there was a named parameter `seasonal_length` that was being read in. When I updated it to  `data_book$get_seasonal_length_definition`, I still left this parameter in as it already was (since I wasn't sure of it). Please, is that okay?

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
