### PR TITLE
Fixed typo in keyboard label from 'siginf' to 'signif'

### DIFF
--- a/instat/ucrCalculator.Designer.vb
+++ b/instat/ucrCalculator.Designer.vb
@@ -3635,10 +3635,10 @@ Partial Class ucrCalculator
         Me.cmdSiginf.ImeMode = System.Windows.Forms.ImeMode.NoControl
         Me.cmdSiginf.Location = New System.Drawing.Point(100, 101)
         Me.cmdSiginf.Margin = New System.Windows.Forms.Padding(2)
-        Me.cmdSiginf.Name = "cmdSiginf"
+        Me.cmdSiginf.Name = "cmdSignif"
         Me.cmdSiginf.Size = New System.Drawing.Size(50, 30)
         Me.cmdSiginf.TabIndex = 145
-        Me.cmdSiginf.Text = "siginf"
+        Me.cmdSiginf.Text = "signif"
         Me.cmdSiginf.UseVisualStyleBackColor = True
         '
         'cmdAbs

--- a/instat/ucrCalculator.Designer.vb
+++ b/instat/ucrCalculator.Designer.vb
@@ -284,7 +284,7 @@ Partial Class ucrCalculator
         Me.cmdLogit = New System.Windows.Forms.Button()
         Me.cmdSign = New System.Windows.Forms.Button()
         Me.cmdRound = New System.Windows.Forms.Button()
-        Me.cmdSiginf = New System.Windows.Forms.Button()
+        Me.cmdSignif = New System.Windows.Forms.Button()
         Me.cmdAbs = New System.Windows.Forms.Button()
         Me.cmdExp = New System.Windows.Forms.Button()
         Me.cmdDeg = New System.Windows.Forms.Button()
@@ -3502,7 +3502,7 @@ Partial Class ucrCalculator
         Me.grpMaths.Controls.Add(Me.cmdLogit)
         Me.grpMaths.Controls.Add(Me.cmdSign)
         Me.grpMaths.Controls.Add(Me.cmdRound)
-        Me.grpMaths.Controls.Add(Me.cmdSiginf)
+        Me.grpMaths.Controls.Add(Me.cmdSignif)
         Me.grpMaths.Controls.Add(Me.cmdAbs)
         Me.grpMaths.Controls.Add(Me.cmdExp)
         Me.grpMaths.Controls.Add(Me.cmdDeg)
@@ -3631,15 +3631,15 @@ Partial Class ucrCalculator
         '
         'cmdSiginf
         '
-        Me.cmdSiginf.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
-        Me.cmdSiginf.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSiginf.Location = New System.Drawing.Point(100, 101)
-        Me.cmdSiginf.Margin = New System.Windows.Forms.Padding(2)
-        Me.cmdSiginf.Name = "cmdSignif"
-        Me.cmdSiginf.Size = New System.Drawing.Size(50, 30)
-        Me.cmdSiginf.TabIndex = 145
-        Me.cmdSiginf.Text = "signif"
-        Me.cmdSiginf.UseVisualStyleBackColor = True
+        Me.cmdSignif.Font = New System.Drawing.Font("Microsoft Sans Serif", 8.25!)
+        Me.cmdSignif.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.cmdSignif.Location = New System.Drawing.Point(100, 101)
+        Me.cmdSignif.Margin = New System.Windows.Forms.Padding(2)
+        Me.cmdSignif.Name = "cmdSignif"
+        Me.cmdSignif.Size = New System.Drawing.Size(50, 30)
+        Me.cmdSignif.TabIndex = 145
+        Me.cmdSignif.Text = "signif"
+        Me.cmdSignif.UseVisualStyleBackColor = True
         '
         'cmdAbs
         '
@@ -8912,7 +8912,7 @@ Partial Class ucrCalculator
     Friend WithEvents grpMaths As GroupBox
     Friend WithEvents cmdSign As Button
     Friend WithEvents cmdRound As Button
-    Friend WithEvents cmdSiginf As Button
+    Friend WithEvents cmdSignif As Button
     Friend WithEvents cmdAbs As Button
     Friend WithEvents cmdExp As Button
     Friend WithEvents cmdDeg As Button

--- a/instat/ucrCalculator.vb
+++ b/instat/ucrCalculator.vb
@@ -75,7 +75,7 @@ Public Class ucrCalculator
         'Temp disabled::Needs discussions to see if they are needed
         bControlsInitialised = True
         ttCalculator.SetToolTip(cmdRound, "round(x) to round to whole numbers, round(x,2) to round to 2 decimal places, round(x,-2) to round to the nearest 100")
-        ttCalculator.SetToolTip(cmdSiginf, "signif(x,3) to round to 3 significant figures")
+        ttCalculator.SetToolTip(cmdSignif, "signif(x,3) to round to 3 significant figures")
 
         'Transform keyboard tooltips
         ttCalculator.SetToolTip(cmdSortF, """Use only With extreme care"" sorts a vector into ascending Or descending order. For example sort(c(5, 7, 4, 4, 3)) = (3, 4, 4, 5, 7)")
@@ -1270,7 +1270,7 @@ Public Class ucrCalculator
         End If
     End Sub
 
-    Private Sub cmdSiginf_Click(sender As Object, e As EventArgs) Handles cmdSiginf.Click
+    Private Sub cmdSiginf_Click(sender As Object, e As EventArgs) Handles cmdSignif.Click
         If chkShowParameters.Checked Then
             ucrReceiverForCalculation.AddToReceiverAtCursorPosition("signif(x= , digits=6)", 12)
         Else


### PR DESCRIPTION
### Before asking for review
Please confirm that you have:

- Completed the developer testing checklist below (ticking items as you go)
- Responded to all AI/bot comments (either fixed or explained)
- Added a short note in the PR describing how you tested these changes
- Noted which issue(s) this PR relates to

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)


Updated the  typing error in the keyboard from 'siginf' to 'signif'
Partially fixes #10331
@berylwaswa @rdstern Kindly review this PR. It addresses only the first part of the issue as a partial fix, since the issue consists of two parts.