### PR TITLE
Improvements to column metadata rename option

### DIFF
--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -621,6 +621,7 @@ Public Class ucrColumnMetadata
     End Sub
     Private Sub mnuColumnRename_Click(sender As Object, e As EventArgs) Handles mnuColumnRename.Click
         dlgName.SetCurrentColumn(GetFirstSelectedDataframeColumnFromSelectedRow(), _grid.CurrentWorksheet.Name)
+        dlgName.bDefaultToSingle = True
         dlgName.ShowDialog()
     End Sub
 

--- a/instat/ucrColumnMetadata.vb
+++ b/instat/ucrColumnMetadata.vb
@@ -620,9 +620,11 @@ Public Class ucrColumnMetadata
         End If
     End Sub
     Private Sub mnuColumnRename_Click(sender As Object, e As EventArgs) Handles mnuColumnRename.Click
-        dlgName.SetCurrentColumn(GetFirstSelectedDataframeColumnFromSelectedRow(), _grid.CurrentWorksheet.Name)
-        dlgName.bDefaultToSingle = True
-        dlgName.ShowDialog()
+        If _grid.CurrentWorksheet IsNot Nothing AndAlso _grid.GetSelectedRows().Count > 0 Then
+            dlgName.SetCurrentColumn(GetFirstSelectedDataframeColumnFromSelectedRow(), _grid.CurrentWorksheet.Name)
+            dlgName.bDefaultToSingle = True
+            dlgName.ShowDialog()
+        End If
     End Sub
 
     Private Sub mnuConvert_Click(sender As Object, e As EventArgs)


### PR DESCRIPTION
Fixes Partly #10310 
Added the flag which lets the first option for the Rename dialog to be the default when the user is working the Column Metadata

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
