### PR TITLE
Adjusted spacing and layout consistency in the Mosaic dialog

### DIFF
--- a/instat/dlgMosaicPlot.Designer.vb
+++ b/instat/dlgMosaicPlot.Designer.vb
@@ -28,6 +28,27 @@ Partial Class dlgMosaicPlot
         Me.lblConditionFactors = New System.Windows.Forms.Label()
         Me.lblWeights = New System.Windows.Forms.Label()
         Me.lblPartitioningType = New System.Windows.Forms.Label()
+        Me.contextMenuStripOptions = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.toolStripMenuItemPlotOptions = New System.Windows.Forms.ToolStripMenuItem()
+        Me.toolStripMenuItemMosaicOptions = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripMenuItemMosaicJitter = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripMenuItemMosaicText = New System.Windows.Forms.ToolStripMenuItem()
+        Me.lblFacetBy = New System.Windows.Forms.Label()
+        Me.lblSizeJitter = New System.Windows.Forms.Label()
+        Me.lblColourJitter = New System.Windows.Forms.Label()
+        Me.lblColourLabel = New System.Windows.Forms.Label()
+        Me.lblSizeLabel = New System.Windows.Forms.Label()
+        Me.ucrColorsLabel = New instat.ucrColors()
+        Me.ucrNudSizeLabel = New instat.ucrNud()
+        Me.ucrChkLabel = New instat.ucrCheck()
+        Me.ucrColors = New instat.ucrColors()
+        Me.ucrNudJitter = New instat.ucrNud()
+        Me.ucrChkJitter = New instat.ucrCheck()
+        Me.ucrInputStation = New instat.ucrInputComboBox()
+        Me.ucr1stFactorReceiver = New instat.ucrReceiverSingle()
+        Me.ucrInputLegendPosition = New instat.ucrInputComboBox()
+        Me.ucrChkLegend = New instat.ucrCheck()
+        Me.cmdOptions = New instat.ucrSplitButton()
         Me.ucrNudXAxisLabelsAngle = New instat.ucrNud()
         Me.ucrInputPartitioning = New instat.ucrInputComboBox()
         Me.ucrChkOmitMissing = New instat.ucrCheck()
@@ -39,27 +60,6 @@ Partial Class dlgMosaicPlot
         Me.ucrChkXAxisLabelAngle = New instat.ucrCheck()
         Me.ucrSelectorMosaicPlot = New instat.ucrSelectorByDataFrameAddRemove()
         Me.ucrBase = New instat.ucrButtons()
-        Me.contextMenuStripOptions = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.toolStripMenuItemPlotOptions = New System.Windows.Forms.ToolStripMenuItem()
-        Me.toolStripMenuItemMosaicOptions = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ToolStripMenuItemMosaicJitter = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ToolStripMenuItemMosaicText = New System.Windows.Forms.ToolStripMenuItem()
-        Me.cmdOptions = New instat.ucrSplitButton()
-        Me.ucrInputStation = New instat.ucrInputComboBox()
-        Me.ucr1stFactorReceiver = New instat.ucrReceiverSingle()
-        Me.lblFacetBy = New System.Windows.Forms.Label()
-        Me.ucrInputLegendPosition = New instat.ucrInputComboBox()
-        Me.ucrChkLegend = New instat.ucrCheck()
-        Me.ucrChkJitter = New instat.ucrCheck()
-        Me.lblSizeJitter = New System.Windows.Forms.Label()
-        Me.ucrNudJitter = New instat.ucrNud()
-        Me.lblColourJitter = New System.Windows.Forms.Label()
-        Me.ucrColors = New instat.ucrColors()
-        Me.ucrColorsLabel = New instat.ucrColors()
-        Me.lblColourLabel = New System.Windows.Forms.Label()
-        Me.ucrNudSizeLabel = New instat.ucrNud()
-        Me.lblSizeLabel = New System.Windows.Forms.Label()
-        Me.ucrChkLabel = New instat.ucrCheck()
         Me.contextMenuStripOptions.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -113,12 +113,221 @@ Partial Class dlgMosaicPlot
         Me.lblPartitioningType.TabIndex = 11
         Me.lblPartitioningType.Text = "Partitioning:"
         '
