### PR TITLE
 Added factor level validation with warning label to Likert dialog

### DIFF
--- a/instat/dlgDescribeOneVariableLikertGraph.Designer.vb
+++ b/instat/dlgDescribeOneVariableLikertGraph.Designer.vb
@@ -261,4 +261,5 @@ Partial Class dlgDescribeOneVariableLikertGraph
     Friend WithEvents ucrSaveSummary As ucrSave
     Friend WithEvents ucrBase As ucrButtons
     Friend WithEvents cmdLikertOptions As Button
+    Friend WithEvents lblLevelWarning As Label
 End Class

--- a/instat/dlgDescribeOneVariableLikertGraph.vb
+++ b/instat/dlgDescribeOneVariableLikertGraph.vb
@@ -16,6 +16,7 @@
 
 Imports System.Windows.Forms.VisualStyles.VisualStyleElement
 Imports instat.Translations
+Imports RDotNet
 
 Public Class dlgDescribeOneVariableLikertGraph
     Private bFirstLoad As Boolean = True
@@ -128,6 +129,15 @@ Public Class dlgDescribeOneVariableLikertGraph
         If Not clsDummyFunction.ContainsParameter("type") Then
             clsDummyFunction.AddParameter("type", Chr(34) & "bar" & Chr(34), iPosition:=0)
         End If
+
+        lblLevelWarning = New System.Windows.Forms.Label()
+        lblLevelWarning.AutoSize = False
+        lblLevelWarning.ForeColor = System.Drawing.Color.Red
+        lblLevelWarning.Text = "All selected factors must have the same number of levels."
+        lblLevelWarning.Visible = False
+        lblLevelWarning.Size = New System.Drawing.Size(200, 40)
+        Me.Controls.Add(lblLevelWarning)
+        lblLevelWarning.BringToFront()
     End Sub
 
     Private Sub SetDefaults()
@@ -187,15 +197,24 @@ Public Class dlgDescribeOneVariableLikertGraph
         ucrPnlGraphType.SetRCode(clsDummyFunction, bReset)
     End Sub
     Public Sub TestOKEnabled()
+        Dim bLevelsMatch As Boolean = SelectedVariablesHaveMatchingLevels()
+
+        If lblLevelWarning IsNot Nothing Then
+            lblLevelWarning.Visible = Not bLevelsMatch AndAlso Not ucrReceiverMultipleLikert.IsEmpty()
+            lblLevelWarning.Location = New System.Drawing.Point(
+            ucrReceiverMultipleLikert.Left,
+            ucrReceiverMultipleLikert.Bottom + 4)
+        End If
+
         If bShowingGraph Then
-            If ucrReceiverMultipleLikert.IsEmpty() OrElse Not ucrSaveGraph.IsComplete Then
+            If ucrReceiverMultipleLikert.IsEmpty() OrElse Not ucrSaveGraph.IsComplete OrElse Not bLevelsMatch Then
                 ucrBase.OKEnabled(False)
             Else
                 ucrBase.OKEnabled(True)
                 grpLikertOptions.Enabled = Not ucrReceiverMultipleLikert.IsEmpty()
             End If
         Else
-            If ucrReceiverMultipleLikert.IsEmpty() OrElse Not ucrSaveSummary.IsComplete Then
+            If ucrReceiverMultipleLikert.IsEmpty() OrElse Not ucrSaveSummary.IsComplete OrElse Not bLevelsMatch Then
                 ucrBase.OKEnabled(False)
             Else
                 ucrBase.OKEnabled(True)
@@ -328,4 +347,39 @@ Public Class dlgDescribeOneVariableLikertGraph
             ucrBase.clsRsyntax.RemoveFromAfterCodes(clsDevOff)
         End If
     End Sub
