### PR TITLE
Fix commenting permission issue

### DIFF
--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -10,7 +10,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   check-translations:


### PR DESCRIPTION
### Before asking for review
Please confirm that you have:

- Completed the developer testing checklist below (ticking items as you go)
- Responded to all AI/bot comments (either fixed or explained)
- Added a short note in the PR describing how you tested these changes
- Noted which issue(s) this PR relates to

**Developer Testing Checklist**
- [ ] Runs without errors  
- [ ] OK disabled when dialog is incomplete or invalid  
- [ ] OK enabled only when required inputs are valid
- [ ] Reset returns dialog to its default/sensible state
- [ ] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [ ] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [ ] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)

fix(ci): restore PR comment write permission in translation-check

Commit e70d469c3 correctly switched to pull_request_target for fork PR support, but inadvertently downgraded pull-requests from write to read. This caused all post-fix runs to fail with 403 when creating or updating PR comments, despite Issues:write being granted.

Restore pull-requests: write so the workflow can post translation check results on external contributor PRs.
