### PR TITLE
Update translation check workflow for PR handling

### DIFF
--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -1,7 +1,7 @@
 name: Translation Check
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ "master" ]
     paths:
       - 'instat/**/*.vb'
@@ -9,17 +9,35 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  issues: write
+  pull-requests: read
 
 jobs:
   check-translations:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: Checkout trusted base tooling
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Full history for git diff
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          persist-credentials: false
+
+      - name: Checkout PR content
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch base branch for diff
+        working-directory: pr
+        run: |
+          git remote add base "https://github.com/${{ github.repository }}.git"
+          git fetch --no-tags base "refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/base/${{ github.event.pull_request.base.ref }}"
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -28,13 +46,12 @@ jobs:
 
       - name: Run translation check
         id: translation-check
-        working-directory: scripts
-        # Non-zero exit on missing translations fails this step and the job.
-        # Captures output to a report file so the follow-up step can post
-        # a PR comment even on failure.
+        working-directory: pr
+        # Run trusted scripts from the base checkout against the PR checkout.
+        # The PR checkout is treated only as data; no PR code is executed.
         run: |
           set +e
-          python check_translations.py --ci > translation-report.txt 2>&1
+          python ../base/scripts/check_translations.py --ci --base="base/${{ github.event.pull_request.base.ref }}" > translation-report.txt 2>&1
           status=$?
           cat translation-report.txt
           exit $status
@@ -43,12 +60,13 @@ jobs:
         if: always()
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
 
             let report = '';
             try {
-              report = fs.readFileSync('scripts/translation-report.txt', 'utf8');
+              report = fs.readFileSync('pr/translation-report.txt', 'utf8');
             } catch (e) {
               report = 'Translation check completed (no detailed report available)';
             }
@@ -66,7 +84,7 @@ jobs:
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number
+              issue_number: context.payload.pull_request.number
             });
 
             const botComment = comments.find(c =>
@@ -85,7 +103,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: context.payload.pull_request.number,
                 body
               });
             }


### PR DESCRIPTION
Use pull_request_target so the workflow token can update PR comments on upstream fork PRs. Run trusted base-branch tooling against the PR checkout without executing PR-supplied scripts.

This PR fixes the existing translations pipeline failures due to permission issues from forks. This is a major blocker and this PR should be treated as a patch requiring immediate attention.


### Before asking for review
Please confirm that you have:

- Completed the developer testing checklist below (ticking items as you go)
- Responded to all AI/bot comments (either fixed or explained)
- Added a short note in the PR describing how you tested these changes
- Noted which issue(s) this PR relates to

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x} Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [ ] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
