### PR TITLE
Updated table header separator handling using Unicode Unit Separator

### DIFF
--- a/instat/UserTables/dlgGeneralTable.vb
+++ b/instat/UserTables/dlgGeneralTable.vb
@@ -222,11 +222,11 @@ Public Class dlgGeneralTable
 
         clsPivotWiderFunction.SetPackageName("tidyr")
         clsPivotWiderFunction.SetRCommand("pivot_wider")
-        clsPivotWiderFunction.AddParameter("names_sep", Chr(34) & "__" & Chr(34), iPosition:=2)
+        clsPivotWiderFunction.AddParameter("names_sep", Chr(34) & "\u241F" & Chr(34), iPosition:=2)
 
         clsPivotWiderAscolumnFunction.SetPackageName("tidyr")
         clsPivotWiderAscolumnFunction.SetRCommand("pivot_wider")
-        clsPivotWiderAscolumnFunction.AddParameter("names_sep", Chr(34) & "__" & Chr(34), iPosition:=3)
+        clsPivotWiderAscolumnFunction.AddParameter("names_sep", Chr(34) & "\u241F" & Chr(34), iPosition:=3)
         clsPivotWiderAscolumnFunction.AddParameter("values_from", Chr(34) & "value" & Chr(34), iPosition:=2)
 
         clsFormatTableFunction.SetRCommand("format_gt_table")
@@ -245,7 +245,7 @@ Public Class dlgGeneralTable
 
         clsSpannerFunction.SetPackageName("gt")
         clsSpannerFunction.SetRCommand("tab_spanner_delim")
-        clsSpannerFunction.AddParameter("delim", Chr(34) & "__" & Chr(34), iPosition:=0)
+        clsSpannerFunction.AddParameter("delim", Chr(34) & "\u241F" & Chr(34), iPosition:=0)
 
         clsCompleteFunction.SetPackageName("tidyr")
         clsCompleteFunction.SetRCommand("complete")

--- a/instat/UserTables/dlgGeneralTable.vb
+++ b/instat/UserTables/dlgGeneralTable.vb
@@ -21,6 +21,7 @@ Public Class dlgGeneralTable
 
     Private bFirstload As Boolean = True
     Private bReset As Boolean = True
+    Private Const DoubleUnitSeparator As String = "\u001F\u001F" 'Double unit separator
 
     Private Sub dlgGeneralTable_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstload Then
@@ -222,11 +223,11 @@ Public Class dlgGeneralTable
 
         clsPivotWiderFunction.SetPackageName("tidyr")
         clsPivotWiderFunction.SetRCommand("pivot_wider")
-        clsPivotWiderFunction.AddParameter("names_sep", Chr(34) & "\u241F" & Chr(34), iPosition:=2)
+        clsPivotWiderFunction.AddParameter("names_sep", Chr(34) & DoubleUnitSeparator & Chr(34), iPosition:=2)
 
         clsPivotWiderAscolumnFunction.SetPackageName("tidyr")
         clsPivotWiderAscolumnFunction.SetRCommand("pivot_wider")
-        clsPivotWiderAscolumnFunction.AddParameter("names_sep", Chr(34) & "\u241F" & Chr(34), iPosition:=3)
+        clsPivotWiderAscolumnFunction.AddParameter("names_sep", Chr(34) & DoubleUnitSeparator & Chr(34), iPosition:=3)
         clsPivotWiderAscolumnFunction.AddParameter("values_from", Chr(34) & "value" & Chr(34), iPosition:=2)
 
         clsFormatTableFunction.SetRCommand("format_gt_table")
@@ -245,7 +246,7 @@ Public Class dlgGeneralTable
 
         clsSpannerFunction.SetPackageName("gt")
         clsSpannerFunction.SetRCommand("tab_spanner_delim")
-        clsSpannerFunction.AddParameter("delim", Chr(34) & "\u241F" & Chr(34), iPosition:=0)
+        clsSpannerFunction.AddParameter("delim", Chr(34) & DoubleUnitSeparator & Chr(34), iPosition:=0)
 
         clsCompleteFunction.SetPackageName("tidyr")
         clsCompleteFunction.SetRCommand("complete")

