### PR TITLE
Made changes to how definitions are run in Start of Rains dialog

### DIFF
--- a/instat/dlgStartofRains.vb
+++ b/instat/dlgStartofRains.vb
@@ -238,6 +238,7 @@ Public Class dlgStartofRains
         SetReceiver()
         AdditionalCondition()
         ChangeDSValue()
+        AddStartRainsDefinitionParams()
     End Sub
 
     Private Sub SetDefaults()

--- a/instat/dlgStartofRains.vb
+++ b/instat/dlgStartofRains.vb
@@ -21,13 +21,13 @@ Public Class dlgStartofRains
     Private clsCalcRainDay, clsCalcStartDOY, clsConvertssndLinkedVariableFunction, clsDeleteunusedrowFunction, clsRunStartStatus2Function, clsStartRainCombine2Function, clsInnerIfElseFunction, clsListFunction, clsNastatus2Function As New RFunction
     Private clsIfElseStatus2Function, clsConvertColumnType1Function, clsConvertColumnType2Function, clsGetColumnDataTypeFunction, clsStatRainStatus2Function, clsSetnameRainStatusFunction, clsCalculatedListformFunction, clsConvertLinkedvariablesvectorFunction As New RFunction
     Private clsListSubCalc, clsManipulationFirstDOYPerYear, clsConditionsFilter, clsCombinedList, clsSetnameRainFunction, clsConvertColumnTypeFunction As New RFunction
-    Private clsConvertLinkedVariablesFunction, clsStationTypeFunction, clsConvertStationtypeFunction, clsVectorFunction, clsGetlinkeddataFunction, clsGetDataFrameFunction, clsListevapFunction, clsRollEvaporationFunction, clsFractionEvapFunction As New RFunction
+    Private clsConvertLinkedVariablesFunction, clsStationTypeFunction, clsConvertStationtypeFunction, clsVectorFunction, clsGetlinkeddataFunction, clsListevapFunction, clsRollEvaporationFunction, clsFractionEvapFunction As New RFunction
     Private clsSumEvapFunction, clsDummyFunction, clsIfelseStatusFunction, clsIfelseStatus1Function, clsFirstStatusFunction, clsIsNAStatusFunction, clsCalcStartDate, clsCombinationCalc, clsListCalFunction, clsCombinationManipList, clsCombinationSubCalcList As New RFunction
     Private clsDayFromAndTo, clsGroupByStation, clsGroupByYear, clsListToTalRain, clsFirstDate As New RFunction
     Private clsDayFromAndToOperator, clsEvapOperator, clsDayFromOperator, clsRainDayConditionOperator, clsTRCombineOperator, clsStartStatusEqualsTrueOperator As New ROperator
     Private clsRollingSumRainDayOperator, clsDSCombineOperator, clsDPCombineOperator, clsDayToOperator, clsRainDayOperator, clsConditionsAndOperator As New ROperator
     Private clsDayFilterCalcFromConvert, clsDayFilterCalcFromList, clsApplyInstatFunction, clsFirstDOY, clsDefineAsClimatic, clsVectorConcat2Function As New RFunction
-    Private clsGetCalulationsFunction, clsGetOffsetTermFunction, clsGetStartRainsDefinitionsFunction As New RFunction
+    Private clsGetOffsetTermFunction, clsGetStartRainsDefinitionsFunction As New RFunction
 
     Private clsSpellsFunction, clsIfElseFirstDoyFilledFunction As New RFunction
     Private clsRainDaySpellsOperator As New ROperator
@@ -262,7 +262,6 @@ Public Class dlgStartofRains
         clsRainRollingSumFunction = New RFunction
         clsGetlinkeddataFunction = New RFunction
         clsVectorFunction = New RFunction
-        clsGetDataFrameFunction = New RFunction
         clsDayFilterCalcFromConvert = New RFunction
         clsDayFilterCalcFromList = New RFunction
         clsDummyFunction = New RFunction
@@ -275,7 +274,6 @@ Public Class dlgStartofRains
         clsListFunction = New RFunction
         clsDefineAsClimatic = New RFunction
         clsVectorConcat2Function = New RFunction
-        clsGetCalulationsFunction = New RFunction
         clsGetOffsetTermFunction = New RFunction
         clsGetStartRainsDefinitionsFunction = New RFunction
 
@@ -830,11 +828,6 @@ Public Class dlgStartofRains
         'Sub_Calculations List
         clsListSubCalc.SetRCommand("list")
 