+    Private Function SelectedVariablesHaveMatchingLevels() As Boolean
+        If ucrReceiverMultipleLikert.IsEmpty() Then Return True
+        Dim varNames As List(Of String) = ucrReceiverMultipleLikert.GetVariableNamesAsList()
+        If varNames.Count <= 1 Then Return True
+        Dim iExpectedLevels As Integer = -1
+        For Each strVar As String In varNames
+            Dim iLevels As Integer = GetVariableLevelCount(ucrSelectorLikert.strCurrentDataFrame, strVar)
+            If iLevels < 0 Then Continue For
+            If iExpectedLevels = -1 Then
+                iExpectedLevels = iLevels
+            ElseIf iLevels <> iExpectedLevels Then
+                Return False
+            End If
+        Next
+        Return True
+    End Function
+    Private Function GetVariableLevelCount(strDataFrame As String, strVarName As String) As Integer
+        Try
+            Dim clsNlevels As New RFunction
+            clsNlevels.SetRCommand("nlevels")
+            Dim clsGetCol As New RFunction
+            clsGetCol.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_columns_from_data")
+            clsGetCol.AddParameter("data_name", Chr(34) & strDataFrame & Chr(34))
+            clsGetCol.AddParameter("col_names", Chr(34) & strVarName & Chr(34))
+            clsNlevels.AddParameter("x", clsRFunctionParameter:=clsGetCol, bIncludeArgumentName:=False)
+            Dim expResult As RDotNet.SymbolicExpression =
+                frmMain.clsRLink.RunInternalScriptGetValue(clsNlevels.ToScript(), bSilent:=True)
+            If expResult IsNot Nothing AndAlso
+                expResult.Type <> RDotNet.Internals.SymbolicExpressionType.Null Then
+                Return expResult.AsInteger()(0)
+            End If
+        Catch ex As Exception
+        End Try
+        Return -1
+    End Function
 End Class

--- a/instat/dlgDescribeOneVariableLikertGraph.vb
+++ b/instat/dlgDescribeOneVariableLikertGraph.vb
@@ -350,12 +350,16 @@ Public Class dlgDescribeOneVariableLikertGraph
         End If
     End Sub
     Private Function SelectedVariablesHaveMatchingLevels() As Boolean
-        If ucrReceiverMultipleLikert.IsEmpty() Then Return True
-        Dim varNames As List(Of String) = ucrReceiverMultipleLikert.GetVariableNamesAsList()
-        If varNames.Count <= 1 Then Return True
+        Dim varNames As List(Of String)
         Dim iExpectedLevels As Integer = -1
+        Dim iLevels As Integer
+    
+        If ucrReceiverMultipleLikert.IsEmpty() Then Return True
+        varNames = ucrReceiverMultipleLikert.GetVariableNamesAsList()
+        If varNames.Count <= 1 Then Return True
+    
         For Each strVar As String In varNames
-            Dim iLevels As Integer = GetVariableLevelCount(ucrSelectorLikert.strCurrentDataFrame, strVar)
+            iLevels = GetVariableLevelCount(ucrSelectorLikert.strCurrentDataFrame, strVar)
             If iLevels < 0 Then Return False
             If iExpectedLevels = -1 Then
                 iExpectedLevels = iLevels

--- a/instat/dlgDescribeOneVariableLikertGraph.vb
+++ b/instat/dlgDescribeOneVariableLikertGraph.vb
@@ -133,7 +133,7 @@ Public Class dlgDescribeOneVariableLikertGraph
         lblLevelWarning = New System.Windows.Forms.Label()
         lblLevelWarning.AutoSize = False
         lblLevelWarning.ForeColor = System.Drawing.Color.Red
-        lblLevelWarning.Text = "All selected factors must have the same number of levels."
+        lblLevelWarning.Text = GetTranslation("All selected factors must have the same number of levels.")
         lblLevelWarning.Visible = False
         lblLevelWarning.Size = New System.Drawing.Size(200, 40)
         Me.Controls.Add(lblLevelWarning)
@@ -372,13 +372,14 @@ Public Class dlgDescribeOneVariableLikertGraph
             clsGetCol.AddParameter("data_name", Chr(34) & strDataFrame & Chr(34))
             clsGetCol.AddParameter("col_names", Chr(34) & strVarName & Chr(34))
             clsNlevels.AddParameter("x", clsRFunctionParameter:=clsGetCol, bIncludeArgumentName:=False)
-            Dim expResult As RDotNet.SymbolicExpression =
+            Dim expResult As SymbolicExpression =
                 frmMain.clsRLink.RunInternalScriptGetValue(clsNlevels.ToScript(), bSilent:=True)
             If expResult IsNot Nothing AndAlso
-                expResult.Type <> RDotNet.Internals.SymbolicExpressionType.Null Then
+                expResult.Type <> Internals.SymbolicExpressionType.Null Then
                 Return expResult.AsInteger()(0)
             End If
         Catch ex As Exception