+        'contextMenuStripOptions
+        '
+        Me.contextMenuStripOptions.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.toolStripMenuItemPlotOptions, Me.toolStripMenuItemMosaicOptions, Me.ToolStripMenuItemMosaicJitter, Me.ToolStripMenuItemMosaicText})
+        Me.contextMenuStripOptions.Name = "contextMenuStripOk"
+        Me.contextMenuStripOptions.Size = New System.Drawing.Size(186, 92)
+        '
+        'toolStripMenuItemPlotOptions
+        '
+        Me.toolStripMenuItemPlotOptions.Name = "toolStripMenuItemPlotOptions"
+        Me.toolStripMenuItemPlotOptions.Size = New System.Drawing.Size(185, 22)
+        Me.toolStripMenuItemPlotOptions.Text = "Plot Options"
+        '
+        'toolStripMenuItemMosaicOptions
+        '
+        Me.toolStripMenuItemMosaicOptions.Name = "toolStripMenuItemMosaicOptions"
+        Me.toolStripMenuItemMosaicOptions.Size = New System.Drawing.Size(185, 22)
+        Me.toolStripMenuItemMosaicOptions.Text = "Mosaic Options"
+        '
+        'ToolStripMenuItemMosaicJitter
+        '
+        Me.ToolStripMenuItemMosaicJitter.Name = "ToolStripMenuItemMosaicJitter"
+        Me.ToolStripMenuItemMosaicJitter.Size = New System.Drawing.Size(185, 22)
+        Me.ToolStripMenuItemMosaicJitter.Text = "Mosaic Jitter Options"
+        '
+        'ToolStripMenuItemMosaicText
+        '
+        Me.ToolStripMenuItemMosaicText.Name = "ToolStripMenuItemMosaicText"
+        Me.ToolStripMenuItemMosaicText.Size = New System.Drawing.Size(185, 22)
+        Me.ToolStripMenuItemMosaicText.Text = "Mosaic Text Options"
+        '
+        'lblFacetBy
+        '
+        Me.lblFacetBy.AutoSize = True
+        Me.lblFacetBy.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblFacetBy.Location = New System.Drawing.Point(227, 443)
+        Me.lblFacetBy.Name = "lblFacetBy"
+        Me.lblFacetBy.Size = New System.Drawing.Size(52, 13)
+        Me.lblFacetBy.TabIndex = 94
+        Me.lblFacetBy.Tag = ""
+        Me.lblFacetBy.Text = "Facet By:"
+        '
+        'lblSizeJitter
+        '
+        Me.lblSizeJitter.AutoSize = True
+        Me.lblSizeJitter.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblSizeJitter.Location = New System.Drawing.Point(107, 388)
+        Me.lblSizeJitter.Name = "lblSizeJitter"
+        Me.lblSizeJitter.Size = New System.Drawing.Size(30, 13)
+        Me.lblSizeJitter.TabIndex = 100
+        Me.lblSizeJitter.Tag = ""
+        Me.lblSizeJitter.Text = "Size:"
+        '
+        'lblColourJitter
+        '
+        Me.lblColourJitter.AutoSize = True
+        Me.lblColourJitter.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblColourJitter.Location = New System.Drawing.Point(227, 388)
+        Me.lblColourJitter.Name = "lblColourJitter"
+        Me.lblColourJitter.Size = New System.Drawing.Size(40, 13)
+        Me.lblColourJitter.TabIndex = 102
+        Me.lblColourJitter.Tag = ""
+        Me.lblColourJitter.Text = "Colour:"
+        '
+        'lblColourLabel
+        '
+        Me.lblColourLabel.AutoSize = True
+        Me.lblColourLabel.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblColourLabel.Location = New System.Drawing.Point(227, 413)
+        Me.lblColourLabel.Name = "lblColourLabel"
+        Me.lblColourLabel.Size = New System.Drawing.Size(40, 13)
+        Me.lblColourLabel.TabIndex = 206
+        Me.lblColourLabel.Tag = ""
+        Me.lblColourLabel.Text = "Colour:"
+        '
+        'lblSizeLabel
+        '
+        Me.lblSizeLabel.AutoSize = True
+        Me.lblSizeLabel.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblSizeLabel.Location = New System.Drawing.Point(107, 413)
+        Me.lblSizeLabel.Name = "lblSizeLabel"
+        Me.lblSizeLabel.Size = New System.Drawing.Size(30, 13)
+        Me.lblSizeLabel.TabIndex = 204
+        Me.lblSizeLabel.Tag = ""
+        Me.lblSizeLabel.Text = "Size:"
+        '
+        'ucrColorsLabel
+        '
+        Me.ucrColorsLabel.AddQuotesIfUnrecognised = True
+        Me.ucrColorsLabel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrColorsLabel.GetSetSelectedIndex = -1
+        Me.ucrColorsLabel.IsReadOnly = False
+        Me.ucrColorsLabel.Location = New System.Drawing.Point(275, 411)
+        Me.ucrColorsLabel.Name = "ucrColorsLabel"
+        Me.ucrColorsLabel.Size = New System.Drawing.Size(70, 22)
+        Me.ucrColorsLabel.TabIndex = 207
+        '
+        'ucrNudSizeLabel
+        '
+        Me.ucrNudSizeLabel.AutoSize = True
+        Me.ucrNudSizeLabel.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudSizeLabel.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        Me.ucrNudSizeLabel.Location = New System.Drawing.Point(143, 413)
+        Me.ucrNudSizeLabel.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudSizeLabel.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudSizeLabel.Name = "ucrNudSizeLabel"
+        Me.ucrNudSizeLabel.Size = New System.Drawing.Size(50, 20)
+        Me.ucrNudSizeLabel.TabIndex = 205
+        Me.ucrNudSizeLabel.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        '
+        'ucrChkLabel
+        '
+        Me.ucrChkLabel.AutoSize = True
+        Me.ucrChkLabel.Checked = False
+        Me.ucrChkLabel.Location = New System.Drawing.Point(12, 409)
+        Me.ucrChkLabel.Name = "ucrChkLabel"
+        Me.ucrChkLabel.Size = New System.Drawing.Size(98, 24)
+        Me.ucrChkLabel.TabIndex = 203
+        '
+        'ucrColors
+        '
+        Me.ucrColors.AddQuotesIfUnrecognised = True
+        Me.ucrColors.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrColors.GetSetSelectedIndex = -1
+        Me.ucrColors.IsReadOnly = False
+        Me.ucrColors.Location = New System.Drawing.Point(275, 385)
+        Me.ucrColors.Name = "ucrColors"
+        Me.ucrColors.Size = New System.Drawing.Size(70, 22)
+        Me.ucrColors.TabIndex = 202
+        '
+        'ucrNudJitter
+        '
+        Me.ucrNudJitter.AutoSize = True
+        Me.ucrNudJitter.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudJitter.Increment = New Decimal(New Integer() {1, 0, 0, 0})
+        Me.ucrNudJitter.Location = New System.Drawing.Point(143, 387)
+        Me.ucrNudJitter.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
+        Me.ucrNudJitter.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
+        Me.ucrNudJitter.Name = "ucrNudJitter"
+        Me.ucrNudJitter.Size = New System.Drawing.Size(50, 20)
+        Me.ucrNudJitter.TabIndex = 101
+        Me.ucrNudJitter.Value = New Decimal(New Integer() {0, 0, 0, 0})
+        '
+        'ucrChkJitter
+        '
+        Me.ucrChkJitter.AutoSize = True
+        Me.ucrChkJitter.Checked = False
+        Me.ucrChkJitter.Location = New System.Drawing.Point(12, 386)
+        Me.ucrChkJitter.Name = "ucrChkJitter"
+        Me.ucrChkJitter.Size = New System.Drawing.Size(98, 24)
+        Me.ucrChkJitter.TabIndex = 99
+        '
+        'ucrInputStation
+        '
+        Me.ucrInputStation.AddQuotesIfUnrecognised = True
+        Me.ucrInputStation.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputStation.GetSetSelectedIndex = -1
+        Me.ucrInputStation.IsReadOnly = False
+        Me.ucrInputStation.Location = New System.Drawing.Point(336, 457)
+        Me.ucrInputStation.Name = "ucrInputStation"
+        Me.ucrInputStation.Size = New System.Drawing.Size(101, 21)
+        Me.ucrInputStation.TabIndex = 96
+        '
+        'ucr1stFactorReceiver
+        '
+        Me.ucr1stFactorReceiver.AutoSize = True
+        Me.ucr1stFactorReceiver.frmParent = Me
+        Me.ucr1stFactorReceiver.Location = New System.Drawing.Point(224, 458)
+        Me.ucr1stFactorReceiver.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucr1stFactorReceiver.Name = "ucr1stFactorReceiver"
+        Me.ucr1stFactorReceiver.Selector = Nothing
+        Me.ucr1stFactorReceiver.Size = New System.Drawing.Size(110, 26)
+        Me.ucr1stFactorReceiver.strNcFilePath = ""
+        Me.ucr1stFactorReceiver.TabIndex = 95
+        Me.ucr1stFactorReceiver.ucrSelector = Nothing
+        '
+        'ucrInputLegendPosition
+        '
+        Me.ucrInputLegendPosition.AddQuotesIfUnrecognised = True
+        Me.ucrInputLegendPosition.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputLegendPosition.GetSetSelectedIndex = -1
+        Me.ucrInputLegendPosition.IsReadOnly = False
+        Me.ucrInputLegendPosition.Location = New System.Drawing.Point(94, 456)
+        Me.ucrInputLegendPosition.Name = "ucrInputLegendPosition"
+        Me.ucrInputLegendPosition.Size = New System.Drawing.Size(112, 21)
+        Me.ucrInputLegendPosition.TabIndex = 98
+        '
+        'ucrChkLegend
+        '
+        Me.ucrChkLegend.AutoSize = True
+        Me.ucrChkLegend.Checked = False
+        Me.ucrChkLegend.Location = New System.Drawing.Point(12, 457)
+        Me.ucrChkLegend.Name = "ucrChkLegend"
+        Me.ucrChkLegend.Size = New System.Drawing.Size(98, 24)
+        Me.ucrChkLegend.TabIndex = 97
+        '
+        'cmdOptions
+        '
+        Me.cmdOptions.AllowDrop = True
+        Me.cmdOptions.AutoSize = True
+        Me.cmdOptions.ContextMenuStrip = Me.contextMenuStripOptions
+        Me.cmdOptions.Location = New System.Drawing.Point(9, 199)
+        Me.cmdOptions.Name = "cmdOptions"
+        Me.cmdOptions.Size = New System.Drawing.Size(148, 23)
+        Me.cmdOptions.SplitMenuStrip = Me.contextMenuStripOptions
+        Me.cmdOptions.TabIndex = 19
+        Me.cmdOptions.Tag = "Plot Options"
+        Me.cmdOptions.Text = "Plot Options"
+        Me.cmdOptions.UseVisualStyleBackColor = True
+        '
         'ucrNudXAxisLabelsAngle
         '
         Me.ucrNudXAxisLabelsAngle.AutoSize = True
         Me.ucrNudXAxisLabelsAngle.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudXAxisLabelsAngle.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudXAxisLabelsAngle.Location = New System.Drawing.Point(140, 327)
