### PR TITLE
Added the pivottable package as an archive into r-instat

### DIFF
--- a/instat/static/InstatObject/R/install_packages.R
+++ b/instat/static/InstatObject/R/install_packages.R
@@ -200,6 +200,7 @@ install.packages("https://cran.r-project.org/src/contrib/Archive/getPass/getPass
 install.packages("https://cran.r-project.org/src/contrib/Archive/PCICt/PCICt_0.5-4.tar.gz", repos=NULL, type="source")
 install.packages("https://cran.r-project.org/src/contrib/Archive/ncdf4.helpers/ncdf4.helpers_0.3-7.tar.gz", repos=NULL, type="source")
 install.packages("https://cran.r-project.org/src/contrib/Archive/climdex.pcic/climdex.pcic_1.1-11.tar.gz", repos=NULL, type="source")
+install.packages("https://cran.r-project.org/src/contrib/Archive/rpivotTable/rpivotTable_0.3.0.tar.gz", repos = NULL, type = "source")
 
 # Only use internal library
 if (length(.libPaths()) >= 2){

--- a/instat/static/InstatObject/R/install_packages.R
+++ b/instat/static/InstatObject/R/install_packages.R
@@ -115,8 +115,7 @@ packs <-
     "lemon",
     #"HistData", This is no longer used
     "caret",
-    "rpivotTable",
-    # For datasets
+       # For datasets
     "gcookbook",
     "tidytext",
     "janitor",

--- a/instat/static/InstatObject/R/install_packages.R
+++ b/instat/static/InstatObject/R/install_packages.R
@@ -199,7 +199,7 @@ install.packages("https://cran.r-project.org/src/contrib/Archive/getPass/getPass
 install.packages("https://cran.r-project.org/src/contrib/Archive/PCICt/PCICt_0.5-4.tar.gz", repos=NULL, type="source")
 install.packages("https://cran.r-project.org/src/contrib/Archive/ncdf4.helpers/ncdf4.helpers_0.3-7.tar.gz", repos=NULL, type="source")
 install.packages("https://cran.r-project.org/src/contrib/Archive/climdex.pcic/climdex.pcic_1.1-11.tar.gz", repos=NULL, type="source")
-install.packages("https://cran.r-project.org/src/contrib/Archive/rpivotTable/rpivotTable_0.3.0.tar.gz", repos = NULL, type = "source")
+install.packages("https://cran.r-project.org/src/contrib/Archive/rpivotTable/rpivotTable_0.3.0.tar.gz", repos=NULL, type = "source")
 
 # Only use internal library
 if (length(.libPaths()) >= 2){


### PR DESCRIPTION
Fixes #10314 
I have added the PivotTable package as an archive into R-instat

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
