### PR TITLE
ci(translation-check): allow fork PR checkout under pull_request_target

### DIFF
--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -18,20 +18,23 @@ jobs:
 
     steps:
       - name: Checkout trusted base tooling
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: base
           persist-credentials: false
 
       - name: Checkout PR content
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr
           fetch-depth: 0
           persist-credentials: false
+          # Reviewed opt-in: the PR checkout is treated only as data below;
+          # no PR code is executed in this privileged pull_request_target context.
+          allow-unsafe-pr-checkout: true
 
       - name: Fetch base branch for diff
         working-directory: pr
@@ -40,7 +43,7 @@ jobs:
           git fetch --no-tags base "refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/base/${{ github.event.pull_request.base.ref }}"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -58,7 +61,7 @@ jobs:
 
       - name: Add PR comment with results
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Recenntly, GitHub released actions/checkout v7 with a new security default: in privileged workflows (pull_request_target, workflow_run), and as a result, actions/checkout now refuses fork PR code in pull_request_target workflows unless opted in, failing the check before it runs. 

Opt-in is reviewed-safe: PR checkout is data-only (persist-credentials false, no PR code executed; only base-repo scripts run against it).

Also bump checkout v5, setup-python v6, github-script v8 to clear Node 20 deprecation warnings (all run on node24).

### Before asking for review
Please confirm that you have:

- Completed the developer testing checklist below (ticking items as you go)
- Responded to all AI/bot comments (either fixed or explained)
- Added a short note in the PR describing how you tested these changes
- Noted which issue(s) this PR relates to

**Developer Testing Checklist**
- [x] Runs without errors  
- [ ] OK disabled when dialog is incomplete or invalid  
- [ ] OK enabled only when required inputs are valid
- [ ] Reset returns dialog to its default/sensible state
- [ ] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [ ] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [x] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