+        Me.ucrNudXAxisLabelsAngle.Location = New System.Drawing.Point(143, 327)
         Me.ucrNudXAxisLabelsAngle.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
         Me.ucrNudXAxisLabelsAngle.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudXAxisLabelsAngle.Name = "ucrNudXAxisLabelsAngle"
@@ -141,7 +350,7 @@ Partial Class dlgMosaicPlot
         '
         Me.ucrChkOmitMissing.AutoSize = True
         Me.ucrChkOmitMissing.Checked = False
-        Me.ucrChkOmitMissing.Location = New System.Drawing.Point(9, 305)
+        Me.ucrChkOmitMissing.Location = New System.Drawing.Point(12, 305)
         Me.ucrChkOmitMissing.Name = "ucrChkOmitMissing"
         Me.ucrChkOmitMissing.Size = New System.Drawing.Size(224, 23)
         Me.ucrChkOmitMissing.TabIndex = 13
@@ -201,7 +410,7 @@ Partial Class dlgMosaicPlot
         'ucrSaveMosaicPlot
         '
         Me.ucrSaveMosaicPlot.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveMosaicPlot.Location = New System.Drawing.Point(9, 487)
+        Me.ucrSaveMosaicPlot.Location = New System.Drawing.Point(12, 485)
         Me.ucrSaveMosaicPlot.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrSaveMosaicPlot.Name = "ucrSaveMosaicPlot"
         Me.ucrSaveMosaicPlot.Size = New System.Drawing.Size(317, 24)
