### PR TITLE
Amendments in Climatic Summary dialog

### DIFF
--- a/instat/dlgClimaticSummary.vb
+++ b/instat/dlgClimaticSummary.vb
@@ -374,7 +374,7 @@ Public Class dlgClimaticSummary
 
         sdgDoyRange.ShowDialog()
 
-        If sdgDoyRange.rdoFromVariable.Checked OrElse sdgDoyRange.rdoToVariable.Checked OrElse sdgDoyRange.rdoLength.Checked Then
+        If sdgDoyRange.IsSeasonal Then
             clsBuildClimaticSummaryDefinitions.AddParameter("seasonal", "TRUE", iPosition:=4)
         Else
             clsBuildClimaticSummaryDefinitions.RemoveParameterByName("seasonal")

--- a/instat/dlgClimaticSummary.vb
+++ b/instat/dlgClimaticSummary.vb
@@ -371,7 +371,15 @@ Public Class dlgClimaticSummary
         If Not bUseDate Then
             sdgDoyRange.ucrChkUseDate.Checked = False
         End If
+
         sdgDoyRange.ShowDialog()
+
+        If sdgDoyRange.rdoFromVariable.Checked OrElse sdgDoyRange.rdoToVariable.Checked OrElse sdgDoyRange.rdoLength.Checked Then
+            clsBuildClimaticSummaryDefinitions.AddParameter("seasonal", "TRUE", iPosition:=4)
+        Else
+            clsBuildClimaticSummaryDefinitions.RemoveParameterByName("seasonal")
+        End If
+
         UpdateDayFilterPreview()
         AddDayRange()
         AddDateDoy()

--- a/instat/sdgDoyRange.vb
+++ b/instat/sdgDoyRange.vb
@@ -214,8 +214,8 @@ Public Class sdgDoyRange
             ElseIf rdoFromVariable.Checked Then
                 clsDayFromOperator.AddParameter("from", strParameterValue:=ucrReceiverFrom.GetVariableNames(False), iPosition:=1)
             End If
+            UpdateCalculatedFrom()
         End If
-        UpdateCalculatedFrom()
     End Sub
 
     Private Sub Tordo_CheckedChanged(sender As Object, e As EventArgs) Handles rdoToFixed.CheckedChanged, rdoToVariable.CheckedChanged, rdoLength.CheckedChanged
@@ -247,8 +247,8 @@ Public Class sdgDoyRange
                     clsIfElseFirstDoyFilledFunction.AddParameter("yes", clsROperatorParameter:=clsFixedDiffOp, iPosition:=1)
                 End If
             End If
+            UpdateCalculatedFrom()
         End If
-        UpdateCalculatedFrom()
     End Sub
 
     Private Sub UpdateCalculatedFrom()
@@ -287,6 +287,12 @@ Public Class sdgDoyRange
     Public ReadOnly Property UseDateChecked As Boolean
         Get
             Return ucrChkUseDate.Checked
+        End Get
+    End Property
+
+    Public ReadOnly Property IsSeasonal As Boolean
+        Get
+            Return rdoFromVariable.Checked OrElse rdoToVariable.Checked OrElse rdoLength.Checked
         End Get
     End Property
 

--- a/instat/sdgDoyRange.vb
+++ b/instat/sdgDoyRange.vb
@@ -214,8 +214,8 @@ Public Class sdgDoyRange
             ElseIf rdoFromVariable.Checked Then
                 clsDayFromOperator.AddParameter("from", strParameterValue:=ucrReceiverFrom.GetVariableNames(False), iPosition:=1)
             End If
-            UpdateCalculatedFrom()
         End If
+        UpdateCalculatedFrom()
     End Sub
 
     Private Sub Tordo_CheckedChanged(sender As Object, e As EventArgs) Handles rdoToFixed.CheckedChanged, rdoToVariable.CheckedChanged, rdoLength.CheckedChanged
@@ -247,8 +247,8 @@ Public Class sdgDoyRange
                     clsIfElseFirstDoyFilledFunction.AddParameter("yes", clsROperatorParameter:=clsFixedDiffOp, iPosition:=1)
                 End If
             End If
-            UpdateCalculatedFrom()
         End If
+        UpdateCalculatedFrom()
     End Sub
 
     Private Sub UpdateCalculatedFrom()


### PR DESCRIPTION
Fixes #10322
@lilyclements @rdstern @berylwaswa @Vitalis95 

This PR addresses the concerns raised in the issue and is ready for review.

**Developer Testing Checklist**
- [X] Runs without errors  
- [X] OK disabled when dialog is incomplete or invalid  
- [X] OK enabled only when required inputs are valid
- [X] Reset returns dialog to its default/sensible state
- [X] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [X] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
