### PR TITLE
Changed event handler to DoubleClick for recent files

### DIFF
--- a/instat/clsRecentFiles.vb
+++ b/instat/clsRecentFiles.vb
@@ -306,7 +306,7 @@ Public Class clsRecentFiles
                     tooltip.SetToolTip(linkMenuItem, strFileName)
                     linkMenuItem.Tag = strPath 'path used when the link is clicked
                     'attach link click event handler for opening the file
-                    AddHandler linkMenuItem.Click, AddressOf OnMnuRecentOpenedFile_Click
+                    AddHandler linkMenuItem.DoubleClick, AddressOf OnMnuRecentOpenedFile_Click
                     ucrDataViewWindow.InsertRecentFileMenuItems(linkMenuItem)
                 End If
 

--- a/instat/clsRecentFiles.vb
+++ b/instat/clsRecentFiles.vb
@@ -16,6 +16,7 @@
 
 Imports System.IO
 Imports instat.Translations
+Imports System.Windows.Forms
 
 Public Class clsRecentFiles
     Public lstRecentDialogs As New List(Of Form)
@@ -305,8 +306,9 @@ Public Class clsRecentFiles
                     ' Set the tooltip texts for the labels.
                     tooltip.SetToolTip(linkMenuItem, strFileName)
                     linkMenuItem.Tag = strPath 'path used when the link is clicked
-                    'attach link click event handler for opening the file
+                    'attach link double-click event handler for opening the file
                     AddHandler linkMenuItem.DoubleClick, AddressOf OnMnuRecentOpenedFile_Click
+                    AddHandler linkMenuItem.KeyDown, AddressOf OnRecentLinkLabelKeyDown
                     ucrDataViewWindow.InsertRecentFileMenuItems(linkMenuItem)
                 End If
 
@@ -389,4 +391,12 @@ Public Class clsRecentFiles
             Return strName
         End If
     End Function
+
+    ''' Enables keyboard access for recent file links (Enter/Space).
+    Private Sub OnRecentLinkLabelKeyDown(sender As Object, e As KeyEventArgs)
+        If e.KeyCode = Keys.Enter OrElse e.KeyCode = Keys.Space Then
+            OnMnuRecentOpenedFile_Click(sender, EventArgs.Empty)
+            e.Handled = True
+        End If
+    End Sub
 End Class


### PR DESCRIPTION
### Before asking for review
Please confirm that you have:

- Completed the developer testing checklist below (ticking items as you go)
- Responded to all AI/bot comments (either fixed or explained)
- Added a short note in the PR describing how you tested these changes
- Noted which issue(s) this PR relates to

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)


Changed the recent files event handler to use the DoubleClick event instead of Click, ensuring that datasets are only opened after a double-click action.

This addresses the issues raised in #7205, #9068 and #8989.

@berylwaswa @Ag-Derek  
As discussed earlier, I investigated the issue and implemented an initial solution. At the moment, datasets listed under recent files can now be opened correctly using a double-click interaction.

@Ag-Derek  @rdstern @N-thony @Patowhiz @lilyclements 
I would appreciate it if you could review and confirm whether the implementation meets the expected requirements.

Additionally, following our earlier discussion @berylwaswa, I am continuing researching the possibility of introducing keyboard shortcuts into R-Instat. One motivation is the absence of common usability shortcuts found in many applications for example, using the `Esc` key to close dialogs instead of relying solely on the `“Close”` button or the `X` button in the top-right corner. I am currently exploring this area further and would welcome any ideas or suggestions that could help guide the implementation.