@@ -211,7 +420,7 @@ Partial Class dlgMosaicPlot
         '
         Me.ucrChkXAxisLabelAngle.AutoSize = True
         Me.ucrChkXAxisLabelAngle.Checked = False
-        Me.ucrChkXAxisLabelAngle.Location = New System.Drawing.Point(9, 327)
+        Me.ucrChkXAxisLabelAngle.Location = New System.Drawing.Point(12, 327)
         Me.ucrChkXAxisLabelAngle.Name = "ucrChkXAxisLabelAngle"
         Me.ucrChkXAxisLabelAngle.Size = New System.Drawing.Size(168, 23)
         Me.ucrChkXAxisLabelAngle.TabIndex = 14
@@ -236,215 +445,6 @@ Partial Class dlgMosaicPlot
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(408, 52)
         Me.ucrBase.TabIndex = 17
-        '
-        'contextMenuStripOptions
-        '
-        Me.contextMenuStripOptions.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.toolStripMenuItemPlotOptions, Me.toolStripMenuItemMosaicOptions, Me.ToolStripMenuItemMosaicJitter, Me.ToolStripMenuItemMosaicText})
-        Me.contextMenuStripOptions.Name = "contextMenuStripOk"
-        Me.contextMenuStripOptions.Size = New System.Drawing.Size(186, 92)
-        '
-        'toolStripMenuItemPlotOptions
-        '
-        Me.toolStripMenuItemPlotOptions.Name = "toolStripMenuItemPlotOptions"
-        Me.toolStripMenuItemPlotOptions.Size = New System.Drawing.Size(185, 22)
-        Me.toolStripMenuItemPlotOptions.Text = "Plot Options"
-        '
-        'toolStripMenuItemMosaicOptions
-        '
-        Me.toolStripMenuItemMosaicOptions.Name = "toolStripMenuItemMosaicOptions"
-        Me.toolStripMenuItemMosaicOptions.Size = New System.Drawing.Size(185, 22)
-        Me.toolStripMenuItemMosaicOptions.Text = "Mosaic Options"
-        '
-        'ToolStripMenuItemMosaicJitter
-        '
-        Me.ToolStripMenuItemMosaicJitter.Name = "ToolStripMenuItemMosaicJitter"
-        Me.ToolStripMenuItemMosaicJitter.Size = New System.Drawing.Size(185, 22)
-        Me.ToolStripMenuItemMosaicJitter.Text = "Mosaic Jitter Options"
-        '
-        'ToolStripMenuItemMosaicText
-        '
-        Me.ToolStripMenuItemMosaicText.Name = "ToolStripMenuItemMosaicText"
-        Me.ToolStripMenuItemMosaicText.Size = New System.Drawing.Size(185, 22)
-        Me.ToolStripMenuItemMosaicText.Text = "Mosaic Text Options"
-        '
-        'cmdOptions
-        '
-        Me.cmdOptions.AllowDrop = True
-        Me.cmdOptions.AutoSize = True
-        Me.cmdOptions.ContextMenuStrip = Me.contextMenuStripOptions
-        Me.cmdOptions.Location = New System.Drawing.Point(9, 199)
-        Me.cmdOptions.Name = "cmdOptions"
-        Me.cmdOptions.Size = New System.Drawing.Size(148, 23)
-        Me.cmdOptions.SplitMenuStrip = Me.contextMenuStripOptions
-        Me.cmdOptions.TabIndex = 19
-        Me.cmdOptions.Tag = "Plot Options"
-        Me.cmdOptions.Text = "Plot Options"
-        Me.cmdOptions.UseVisualStyleBackColor = True
-        '
-        'ucrInputStation
-        '
-        Me.ucrInputStation.AddQuotesIfUnrecognised = True
-        Me.ucrInputStation.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrInputStation.GetSetSelectedIndex = -1
-        Me.ucrInputStation.IsReadOnly = False
-        Me.ucrInputStation.Location = New System.Drawing.Point(333, 405)
-        Me.ucrInputStation.Name = "ucrInputStation"
-        Me.ucrInputStation.Size = New System.Drawing.Size(101, 21)
-        Me.ucrInputStation.TabIndex = 96
-        '
-        'ucr1stFactorReceiver
-        '
-        Me.ucr1stFactorReceiver.AutoSize = True
-        Me.ucr1stFactorReceiver.frmParent = Me
-        Me.ucr1stFactorReceiver.Location = New System.Drawing.Point(221, 406)
-        Me.ucr1stFactorReceiver.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucr1stFactorReceiver.Name = "ucr1stFactorReceiver"
-        Me.ucr1stFactorReceiver.Selector = Nothing
-        Me.ucr1stFactorReceiver.Size = New System.Drawing.Size(110, 26)
-        Me.ucr1stFactorReceiver.strNcFilePath = ""
-        Me.ucr1stFactorReceiver.TabIndex = 95
-        Me.ucr1stFactorReceiver.ucrSelector = Nothing
-        '
-        'lblFacetBy
-        '
-        Me.lblFacetBy.AutoSize = True
-        Me.lblFacetBy.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblFacetBy.Location = New System.Drawing.Point(224, 391)
-        Me.lblFacetBy.Name = "lblFacetBy"
-        Me.lblFacetBy.Size = New System.Drawing.Size(52, 13)
-        Me.lblFacetBy.TabIndex = 94
-        Me.lblFacetBy.Tag = ""
-        Me.lblFacetBy.Text = "Facet By:"
-        '
-        'ucrInputLegendPosition
-        '
-        Me.ucrInputLegendPosition.AddQuotesIfUnrecognised = True
-        Me.ucrInputLegendPosition.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrInputLegendPosition.GetSetSelectedIndex = -1
-        Me.ucrInputLegendPosition.IsReadOnly = False
-        Me.ucrInputLegendPosition.Location = New System.Drawing.Point(91, 404)
-        Me.ucrInputLegendPosition.Name = "ucrInputLegendPosition"
-        Me.ucrInputLegendPosition.Size = New System.Drawing.Size(112, 21)
-        Me.ucrInputLegendPosition.TabIndex = 98
-        '
-        'ucrChkLegend
-        '
-        Me.ucrChkLegend.AutoSize = True
-        Me.ucrChkLegend.Checked = False
-        Me.ucrChkLegend.Location = New System.Drawing.Point(9, 405)
-        Me.ucrChkLegend.Name = "ucrChkLegend"
-        Me.ucrChkLegend.Size = New System.Drawing.Size(98, 24)
-        Me.ucrChkLegend.TabIndex = 97
-        '
-        'ucrChkJitter
-        '
-        Me.ucrChkJitter.AutoSize = True
-        Me.ucrChkJitter.Checked = False
-        Me.ucrChkJitter.Location = New System.Drawing.Point(9, 432)
-        Me.ucrChkJitter.Name = "ucrChkJitter"
-        Me.ucrChkJitter.Size = New System.Drawing.Size(98, 24)
-        Me.ucrChkJitter.TabIndex = 99
-        '
-        'lblSizeJitter
-        '
-        Me.lblSizeJitter.AutoSize = True
-        Me.lblSizeJitter.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblSizeJitter.Location = New System.Drawing.Point(104, 434)
-        Me.lblSizeJitter.Name = "lblSizeJitter"
-        Me.lblSizeJitter.Size = New System.Drawing.Size(30, 13)
-        Me.lblSizeJitter.TabIndex = 100
-        Me.lblSizeJitter.Tag = ""
-        Me.lblSizeJitter.Text = "Size:"
-        '
-        'ucrNudJitter
-        '
-        Me.ucrNudJitter.AutoSize = True
-        Me.ucrNudJitter.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudJitter.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudJitter.Location = New System.Drawing.Point(140, 433)
-        Me.ucrNudJitter.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
-        Me.ucrNudJitter.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudJitter.Name = "ucrNudJitter"
-        Me.ucrNudJitter.Size = New System.Drawing.Size(50, 20)
-        Me.ucrNudJitter.TabIndex = 101
-        Me.ucrNudJitter.Value = New Decimal(New Integer() {0, 0, 0, 0})
-        '
-        'lblColourJitter
-        '
-        Me.lblColourJitter.AutoSize = True
-        Me.lblColourJitter.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblColourJitter.Location = New System.Drawing.Point(224, 434)
-        Me.lblColourJitter.Name = "lblColourJitter"
-        Me.lblColourJitter.Size = New System.Drawing.Size(40, 13)
-        Me.lblColourJitter.TabIndex = 102
-        Me.lblColourJitter.Tag = ""
-        Me.lblColourJitter.Text = "Colour:"
-        '
-        'ucrColors
-        '
-        Me.ucrColors.AddQuotesIfUnrecognised = True
-        Me.ucrColors.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrColors.GetSetSelectedIndex = -1
-        Me.ucrColors.IsReadOnly = False
-        Me.ucrColors.Location = New System.Drawing.Point(272, 431)
-        Me.ucrColors.Name = "ucrColors"
-        Me.ucrColors.Size = New System.Drawing.Size(70, 22)
-        Me.ucrColors.TabIndex = 202
-        '
-        'ucrColorsLabel
-        '
-        Me.ucrColorsLabel.AddQuotesIfUnrecognised = True
-        Me.ucrColorsLabel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrColorsLabel.GetSetSelectedIndex = -1
-        Me.ucrColorsLabel.IsReadOnly = False
-        Me.ucrColorsLabel.Location = New System.Drawing.Point(272, 457)
-        Me.ucrColorsLabel.Name = "ucrColorsLabel"
-        Me.ucrColorsLabel.Size = New System.Drawing.Size(70, 22)
-        Me.ucrColorsLabel.TabIndex = 207
-        '
-        'lblColourLabel
-        '
-        Me.lblColourLabel.AutoSize = True
-        Me.lblColourLabel.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblColourLabel.Location = New System.Drawing.Point(224, 459)
-        Me.lblColourLabel.Name = "lblColourLabel"
-        Me.lblColourLabel.Size = New System.Drawing.Size(40, 13)
-        Me.lblColourLabel.TabIndex = 206
-        Me.lblColourLabel.Tag = ""
-        Me.lblColourLabel.Text = "Colour:"
-        '
-        'ucrNudSizeLabel
-        '
-        Me.ucrNudSizeLabel.AutoSize = True
-        Me.ucrNudSizeLabel.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudSizeLabel.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudSizeLabel.Location = New System.Drawing.Point(140, 459)
-        Me.ucrNudSizeLabel.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
-        Me.ucrNudSizeLabel.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
-        Me.ucrNudSizeLabel.Name = "ucrNudSizeLabel"
-        Me.ucrNudSizeLabel.Size = New System.Drawing.Size(50, 20)
-        Me.ucrNudSizeLabel.TabIndex = 205
-        Me.ucrNudSizeLabel.Value = New Decimal(New Integer() {0, 0, 0, 0})
-        '
-        'lblSizeLabel
-        '
-        Me.lblSizeLabel.AutoSize = True
-        Me.lblSizeLabel.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblSizeLabel.Location = New System.Drawing.Point(104, 459)
-        Me.lblSizeLabel.Name = "lblSizeLabel"
-        Me.lblSizeLabel.Size = New System.Drawing.Size(30, 13)
-        Me.lblSizeLabel.TabIndex = 204
-        Me.lblSizeLabel.Tag = ""
-        Me.lblSizeLabel.Text = "Size:"
-        '
-        'ucrChkLabel
-        '
-        Me.ucrChkLabel.AutoSize = True
-        Me.ucrChkLabel.Checked = False
-        Me.ucrChkLabel.Location = New System.Drawing.Point(9, 455)
-        Me.ucrChkLabel.Name = "ucrChkLabel"
-        Me.ucrChkLabel.Size = New System.Drawing.Size(98, 24)
-        Me.ucrChkLabel.TabIndex = 203
         '
         'dlgMosaicPlot
         '

