### PR TITLE
Saved output to a different data name

### DIFF
--- a/instat/dlgClimaticSummary.vb
+++ b/instat/dlgClimaticSummary.vb
@@ -165,6 +165,7 @@ Public Class dlgClimaticSummary
 
         ucrSaveObject.SetSaveType(strRObjectType:=RObjectTypeLabel.StructureLabel, strRObjectFormat:=RObjectFormat.Text)
         ucrSaveObject.SetDataFrameSelector(ucrSelectorVariable.ucrAvailableDataFrames)
+        ucrSaveObject.SetDataNameAsRVariable("linked_data_name")
         ucrSaveObject.SetLabelText("Name:")
         ucrSaveObject.SetIsComboBox()
         ucrSaveObject.SetAssignToBooleans(bTempAssignToIsPrefix:=True)

--- a/instat/dlgEndOfRainsSeason.vb
+++ b/instat/dlgEndOfRainsSeason.vb
@@ -365,6 +365,7 @@ Public Class dlgEndOfRainsSeason
 
         ucrSaveObject.SetSaveType(strRObjectType:=RObjectTypeLabel.StructureLabel, strRObjectFormat:=RObjectFormat.Text)
         ucrSaveObject.SetDataFrameSelector(ucrSelectorForWaterBalance.ucrAvailableDataFrames)
+        ucrSaveObject.SetDataNameAsRVariable("linked_data_name")
         ucrSaveObject.SetCheckBoxText("Store Definitions:")
         ucrSaveObject.SetIsComboBox()
         ucrSaveObject.SetAssignToBooleans(bTempAssignToIsPrefix:=True)

--- a/instat/dlgPICSACrops.vb
+++ b/instat/dlgPICSACrops.vb
@@ -230,12 +230,14 @@ Public Class dlgPICSACrops
         ucrSaveDefinitionCrops.SetIsComboBox()
         ucrSaveDefinitionCrops.SetCheckBoxText("Store Crops Data Definitions")
         ucrSaveDefinitionCrops.SetDataFrameSelector(ucrSelectorForCrops.ucrAvailableDataFrames)
+        ucrSaveDefinitionCrops.SetDataNameAsRVariable("new_crop_def")
 
         ucrSaveDefinitionProportions.SetPrefix("crops_proportion_definition")
         ucrSaveDefinitionProportions.SetSaveType(strRObjectType:=RObjectTypeLabel.StructureLabel, strRObjectFormat:=RObjectFormat.Text)
         ucrSaveDefinitionProportions.SetIsComboBox()
         ucrSaveDefinitionProportions.SetCheckBoxText("Store Proportion Definitions")
         ucrSaveDefinitionProportions.SetDataFrameSelector(ucrSelectorForCrops.ucrAvailableDataFrames)
+        ucrSaveDefinitionProportions.SetDataNameAsRVariable("new_crop_prop")
 
         'Linking of controls
         ucrChkDataProp.AddToLinkedControls({ucrChkDataCrops, ucrSaveDefinitionProportions}, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedDisabledIfParameterMissing:=True)


### PR DESCRIPTION
Fixes #10342 
@lilyclements @rdstern @berylwaswa 

@lilyclements I have changed the save name as specified in the issue. The dialogs affected are as follows
- End of Rains / End of Seasons
- Climatic Summaries
- PICSA Crops

In PICSA Crops, the new data name I used was not `linked_data_name` (as was done in the other dialogs). Instead, when we're saving proportions, we have `new_crop_prop`, and when we're saving crop definitions, we have `new_crop_def`

Lastly, I have not added the option for the spells dialog here because there's an open PR (#10200) on that, and I believe this change was the last bit needed to get it merged. I'll add it in there now.

**Developer Testing Checklist**
- [X] Runs without errors  
- [X] OK disabled when dialog is incomplete or invalid  
- [X] OK enabled only when required inputs are valid
- [X] Reset returns dialog to its default/sensible state
- [X] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [X] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