--- a/instat/dlgSummaryTables.vb
+++ b/instat/dlgSummaryTables.vb
@@ -204,6 +204,7 @@ Public Class dlgSummaryTables
         clsPivotWiderFunction.SetRCommand("pivot_wider")
         clsPivotWiderFunction.AddParameter("values_from", "value", iPosition:=1)
         clsPivotWiderFunction.AddParameter("names_sort", "TRUE", iPosition:=2)
+        clsPivotWiderFunction.AddParameter("names_sep", Chr(34) & "\u241F" & Chr(34), iPosition:=3)
 
         clsSummariesList.SetRCommand("c")
         clsSummariesList.AddParameter("summary_mean", Chr(34) & "summary_mean" & Chr(34), bIncludeArgumentName:=False) ' TODO decide which default(s) to use?
@@ -228,7 +229,7 @@ Public Class dlgSummaryTables
 
         ClsTabSpannerDelimFunction.SetPackageName("gt")
         ClsTabSpannerDelimFunction.SetRCommand("tab_spanner_delim")
-        ClsTabSpannerDelimFunction.AddParameter("delim", Chr(34) & "_" & Chr(34))
+        ClsTabSpannerDelimFunction.AddParameter("delim", Chr(34) & "\u241F" & Chr(34))
 
         clsSelectFunction.SetPackageName("dplyr")
         clsSelectFunction.SetRCommand("select")

--- a/instat/dlgSummaryTables.vb
+++ b/instat/dlgSummaryTables.vb
@@ -30,6 +30,7 @@ Public Class dlgSummaryTables
     Private firstAutoBumpDone As Boolean = False
     Private clsDummyFunction As New RFunction
     Private clsSummaryOperator, clsFrequencyOperator, clsJoiningPipeOperator, clsSpannerOperator As New ROperator
+    Private Const UnitSeparator As String = "\u241F" 'single unit separator
 
     Private Sub dlgNewSummaryTables_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstload Then
@@ -204,7 +205,7 @@ Public Class dlgSummaryTables
         clsPivotWiderFunction.SetRCommand("pivot_wider")
         clsPivotWiderFunction.AddParameter("values_from", "value", iPosition:=1)
         clsPivotWiderFunction.AddParameter("names_sort", "TRUE", iPosition:=2)
-        clsPivotWiderFunction.AddParameter("names_sep", Chr(34) & "\u241F" & Chr(34), iPosition:=3)
+        clsPivotWiderFunction.AddParameter("names_sep", Chr(34) & UnitSeparator & Chr(34), iPosition:=3)
 
         clsSummariesList.SetRCommand("c")
         clsSummariesList.AddParameter("summary_mean", Chr(34) & "summary_mean" & Chr(34), bIncludeArgumentName:=False) ' TODO decide which default(s) to use?
@@ -229,7 +230,7 @@ Public Class dlgSummaryTables
 
         ClsTabSpannerDelimFunction.SetPackageName("gt")
         ClsTabSpannerDelimFunction.SetRCommand("tab_spanner_delim")
-        ClsTabSpannerDelimFunction.AddParameter("delim", Chr(34) & "\u241F" & Chr(34))
+        ClsTabSpannerDelimFunction.AddParameter("delim", Chr(34) & UnitSeparator & Chr(34))
 
         clsSelectFunction.SetPackageName("dplyr")
         clsSelectFunction.SetRCommand("select")


### PR DESCRIPTION
Replaced "__" and "_" separators with the Unicode Unit Separator ("\u241F") in table formatting logic to improve header parsing consistency and avoid delimiter conflicts in table names and column labels.

Solves #9256

### Before asking for review
Please confirm that you have:

- Completed the developer testing checklist below (ticking items as you go)
- Responded to all AI/bot comments (either fixed or explained)
- Added a short note in the PR describing how you tested these changes
- Noted which issue(s) this PR relates to

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)

@lilyclements @berylwaswa Kindly review