--- a/instat/dlgMosaicPlot.Designer.vb
+++ b/instat/dlgMosaicPlot.Designer.vb
@@ -118,7 +118,7 @@ Partial Class dlgMosaicPlot
         Me.ucrNudXAxisLabelsAngle.AutoSize = True
         Me.ucrNudXAxisLabelsAngle.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudXAxisLabelsAngle.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudXAxisLabelsAngle.Location = New System.Drawing.Point(140, 326)
+        Me.ucrNudXAxisLabelsAngle.Location = New System.Drawing.Point(140, 327)
         Me.ucrNudXAxisLabelsAngle.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
         Me.ucrNudXAxisLabelsAngle.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudXAxisLabelsAngle.Name = "ucrNudXAxisLabelsAngle"
@@ -141,7 +141,7 @@ Partial Class dlgMosaicPlot
         '
         Me.ucrChkOmitMissing.AutoSize = True
         Me.ucrChkOmitMissing.Checked = False
-        Me.ucrChkOmitMissing.Location = New System.Drawing.Point(9, 278)
+        Me.ucrChkOmitMissing.Location = New System.Drawing.Point(9, 305)
         Me.ucrChkOmitMissing.Name = "ucrChkOmitMissing"
         Me.ucrChkOmitMissing.Size = New System.Drawing.Size(224, 23)
         Me.ucrChkOmitMissing.TabIndex = 13