+            Debug.WriteLine("GetVariableLevelCount failed for " & strVarName & ": " & ex.Message)
         End Try
         Return -1
     End Function

--- a/instat/dlgDescribeOneVariableLikertGraph.vb
+++ b/instat/dlgDescribeOneVariableLikertGraph.vb
@@ -133,9 +133,9 @@ Public Class dlgDescribeOneVariableLikertGraph
         lblLevelWarning = New System.Windows.Forms.Label()
         lblLevelWarning.AutoSize = False
         lblLevelWarning.ForeColor = System.Drawing.Color.Red
-        lblLevelWarning.Text = GetTranslation("All selected factors must have the same number of levels.")
+        lblLevelWarning.Text = GetTranslation("All factors must have the same number of levels.")
         lblLevelWarning.Visible = False
-        lblLevelWarning.Size = New System.Drawing.Size(200, 40)
+        lblLevelWarning.Size = New System.Drawing.Size(160, 40)
         Me.Controls.Add(lblLevelWarning)
         lblLevelWarning.BringToFront()
     End Sub

--- a/instat/dlgDescribeOneVariableLikertGraph.vb
+++ b/instat/dlgDescribeOneVariableLikertGraph.vb
@@ -24,6 +24,7 @@ Public Class dlgDescribeOneVariableLikertGraph
     Private Shared bShowingGraph As Boolean = True
     Private bHistogramChecked As Boolean = False
     Private bCentreChecked As Boolean = False
+    Private bLevelsValid As Boolean = True
     Private clsLikertFunction As New RFunction
     Private clsPlotFunction As New RFunction
     Private clsSummaryFunction As New RFunction
@@ -130,13 +131,13 @@ Public Class dlgDescribeOneVariableLikertGraph
             clsDummyFunction.AddParameter("type", Chr(34) & "bar" & Chr(34), iPosition:=0)
         End If
 
-        lblLevelWarning = New System.Windows.Forms.Label()
+        lblLevelWarning = New Label()
         lblLevelWarning.AutoSize = False
         lblLevelWarning.ForeColor = System.Drawing.Color.Red
         lblLevelWarning.Text = GetTranslation("All factors must have the same number of levels.")
         lblLevelWarning.Visible = False
         lblLevelWarning.Size = New System.Drawing.Size(160, 40)
-        Me.Controls.Add(lblLevelWarning)
+        Controls.Add(lblLevelWarning)
         lblLevelWarning.BringToFront()
     End Sub
 
@@ -181,6 +182,7 @@ Public Class dlgDescribeOneVariableLikertGraph
         cmdLikertOptions.Enabled = False
         bHistogramChecked = False
         bCentreChecked = False
+        bLevelsValid = True
 
         If bShowingGraph Then
             ucrBase.clsRsyntax.SetBaseRFunction(clsPlotFunction)
@@ -197,24 +199,17 @@ Public Class dlgDescribeOneVariableLikertGraph
         ucrPnlGraphType.SetRCode(clsDummyFunction, bReset)
     End Sub
     Public Sub TestOKEnabled()
-        Dim bLevelsMatch As Boolean = SelectedVariablesHaveMatchingLevels()
-
-        If lblLevelWarning IsNot Nothing Then
-            lblLevelWarning.Visible = Not bLevelsMatch AndAlso Not ucrReceiverMultipleLikert.IsEmpty()
-            lblLevelWarning.Location = New System.Drawing.Point(
-            ucrReceiverMultipleLikert.Left,
-            ucrReceiverMultipleLikert.Bottom + 4)
-        End If
+        UpdateLevelWarning()
 
         If bShowingGraph Then
-            If ucrReceiverMultipleLikert.IsEmpty() OrElse Not ucrSaveGraph.IsComplete OrElse Not bLevelsMatch Then
+            If ucrReceiverMultipleLikert.IsEmpty() OrElse Not ucrSaveGraph.IsComplete OrElse Not bLevelsValid Then
                 ucrBase.OKEnabled(False)
             Else
                 ucrBase.OKEnabled(True)
                 grpLikertOptions.Enabled = Not ucrReceiverMultipleLikert.IsEmpty()
             End If
         Else
-            If ucrReceiverMultipleLikert.IsEmpty() OrElse Not ucrSaveSummary.IsComplete OrElse Not bLevelsMatch Then
+            If ucrReceiverMultipleLikert.IsEmpty() OrElse Not ucrSaveSummary.IsComplete OrElse Not bLevelsValid Then
                 ucrBase.OKEnabled(False)
             Else
                 ucrBase.OKEnabled(True)