-        ' IF ANY POTENTIAL PROBLEMS, REVERT THIS PART BACK TO ORIGINAL FORM
-        clsGetDataFrameFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_data_frame")
-        clsGetDataFrameFunction.AddParameter("x", strLinkedDataName, iPosition:=0, bIncludeArgumentName:=False)
-        clsGetDataFrameFunction.SetAssignTo("summary_data")
-
         clsGetlinkeddataFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_linked_to_data_name")
         clsGetlinkeddataFunction.SetAssignTo(strLinkedDataName)
 
@@ -926,18 +919,12 @@ Public Class dlgStartofRains
         clsDeleteunusedrowFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$remove_unused_station_year_combinations")
         clsDeleteunusedrowFunction.AddParameter("data_name", Chr(34) & ucrSelectorForStartofRains.ucrAvailableDataFrames.cboAvailableDataFrames.Text & Chr(34), iPosition:=0)
 
-        clsGetCalulationsFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_calculations")
-        clsGetCalulationsFunction.AddParameter("x", strLinkedDataName, iPosition:=0, bIncludeArgumentName:=False)
-        clsGetCalulationsFunction.SetAssignTo("calculations_data")
-
         clsGetOffsetTermFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_offset_term")
         clsGetOffsetTermFunction.SetAssignTo("definitions_offset")
 
-        clsGetStartRainsDefinitionsFunction.SetRCommand("get_start_rains_definition")
-        clsGetStartRainsDefinitionsFunction.AddParameter("summary_data", clsRFunctionParameter:=clsGetDataFrameFunction, iPosition:=0)
-        clsGetStartRainsDefinitionsFunction.AddParameter("calculations_data", clsRFunctionParameter:=clsGetCalulationsFunction, iPosition:=1)
+        clsGetStartRainsDefinitionsFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_start_rains_definition")
+        clsGetStartRainsDefinitionsFunction.AddParameter("data_name", strLinkedDataName, iPosition:=0)
         clsGetStartRainsDefinitionsFunction.AddParameter("definitions_offset", clsRFunctionParameter:=clsGetOffsetTermFunction, iPosition:=5)
-
 
         ucrBase.clsRsyntax.ClearCodes()
 
@@ -994,6 +981,7 @@ Public Class dlgStartofRains
         ucrReceiverEvap.SetRCode(clsEvapOperator, bReset)
         ucrNudEvapo.SetRCode(clsEvapOperator, bReset)
         AdditionalCondition()
+        AddDefinitionName()
     End Sub
 
     Private Sub TestOKEnabled()
@@ -1348,6 +1336,18 @@ Public Class dlgStartofRains
         ChangeDSValue()
     End Sub
 
+
+
+    Private Sub AddDefinitionName()
+        Dim strDefinitionName = ucrSaveDefinition.GetText()
+
+        If strDefinitionName <> "" Then
+            clsGetStartRainsDefinitionsFunction.AddParameter("definition_name", Chr(34) & strDefinitionName & Chr(34), iPosition:=1)
+        Else
+            clsGetStartRainsDefinitionsFunction.RemoveParameterByName("definition_name")
+        End If
+    End Sub
+
     Private Sub ChangeDSValue()
         If ucrChkAdditional.Checked Then
             If sdgAdditionalCondition.ucrChkNumberOfRainyDays.Checked Then
@@ -1473,6 +1473,7 @@ Public Class dlgStartofRains
     End Sub
 
     Private Sub ucrSaveDefinition_ControlContentChanged(ucrChangedControl As ucrCore) Handles ucrSaveDefinition.ControlValueChanged
+        AddDefinitionName()
         AddSaveDefinitionCodes()
     End Sub
 


### PR DESCRIPTION
Fixes #10302 
@lilyclements @rdstern @berylwaswa 

I have implemented the new changes in how definitions are run in the `Start of Rains` dialog. As with the other dialogs, I only removed the parameters outlined in the issue and left the others intact. I removed `summary_data` and `calculation_data` from `data_book$get_start_rains_definition` and added the new parameters `data_name` and `definition_name`, 

@lilyclements I hope this is as expected.

**Developer Testing Checklist**
- [X] Runs without errors  
- [X] OK disabled when dialog is incomplete or invalid  
- [X] OK enabled only when required inputs are valid
- [X] Reset returns dialog to its default/sensible state
- [X] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [X] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