@@ -201,7 +201,7 @@ Partial Class dlgMosaicPlot
         'ucrSaveMosaicPlot
         '
         Me.ucrSaveMosaicPlot.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveMosaicPlot.Location = New System.Drawing.Point(9, 513)
+        Me.ucrSaveMosaicPlot.Location = New System.Drawing.Point(9, 487)
         Me.ucrSaveMosaicPlot.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrSaveMosaicPlot.Name = "ucrSaveMosaicPlot"
         Me.ucrSaveMosaicPlot.Size = New System.Drawing.Size(317, 24)
@@ -211,7 +211,7 @@ Partial Class dlgMosaicPlot
         '
         Me.ucrChkXAxisLabelAngle.AutoSize = True
         Me.ucrChkXAxisLabelAngle.Checked = False
-        Me.ucrChkXAxisLabelAngle.Location = New System.Drawing.Point(9, 326)
+        Me.ucrChkXAxisLabelAngle.Location = New System.Drawing.Point(9, 327)
         Me.ucrChkXAxisLabelAngle.Name = "ucrChkXAxisLabelAngle"
         Me.ucrChkXAxisLabelAngle.Size = New System.Drawing.Size(168, 23)
         Me.ucrChkXAxisLabelAngle.TabIndex = 14
@@ -232,7 +232,7 @@ Partial Class dlgMosaicPlot
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(14, 544)
+        Me.ucrBase.Location = New System.Drawing.Point(12, 512)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(408, 52)
         Me.ucrBase.TabIndex = 17