@@ -231,6 +226,9 @@ Public Class dlgDescribeOneVariableLikertGraph
 
     Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverMultipleLikert.ControlContentsChanged,
         ucrSaveGraph.ControlContentsChanged, ucrSaveSummary.ControlContentsChanged
+        If ucrChangedControl Is ucrReceiverMultipleLikert Then
+            bLevelsValid = SelectedVariablesHaveMatchingLevels()
+        End If
         TestOKEnabled()
     End Sub
     Private Sub rdoGraph_CheckedChanged(sender As Object, e As EventArgs) Handles rdoGraph.CheckedChanged
@@ -315,17 +313,13 @@ Public Class dlgDescribeOneVariableLikertGraph
             clsGetDataFrame.SetAssignTo("likert_data")
             ucrBase.clsRsyntax.AddToBeforeCodes(clsGetDataFrame, iPosition:=0)
 
-            ' For summary and graph - single likert object
             ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsLikertSummaryFunction)
             clsLikertSummaryFunction.RemoveParameterByName("items")
             clsLikertSummaryFunction.AddParameter("items", "likert_data", iPosition:=0, bIncludeArgumentName:=False)
             clsLikertSummaryFunction.SetAssignTo("likert_object")
             ucrBase.clsRsyntax.AddToBeforeCodes(clsLikertSummaryFunction, iPosition:=1)
 
-            ' Graph uses likert_object
             clsPlotFunction.AddParameter("x", "likert_object", iPosition:=0, bIncludeArgumentName:=False)
-
-            ' Summary uses likert_object
             clsSummaryFunction.AddParameter("object", "likert_object", bIncludeArgumentName:=False)
         Else
             ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsGetDataFrame)
@@ -347,6 +341,14 @@ Public Class dlgDescribeOneVariableLikertGraph
             ucrBase.clsRsyntax.RemoveFromAfterCodes(clsDevOff)
         End If
     End Sub
+    Private Sub UpdateLevelWarning()
+        If lblLevelWarning IsNot Nothing Then
+            lblLevelWarning.Visible = Not bLevelsValid AndAlso Not ucrReceiverMultipleLikert.IsEmpty()
+            lblLevelWarning.Location = New System.Drawing.Point(
+                ucrReceiverMultipleLikert.Left,
+                ucrReceiverMultipleLikert.Bottom + 4)
+        End If
+    End Sub
     Private Function SelectedVariablesHaveMatchingLevels() As Boolean
         If ucrReceiverMultipleLikert.IsEmpty() Then Return True
         Dim varNames As List(Of String) = ucrReceiverMultipleLikert.GetVariableNamesAsList()
@@ -354,7 +356,7 @@ Public Class dlgDescribeOneVariableLikertGraph
         Dim iExpectedLevels As Integer = -1
         For Each strVar As String In varNames
             Dim iLevels As Integer = GetVariableLevelCount(ucrSelectorLikert.strCurrentDataFrame, strVar)
-            If iLevels < 0 Then Continue For
+            If iLevels < 0 Then Return False
             If iExpectedLevels = -1 Then
                 iExpectedLevels = iLevels
             ElseIf iLevels <> iExpectedLevels Then


### PR DESCRIPTION
@lilyclements @berylwaswa @rdstern Kindly Check

Partly fixes #9330

The likert function in R requires all selected factor variables to have the same number of levels. Previously, the dialog had no validation for this , users could select mismatched factors and only discover the error when R threw an exception after clicking OK.

I went ahead and added validation that catches the mismatch early, shows a warning, and disables the OK button until the issue is resolved.

I used the data in Import from Library -> likert -> mass

**down here i have highlited the warning  message** 

<img width="606" height="633" alt="Warning Message" src="https://github.com/user-attachments/assets/be95c5f9-da94-45a7-bb65-d4ccbede15c0" />

---


**here i have shown that the OK button is disabled until the issue is resolved**




<img width="606" height="633" alt="Ok Is disabled when differennt levels" src="https://github.com/user-attachments/assets/76b8c0fa-deb6-4f51-adc5-6e87356dcedb" />

---
**I also used the survey data to check too** 

<img width="606" height="633" alt="image" src="https://github.com/user-attachments/assets/7f85e014-a430-4ccb-b468-898a60e27926" />