@@ -287,7 +287,7 @@ Partial Class dlgMosaicPlot
         Me.ucrInputStation.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputStation.GetSetSelectedIndex = -1
         Me.ucrInputStation.IsReadOnly = False
-        Me.ucrInputStation.Location = New System.Drawing.Point(321, 381)
+        Me.ucrInputStation.Location = New System.Drawing.Point(333, 405)
         Me.ucrInputStation.Name = "ucrInputStation"
         Me.ucrInputStation.Size = New System.Drawing.Size(101, 21)
         Me.ucrInputStation.TabIndex = 96
@@ -296,7 +296,7 @@ Partial Class dlgMosaicPlot
         '
         Me.ucr1stFactorReceiver.AutoSize = True
         Me.ucr1stFactorReceiver.frmParent = Me
-        Me.ucr1stFactorReceiver.Location = New System.Drawing.Point(209, 382)
+        Me.ucr1stFactorReceiver.Location = New System.Drawing.Point(221, 406)
         Me.ucr1stFactorReceiver.Margin = New System.Windows.Forms.Padding(0)
         Me.ucr1stFactorReceiver.Name = "ucr1stFactorReceiver"
         Me.ucr1stFactorReceiver.Selector = Nothing
@@ -309,7 +309,7 @@ Partial Class dlgMosaicPlot
         '
         Me.lblFacetBy.AutoSize = True
         Me.lblFacetBy.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblFacetBy.Location = New System.Drawing.Point(212, 367)
+        Me.lblFacetBy.Location = New System.Drawing.Point(224, 391)
         Me.lblFacetBy.Name = "lblFacetBy"
         Me.lblFacetBy.Size = New System.Drawing.Size(52, 13)
         Me.lblFacetBy.TabIndex = 94
@@ -322,7 +322,7 @@ Partial Class dlgMosaicPlot
         Me.ucrInputLegendPosition.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputLegendPosition.GetSetSelectedIndex = -1
         Me.ucrInputLegendPosition.IsReadOnly = False
-        Me.ucrInputLegendPosition.Location = New System.Drawing.Point(91, 381)
+        Me.ucrInputLegendPosition.Location = New System.Drawing.Point(91, 404)
         Me.ucrInputLegendPosition.Name = "ucrInputLegendPosition"
         Me.ucrInputLegendPosition.Size = New System.Drawing.Size(112, 21)
         Me.ucrInputLegendPosition.TabIndex = 98
@@ -331,7 +331,7 @@ Partial Class dlgMosaicPlot
         '
         Me.ucrChkLegend.AutoSize = True
         Me.ucrChkLegend.Checked = False
-        Me.ucrChkLegend.Location = New System.Drawing.Point(9, 382)
+        Me.ucrChkLegend.Location = New System.Drawing.Point(9, 405)
         Me.ucrChkLegend.Name = "ucrChkLegend"
         Me.ucrChkLegend.Size = New System.Drawing.Size(98, 24)
         Me.ucrChkLegend.TabIndex = 97
@@ -340,7 +340,7 @@ Partial Class dlgMosaicPlot
         '
         Me.ucrChkJitter.AutoSize = True
         Me.ucrChkJitter.Checked = False
-        Me.ucrChkJitter.Location = New System.Drawing.Point(9, 429)
+        Me.ucrChkJitter.Location = New System.Drawing.Point(9, 432)
         Me.ucrChkJitter.Name = "ucrChkJitter"
         Me.ucrChkJitter.Size = New System.Drawing.Size(98, 24)
         Me.ucrChkJitter.TabIndex = 99
@@ -349,7 +349,7 @@ Partial Class dlgMosaicPlot
         '
         Me.lblSizeJitter.AutoSize = True
         Me.lblSizeJitter.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblSizeJitter.Location = New System.Drawing.Point(104, 431)
+        Me.lblSizeJitter.Location = New System.Drawing.Point(104, 434)
         Me.lblSizeJitter.Name = "lblSizeJitter"
         Me.lblSizeJitter.Size = New System.Drawing.Size(30, 13)
         Me.lblSizeJitter.TabIndex = 100
@@ -361,7 +361,7 @@ Partial Class dlgMosaicPlot
         Me.ucrNudJitter.AutoSize = True
         Me.ucrNudJitter.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudJitter.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudJitter.Location = New System.Drawing.Point(140, 430)
+        Me.ucrNudJitter.Location = New System.Drawing.Point(140, 433)
         Me.ucrNudJitter.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
         Me.ucrNudJitter.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudJitter.Name = "ucrNudJitter"
@@ -373,7 +373,7 @@ Partial Class dlgMosaicPlot
         '
         Me.lblColourJitter.AutoSize = True
         Me.lblColourJitter.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblColourJitter.Location = New System.Drawing.Point(224, 431)
+        Me.lblColourJitter.Location = New System.Drawing.Point(224, 434)
         Me.lblColourJitter.Name = "lblColourJitter"
         Me.lblColourJitter.Size = New System.Drawing.Size(40, 13)
         Me.lblColourJitter.TabIndex = 102
@@ -386,7 +386,7 @@ Partial Class dlgMosaicPlot
         Me.ucrColors.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrColors.GetSetSelectedIndex = -1
         Me.ucrColors.IsReadOnly = False
-        Me.ucrColors.Location = New System.Drawing.Point(272, 428)
+        Me.ucrColors.Location = New System.Drawing.Point(272, 431)
         Me.ucrColors.Name = "ucrColors"
         Me.ucrColors.Size = New System.Drawing.Size(70, 22)
         Me.ucrColors.TabIndex = 202
@@ -397,7 +397,7 @@ Partial Class dlgMosaicPlot
         Me.ucrColorsLabel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrColorsLabel.GetSetSelectedIndex = -1
         Me.ucrColorsLabel.IsReadOnly = False
-        Me.ucrColorsLabel.Location = New System.Drawing.Point(272, 473)
+        Me.ucrColorsLabel.Location = New System.Drawing.Point(272, 457)
         Me.ucrColorsLabel.Name = "ucrColorsLabel"
         Me.ucrColorsLabel.Size = New System.Drawing.Size(70, 22)
         Me.ucrColorsLabel.TabIndex = 207
@@ -406,7 +406,7 @@ Partial Class dlgMosaicPlot
         '
         Me.lblColourLabel.AutoSize = True
         Me.lblColourLabel.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblColourLabel.Location = New System.Drawing.Point(224, 475)
+        Me.lblColourLabel.Location = New System.Drawing.Point(224, 459)
         Me.lblColourLabel.Name = "lblColourLabel"
         Me.lblColourLabel.Size = New System.Drawing.Size(40, 13)
         Me.lblColourLabel.TabIndex = 206
@@ -418,7 +418,7 @@ Partial Class dlgMosaicPlot
         Me.ucrNudSizeLabel.AutoSize = True
         Me.ucrNudSizeLabel.DecimalPlaces = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudSizeLabel.Increment = New Decimal(New Integer() {1, 0, 0, 0})
-        Me.ucrNudSizeLabel.Location = New System.Drawing.Point(140, 475)
+        Me.ucrNudSizeLabel.Location = New System.Drawing.Point(140, 459)
         Me.ucrNudSizeLabel.Maximum = New Decimal(New Integer() {100, 0, 0, 0})
         Me.ucrNudSizeLabel.Minimum = New Decimal(New Integer() {0, 0, 0, 0})
         Me.ucrNudSizeLabel.Name = "ucrNudSizeLabel"
@@ -430,7 +430,7 @@ Partial Class dlgMosaicPlot
         '
         Me.lblSizeLabel.AutoSize = True
         Me.lblSizeLabel.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblSizeLabel.Location = New System.Drawing.Point(104, 475)
+        Me.lblSizeLabel.Location = New System.Drawing.Point(104, 459)
         Me.lblSizeLabel.Name = "lblSizeLabel"
         Me.lblSizeLabel.Size = New System.Drawing.Size(30, 13)
         Me.lblSizeLabel.TabIndex = 204
@@ -441,7 +441,7 @@ Partial Class dlgMosaicPlot
         '
         Me.ucrChkLabel.AutoSize = True
         Me.ucrChkLabel.Checked = False
-        Me.ucrChkLabel.Location = New System.Drawing.Point(9, 471)
+        Me.ucrChkLabel.Location = New System.Drawing.Point(9, 455)
         Me.ucrChkLabel.Name = "ucrChkLabel"
         Me.ucrChkLabel.Size = New System.Drawing.Size(98, 24)
         Me.ucrChkLabel.TabIndex = 203
@@ -451,7 +451,7 @@ Partial Class dlgMosaicPlot
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSize = True
-        Me.ClientSize = New System.Drawing.Size(441, 605)
+        Me.ClientSize = New System.Drawing.Size(441, 569)
         Me.Controls.Add(Me.ucrColorsLabel)
         Me.Controls.Add(Me.lblColourLabel)
         Me.Controls.Add(Me.ucrNudSizeLabel)

--- a/instat/dlgMosaicPlot.resx
+++ b/instat/dlgMosaicPlot.resx
@@ -117,10 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>42</value>
-  </metadata>
   <metadata name="contextMenuStripOptions.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>42</value>
   </metadata>
 </root>

--- a/instat/dlgMosaicPlot.vb
+++ b/instat/dlgMosaicPlot.vb
@@ -667,6 +667,10 @@ Public Class dlgMosaicPlot
         openSdgLayerOptions(clsMosaicTextFunction)
     End Sub
 
+    Private Sub ucrInput_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputStation.ControlValueChanged
+
+    End Sub
+
     Private Sub ucrChkJitter_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkJitter.ControlValueChanged, ucrColors.ControlValueChanged, ucrNudJitter.ControlValueChanged
         If ucrChkJitter.Checked Then
             clsBaseOperator.AddParameter("geom_mosaic_jitter", clsRFunctionParameter:=clsMosaicJitterFunction)


### PR DESCRIPTION
Reduced spacing between controls in the Mosaic dialog to improve layout consistency with other dialogs in R-Instat.

Fixes #10329

### Before asking for review
Please confirm that you have:

- Completed the developer testing checklist below (ticking items as you go)
- Responded to all AI/bot comments (either fixed or explained)
- Added a short note in the PR describing how you tested these changes
- Noted which issue(s) this PR relates to

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)


@berylwaswa @rdstern Kindly could you review.