### PR TITLE
Added Store Model Options to the 2/3 Summarise Dialog

### DIFF
--- a/instat/dlgDescribeTwoVariable.Designer.vb
+++ b/instat/dlgDescribeTwoVariable.Designer.vb
@@ -104,9 +104,10 @@ Partial Class dlgDescribeTwoVariable
         Me.rdoThreeVariable.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
         Me.rdoThreeVariable.FlatStyle = System.Windows.Forms.FlatStyle.Flat
         Me.rdoThreeVariable.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.rdoThreeVariable.Location = New System.Drawing.Point(194, 8)
+        Me.rdoThreeVariable.Location = New System.Drawing.Point(291, 12)
+        Me.rdoThreeVariable.Margin = New System.Windows.Forms.Padding(4)
         Me.rdoThreeVariable.Name = "rdoThreeVariable"
-        Me.rdoThreeVariable.Size = New System.Drawing.Size(100, 28)
+        Me.rdoThreeVariable.Size = New System.Drawing.Size(150, 42)
         Me.rdoThreeVariable.TabIndex = 3
         Me.rdoThreeVariable.Text = "Three Variables"
         Me.rdoThreeVariable.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
@@ -115,9 +116,10 @@ Partial Class dlgDescribeTwoVariable
         'cmdFormatTable
         '
         Me.cmdFormatTable.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdFormatTable.Location = New System.Drawing.Point(326, 430)
+        Me.cmdFormatTable.Location = New System.Drawing.Point(489, 645)
+        Me.cmdFormatTable.Margin = New System.Windows.Forms.Padding(4)
         Me.cmdFormatTable.Name = "cmdFormatTable"
-        Me.cmdFormatTable.Size = New System.Drawing.Size(104, 23)
+        Me.cmdFormatTable.Size = New System.Drawing.Size(156, 34)
         Me.cmdFormatTable.TabIndex = 23
         Me.cmdFormatTable.Text = "Table Options..."
         Me.cmdFormatTable.UseVisualStyleBackColor = True
@@ -125,9 +127,10 @@ Partial Class dlgDescribeTwoVariable
         'lblThreeVariableSecondFactor
         '
         Me.lblThreeVariableSecondFactor.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblThreeVariableSecondFactor.Location = New System.Drawing.Point(315, 150)
+        Me.lblThreeVariableSecondFactor.Location = New System.Drawing.Point(472, 225)
+        Me.lblThreeVariableSecondFactor.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblThreeVariableSecondFactor.Name = "lblThreeVariableSecondFactor"
-        Me.lblThreeVariableSecondFactor.Size = New System.Drawing.Size(100, 15)
+        Me.lblThreeVariableSecondFactor.Size = New System.Drawing.Size(150, 22)
         Me.lblThreeVariableSecondFactor.TabIndex = 10
         Me.lblThreeVariableSecondFactor.Tag = ""
         Me.lblThreeVariableSecondFactor.Text = "Second Variable :"
@@ -135,9 +138,10 @@ Partial Class dlgDescribeTwoVariable
         'cmdMissingOptions
         '
         Me.cmdMissingOptions.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdMissingOptions.Location = New System.Drawing.Point(146, 365)
+        Me.cmdMissingOptions.Location = New System.Drawing.Point(219, 548)
+        Me.cmdMissingOptions.Margin = New System.Windows.Forms.Padding(4)
         Me.cmdMissingOptions.Name = "cmdMissingOptions"
-        Me.cmdMissingOptions.Size = New System.Drawing.Size(105, 23)
+        Me.cmdMissingOptions.Size = New System.Drawing.Size(158, 34)
         Me.cmdMissingOptions.TabIndex = 21
         Me.cmdMissingOptions.Text = "Missing Options..."
         Me.cmdMissingOptions.UseVisualStyleBackColor = True
@@ -145,9 +149,10 @@ Partial Class dlgDescribeTwoVariable
         'lbSecondVariable
         '
         Me.lbSecondVariable.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lbSecondVariable.Location = New System.Drawing.Point(310, 150)
+        Me.lbSecondVariable.Location = New System.Drawing.Point(465, 225)
+        Me.lbSecondVariable.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lbSecondVariable.Name = "lbSecondVariable"
-        Me.lbSecondVariable.Size = New System.Drawing.Size(100, 15)
+        Me.lbSecondVariable.Size = New System.Drawing.Size(150, 22)
         Me.lbSecondVariable.TabIndex = 9
         Me.lbSecondVariable.Tag = ""
         Me.lbSecondVariable.Text = "Second Variable:"
@@ -156,9 +161,10 @@ Partial Class dlgDescribeTwoVariable
         '
         Me.lblFirstVariable.AutoSize = True
         Me.lblFirstVariable.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblFirstVariable.Location = New System.Drawing.Point(310, 49)
+        Me.lblFirstVariable.Location = New System.Drawing.Point(465, 74)
+        Me.lblFirstVariable.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblFirstVariable.Name = "lblFirstVariable"
-        Me.lblFirstVariable.Size = New System.Drawing.Size(75, 13)
+        Me.lblFirstVariable.Size = New System.Drawing.Size(114, 20)
         Me.lblFirstVariable.TabIndex = 5
         Me.lblFirstVariable.Tag = ""
         Me.lblFirstVariable.Text = "First Variables:"
@@ -172,9 +178,11 @@ Partial Class dlgDescribeTwoVariable
         Me.grpSummaries.Controls.Add(Me.lblSummary)
         Me.grpSummaries.Controls.Add(Me.lblBy)
         Me.grpSummaries.Controls.Add(Me.lblSecondType)
-        Me.grpSummaries.Location = New System.Drawing.Point(11, 219)
+        Me.grpSummaries.Location = New System.Drawing.Point(16, 328)
+        Me.grpSummaries.Margin = New System.Windows.Forms.Padding(4)
         Me.grpSummaries.Name = "grpSummaries"
-        Me.grpSummaries.Size = New System.Drawing.Size(210, 72)
+        Me.grpSummaries.Padding = New System.Windows.Forms.Padding(4)
+        Me.grpSummaries.Size = New System.Drawing.Size(315, 108)
         Me.grpSummaries.TabIndex = 17
         Me.grpSummaries.TabStop = False
         '
@@ -182,18 +190,20 @@ Partial Class dlgDescribeTwoVariable
         '
         Me.lblFirstType.AutoSize = True
         Me.lblFirstType.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblFirstType.Location = New System.Drawing.Point(12, 18)
+        Me.lblFirstType.Location = New System.Drawing.Point(18, 27)
+        Me.lblFirstType.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblFirstType.Name = "lblFirstType"
-        Me.lblFirstType.Size = New System.Drawing.Size(0, 13)
+        Me.lblFirstType.Size = New System.Drawing.Size(0, 20)
         Me.lblFirstType.TabIndex = 0
         '
         'lblSecondBy
         '
         Me.lblSecondBy.AutoSize = True
         Me.lblSecondBy.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblSecondBy.Location = New System.Drawing.Point(180, 16)
+        Me.lblSecondBy.Location = New System.Drawing.Point(270, 24)
+        Me.lblSecondBy.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblSecondBy.Name = "lblSecondBy"
-        Me.lblSecondBy.Size = New System.Drawing.Size(18, 13)
+        Me.lblSecondBy.Size = New System.Drawing.Size(25, 20)
         Me.lblSecondBy.TabIndex = 6
         Me.lblSecondBy.Text = "by"
         '
@@ -201,9 +211,10 @@ Partial Class dlgDescribeTwoVariable
         '
         Me.lblThreeVariableCategorical.AutoSize = True
         Me.lblThreeVariableCategorical.ForeColor = System.Drawing.SystemColors.Highlight
-        Me.lblThreeVariableCategorical.Location = New System.Drawing.Point(12, 33)
+        Me.lblThreeVariableCategorical.Location = New System.Drawing.Point(18, 50)
+        Me.lblThreeVariableCategorical.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblThreeVariableCategorical.Name = "lblThreeVariableCategorical"
-        Me.lblThreeVariableCategorical.Size = New System.Drawing.Size(59, 13)
+        Me.lblThreeVariableCategorical.Size = New System.Drawing.Size(86, 20)
         Me.lblThreeVariableCategorical.TabIndex = 1
         Me.lblThreeVariableCategorical.Text = "categorical"
         '
@@ -211,18 +222,20 @@ Partial Class dlgDescribeTwoVariable
         '
         Me.lblSummaryName.AutoSize = True
         Me.lblSummaryName.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblSummaryName.Location = New System.Drawing.Point(70, 51)
+        Me.lblSummaryName.Location = New System.Drawing.Point(105, 76)
+        Me.lblSummaryName.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblSummaryName.Name = "lblSummaryName"
-        Me.lblSummaryName.Size = New System.Drawing.Size(0, 13)
+        Me.lblSummaryName.Size = New System.Drawing.Size(0, 20)
         Me.lblSummaryName.TabIndex = 3
         '
         'lblSummary
         '
         Me.lblSummary.AutoSize = True
         Me.lblSummary.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblSummary.Location = New System.Drawing.Point(12, 51)
+        Me.lblSummary.Location = New System.Drawing.Point(18, 76)
+        Me.lblSummary.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblSummary.Name = "lblSummary"
-        Me.lblSummary.Size = New System.Drawing.Size(53, 13)
+        Me.lblSummary.Size = New System.Drawing.Size(80, 20)
         Me.lblSummary.TabIndex = 2
         Me.lblSummary.Text = "Summary:"
         '
@@ -230,9 +243,10 @@ Partial Class dlgDescribeTwoVariable
         '
         Me.lblBy.AutoSize = True
         Me.lblBy.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblBy.Location = New System.Drawing.Point(82, 16)
+        Me.lblBy.Location = New System.Drawing.Point(123, 24)
+        Me.lblBy.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblBy.Name = "lblBy"
-        Me.lblBy.Size = New System.Drawing.Size(18, 13)
+        Me.lblBy.Size = New System.Drawing.Size(25, 20)
         Me.lblBy.TabIndex = 4
         Me.lblBy.Text = "by"
         '
@@ -240,17 +254,19 @@ Partial Class dlgDescribeTwoVariable
         '
         Me.lblSecondType.AutoSize = True
         Me.lblSecondType.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblSecondType.Location = New System.Drawing.Point(106, 18)
+        Me.lblSecondType.Location = New System.Drawing.Point(159, 27)
+        Me.lblSecondType.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblSecondType.Name = "lblSecondType"
-        Me.lblSecondType.Size = New System.Drawing.Size(0, 13)
+        Me.lblSecondType.Size = New System.Drawing.Size(0, 20)
         Me.lblSecondType.TabIndex = 5
         '
         'lblFirstGroupByFactor
         '
         Me.lblFirstGroupByFactor.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblFirstGroupByFactor.Location = New System.Drawing.Point(315, 149)
+        Me.lblFirstGroupByFactor.Location = New System.Drawing.Point(472, 224)
+        Me.lblFirstGroupByFactor.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblFirstGroupByFactor.Name = "lblFirstGroupByFactor"
-        Me.lblFirstGroupByFactor.Size = New System.Drawing.Size(100, 15)
+        Me.lblFirstGroupByFactor.Size = New System.Drawing.Size(150, 22)
         Me.lblFirstGroupByFactor.TabIndex = 7
         Me.lblFirstGroupByFactor.Tag = ""
         Me.lblFirstGroupByFactor.Text = "Factor (Optional) :"
@@ -263,9 +279,10 @@ Partial Class dlgDescribeTwoVariable
         Me.rdoSkim.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
         Me.rdoSkim.FlatStyle = System.Windows.Forms.FlatStyle.Flat
         Me.rdoSkim.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.rdoSkim.Location = New System.Drawing.Point(290, 8)
+        Me.rdoSkim.Location = New System.Drawing.Point(435, 12)
+        Me.rdoSkim.Margin = New System.Windows.Forms.Padding(4)
         Me.rdoSkim.Name = "rdoSkim"
-        Me.rdoSkim.Size = New System.Drawing.Size(100, 28)
+        Me.rdoSkim.Size = New System.Drawing.Size(150, 42)
         Me.rdoSkim.TabIndex = 1
         Me.rdoSkim.Text = "Skim"
         Me.rdoSkim.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
@@ -274,9 +291,10 @@ Partial Class dlgDescribeTwoVariable
         'lblThirdVariable
         '
         Me.lblThirdVariable.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblThirdVariable.Location = New System.Drawing.Point(310, 191)
+        Me.lblThirdVariable.Location = New System.Drawing.Point(465, 286)
+        Me.lblThirdVariable.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblThirdVariable.Name = "lblThirdVariable"
-        Me.lblThirdVariable.Size = New System.Drawing.Size(154, 15)
+        Me.lblThirdVariable.Size = New System.Drawing.Size(231, 22)
         Me.lblThirdVariable.TabIndex = 13
         Me.lblThirdVariable.Tag = ""
         Me.lblThirdVariable.Text = "Third Variable :"
@@ -284,9 +302,10 @@ Partial Class dlgDescribeTwoVariable
         'lblSecondGroupByFactor
         '
         Me.lblSecondGroupByFactor.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblSecondGroupByFactor.Location = New System.Drawing.Point(315, 191)
+        Me.lblSecondGroupByFactor.Location = New System.Drawing.Point(472, 286)
+        Me.lblSecondGroupByFactor.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblSecondGroupByFactor.Name = "lblSecondGroupByFactor"
-        Me.lblSecondGroupByFactor.Size = New System.Drawing.Size(137, 15)
+        Me.lblSecondGroupByFactor.Size = New System.Drawing.Size(206, 22)
         Me.lblSecondGroupByFactor.TabIndex = 33
         Me.lblSecondGroupByFactor.Tag = ""
         Me.lblSecondGroupByFactor.Text = "Second Factor (Optional) :"
@@ -299,9 +318,10 @@ Partial Class dlgDescribeTwoVariable
         Me.rdoTwoVariable.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
         Me.rdoTwoVariable.FlatStyle = System.Windows.Forms.FlatStyle.Flat
         Me.rdoTwoVariable.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.rdoTwoVariable.Location = New System.Drawing.Point(96, 8)
+        Me.rdoTwoVariable.Location = New System.Drawing.Point(144, 12)
+        Me.rdoTwoVariable.Margin = New System.Windows.Forms.Padding(4)
         Me.rdoTwoVariable.Name = "rdoTwoVariable"
-        Me.rdoTwoVariable.Size = New System.Drawing.Size(100, 28)
+        Me.rdoTwoVariable.Size = New System.Drawing.Size(150, 42)
         Me.rdoTwoVariable.TabIndex = 2
         Me.rdoTwoVariable.Text = "Two Variables"
         Me.rdoTwoVariable.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
@@ -310,9 +330,10 @@ Partial Class dlgDescribeTwoVariable
         'cmdSummaries
         '
         Me.cmdSummaries.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.cmdSummaries.Location = New System.Drawing.Point(310, 248)
+        Me.cmdSummaries.Location = New System.Drawing.Point(465, 372)
+        Me.cmdSummaries.Margin = New System.Windows.Forms.Padding(4)
         Me.cmdSummaries.Name = "cmdSummaries"
-        Me.cmdSummaries.Size = New System.Drawing.Size(120, 23)
+        Me.cmdSummaries.Size = New System.Drawing.Size(180, 34)
         Me.cmdSummaries.TabIndex = 1
         Me.cmdSummaries.Tag = "Summaries"
         Me.cmdSummaries.Text = "Choose Summaries..."
@@ -321,9 +342,10 @@ Partial Class dlgDescribeTwoVariable
         'lblMarginName
         '
         Me.lblMarginName.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblMarginName.Location = New System.Drawing.Point(15, 320)
+        Me.lblMarginName.Location = New System.Drawing.Point(22, 480)
+        Me.lblMarginName.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMarginName.Name = "lblMarginName"
-        Me.lblMarginName.Size = New System.Drawing.Size(93, 15)
+        Me.lblMarginName.Size = New System.Drawing.Size(140, 22)
         Me.lblMarginName.TabIndex = 19
         Me.lblMarginName.Tag = ""
         Me.lblMarginName.Text = "Margin Name:"
@@ -331,9 +353,11 @@ Partial Class dlgDescribeTwoVariable
         'grpDisplay
         '
         Me.grpDisplay.Controls.Add(Me.ucrChkDisplayAsPercentage)
-        Me.grpDisplay.Location = New System.Drawing.Point(276, 191)
+        Me.grpDisplay.Location = New System.Drawing.Point(414, 286)
+        Me.grpDisplay.Margin = New System.Windows.Forms.Padding(4)
         Me.grpDisplay.Name = "grpDisplay"
-        Me.grpDisplay.Size = New System.Drawing.Size(197, 77)
+        Me.grpDisplay.Padding = New System.Windows.Forms.Padding(4)
+        Me.grpDisplay.Size = New System.Drawing.Size(296, 116)
         Me.grpDisplay.TabIndex = 15
         Me.grpDisplay.TabStop = False
         Me.grpDisplay.Text = "Percentages"
@@ -342,19 +366,18 @@ Partial Class dlgDescribeTwoVariable
         '
         Me.ucrChkDisplayAsPercentage.AutoSize = True
         Me.ucrChkDisplayAsPercentage.Checked = False
-        Me.ucrChkDisplayAsPercentage.Location = New System.Drawing.Point(14, 21)
-        Me.ucrChkDisplayAsPercentage.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkDisplayAsPercentage.Location = New System.Drawing.Point(21, 32)
+        Me.ucrChkDisplayAsPercentage.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkDisplayAsPercentage.Name = "ucrChkDisplayAsPercentage"
-        Me.ucrChkDisplayAsPercentage.Size = New System.Drawing.Size(171, 34)
+        Me.ucrChkDisplayAsPercentage.Size = New System.Drawing.Size(256, 51)
         Me.ucrChkDisplayAsPercentage.TabIndex = 54
         '
         'rdoOCol
         '
         Me.rdoOCol.AutoSize = True
-        Me.rdoOCol.Location = New System.Drawing.Point(288, 238)
-        Me.rdoOCol.Margin = New System.Windows.Forms.Padding(2)
+        Me.rdoOCol.Location = New System.Drawing.Point(432, 357)
         Me.rdoOCol.Name = "rdoOCol"
-        Me.rdoOCol.Size = New System.Drawing.Size(61, 17)
+        Me.rdoOCol.Size = New System.Drawing.Size(90, 24)
         Me.rdoOCol.TabIndex = 40
         Me.rdoOCol.TabStop = True
         Me.rdoOCol.Text = "Row(%)"
@@ -363,10 +386,9 @@ Partial Class dlgDescribeTwoVariable
         'rdoOCell
         '
         Me.rdoOCell.AutoSize = True
-        Me.rdoOCell.Location = New System.Drawing.Point(410, 237)
-        Me.rdoOCell.Margin = New System.Windows.Forms.Padding(2)
+        Me.rdoOCell.Location = New System.Drawing.Point(615, 356)
         Me.rdoOCell.Name = "rdoOCell"
-        Me.rdoOCell.Size = New System.Drawing.Size(56, 17)
+        Me.rdoOCell.Size = New System.Drawing.Size(84, 24)
         Me.rdoOCell.TabIndex = 41
         Me.rdoOCell.TabStop = True
         Me.rdoOCell.Text = "Cell(%)"
@@ -375,10 +397,9 @@ Partial Class dlgDescribeTwoVariable
         'rdoORow
         '
         Me.rdoORow.AutoSize = True
-        Me.rdoORow.Location = New System.Drawing.Point(351, 238)
-        Me.rdoORow.Margin = New System.Windows.Forms.Padding(2)
+        Me.rdoORow.Location = New System.Drawing.Point(526, 357)
         Me.rdoORow.Name = "rdoORow"
-        Me.rdoORow.Size = New System.Drawing.Size(54, 17)
+        Me.rdoORow.Size = New System.Drawing.Size(81, 24)
         Me.rdoORow.TabIndex = 42
         Me.rdoORow.TabStop = True
         Me.rdoORow.Text = "Col(%)"
@@ -388,11 +409,11 @@ Partial Class dlgDescribeTwoVariable
         '
         Me.ucrReceiverThreeVariableThirdVariable.AutoSize = True
         Me.ucrReceiverThreeVariableThirdVariable.frmParent = Me
-        Me.ucrReceiverThreeVariableThirdVariable.Location = New System.Drawing.Point(310, 209)
+        Me.ucrReceiverThreeVariableThirdVariable.Location = New System.Drawing.Point(465, 314)
         Me.ucrReceiverThreeVariableThirdVariable.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverThreeVariableThirdVariable.Name = "ucrReceiverThreeVariableThirdVariable"
         Me.ucrReceiverThreeVariableThirdVariable.Selector = Nothing
-        Me.ucrReceiverThreeVariableThirdVariable.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverThreeVariableThirdVariable.Size = New System.Drawing.Size(180, 30)
         Me.ucrReceiverThreeVariableThirdVariable.strNcFilePath = ""
         Me.ucrReceiverThreeVariableThirdVariable.TabIndex = 14
         Me.ucrReceiverThreeVariableThirdVariable.ucrSelector = Nothing
@@ -400,21 +421,21 @@ Partial Class dlgDescribeTwoVariable
         'ucrpnlPercent
         '
         Me.ucrpnlPercent.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrpnlPercent.Location = New System.Drawing.Point(283, 235)
-        Me.ucrpnlPercent.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrpnlPercent.Location = New System.Drawing.Point(424, 352)
+        Me.ucrpnlPercent.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrpnlPercent.Name = "ucrpnlPercent"
-        Me.ucrpnlPercent.Size = New System.Drawing.Size(187, 25)
+        Me.ucrpnlPercent.Size = New System.Drawing.Size(280, 38)
         Me.ucrpnlPercent.TabIndex = 43
         '
         'ucrReceiverThreeVariableSecondFactor
         '
         Me.ucrReceiverThreeVariableSecondFactor.AutoSize = True
         Me.ucrReceiverThreeVariableSecondFactor.frmParent = Me
-        Me.ucrReceiverThreeVariableSecondFactor.Location = New System.Drawing.Point(310, 164)
+        Me.ucrReceiverThreeVariableSecondFactor.Location = New System.Drawing.Point(465, 246)
         Me.ucrReceiverThreeVariableSecondFactor.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverThreeVariableSecondFactor.Name = "ucrReceiverThreeVariableSecondFactor"
         Me.ucrReceiverThreeVariableSecondFactor.Selector = Nothing
-        Me.ucrReceiverThreeVariableSecondFactor.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverThreeVariableSecondFactor.Size = New System.Drawing.Size(180, 30)
         Me.ucrReceiverThreeVariableSecondFactor.strNcFilePath = ""
         Me.ucrReceiverThreeVariableSecondFactor.TabIndex = 12
         Me.ucrReceiverThreeVariableSecondFactor.ucrSelector = Nothing
@@ -423,11 +444,11 @@ Partial Class dlgDescribeTwoVariable
         '
         Me.ucrReceiverSecondTwoVariableFactor.AutoSize = True
         Me.ucrReceiverSecondTwoVariableFactor.frmParent = Me
-        Me.ucrReceiverSecondTwoVariableFactor.Location = New System.Drawing.Point(310, 164)
+        Me.ucrReceiverSecondTwoVariableFactor.Location = New System.Drawing.Point(465, 246)
         Me.ucrReceiverSecondTwoVariableFactor.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverSecondTwoVariableFactor.Name = "ucrReceiverSecondTwoVariableFactor"
         Me.ucrReceiverSecondTwoVariableFactor.Selector = Nothing
-        Me.ucrReceiverSecondTwoVariableFactor.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverSecondTwoVariableFactor.Size = New System.Drawing.Size(180, 30)
         Me.ucrReceiverSecondTwoVariableFactor.strNcFilePath = ""
         Me.ucrReceiverSecondTwoVariableFactor.TabIndex = 1
         Me.ucrReceiverSecondTwoVariableFactor.ucrSelector = Nothing
@@ -436,11 +457,11 @@ Partial Class dlgDescribeTwoVariable
         '
         Me.ucrReceiverFirstVars.AutoSize = True
         Me.ucrReceiverFirstVars.frmParent = Me
-        Me.ucrReceiverFirstVars.Location = New System.Drawing.Point(310, 64)
+        Me.ucrReceiverFirstVars.Location = New System.Drawing.Point(465, 96)
         Me.ucrReceiverFirstVars.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverFirstVars.Name = "ucrReceiverFirstVars"
         Me.ucrReceiverFirstVars.Selector = Nothing
-        Me.ucrReceiverFirstVars.Size = New System.Drawing.Size(120, 79)
+        Me.ucrReceiverFirstVars.Size = New System.Drawing.Size(180, 118)
         Me.ucrReceiverFirstVars.strNcFilePath = ""
         Me.ucrReceiverFirstVars.TabIndex = 6
         Me.ucrReceiverFirstVars.ucrSelector = Nothing
@@ -448,10 +469,10 @@ Partial Class dlgDescribeTwoVariable
         'ucrSaveTable
         '
         Me.ucrSaveTable.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveTable.Location = New System.Drawing.Point(15, 451)
-        Me.ucrSaveTable.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrSaveTable.Location = New System.Drawing.Point(22, 676)
+        Me.ucrSaveTable.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
         Me.ucrSaveTable.Name = "ucrSaveTable"
-        Me.ucrSaveTable.Size = New System.Drawing.Size(306, 24)
+        Me.ucrSaveTable.Size = New System.Drawing.Size(419, 36)
         Me.ucrSaveTable.TabIndex = 24
         '
         'ucrInputMarginName
@@ -460,18 +481,18 @@ Partial Class dlgDescribeTwoVariable
         Me.ucrInputMarginName.AutoSize = True
         Me.ucrInputMarginName.IsMultiline = False
         Me.ucrInputMarginName.IsReadOnly = False
-        Me.ucrInputMarginName.Location = New System.Drawing.Point(114, 318)
-        Me.ucrInputMarginName.Margin = New System.Windows.Forms.Padding(9)
+        Me.ucrInputMarginName.Location = New System.Drawing.Point(171, 477)
+        Me.ucrInputMarginName.Margin = New System.Windows.Forms.Padding(14)
         Me.ucrInputMarginName.Name = "ucrInputMarginName"
-        Me.ucrInputMarginName.Size = New System.Drawing.Size(137, 21)
+        Me.ucrInputMarginName.Size = New System.Drawing.Size(206, 32)
         Me.ucrInputMarginName.TabIndex = 22
         '
         'ucrReorderSummary
         '
-        Me.ucrReorderSummary.Location = New System.Drawing.Point(275, 273)
-        Me.ucrReorderSummary.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrReorderSummary.Location = New System.Drawing.Point(412, 410)
+        Me.ucrReorderSummary.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrReorderSummary.Name = "ucrReorderSummary"
-        Me.ucrReorderSummary.Size = New System.Drawing.Size(194, 156)
+        Me.ucrReorderSummary.Size = New System.Drawing.Size(291, 234)
         Me.ucrReorderSummary.TabIndex = 16
         Me.ucrReorderSummary.ucrDataFrameList = Nothing
         Me.ucrReorderSummary.ucrReceiver = Nothing
@@ -480,21 +501,21 @@ Partial Class dlgDescribeTwoVariable
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(15, 489)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(4)
+        Me.ucrBase.Location = New System.Drawing.Point(22, 734)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(408, 52)
+        Me.ucrBase.Size = New System.Drawing.Size(611, 77)
         Me.ucrBase.TabIndex = 25
         '
         'ucrReceiverSecondSkimrGroupByFactor
         '
         Me.ucrReceiverSecondSkimrGroupByFactor.AutoSize = True
         Me.ucrReceiverSecondSkimrGroupByFactor.frmParent = Me
-        Me.ucrReceiverSecondSkimrGroupByFactor.Location = New System.Drawing.Point(310, 204)
+        Me.ucrReceiverSecondSkimrGroupByFactor.Location = New System.Drawing.Point(465, 306)
         Me.ucrReceiverSecondSkimrGroupByFactor.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverSecondSkimrGroupByFactor.Name = "ucrReceiverSecondSkimrGroupByFactor"
         Me.ucrReceiverSecondSkimrGroupByFactor.Selector = Nothing
-        Me.ucrReceiverSecondSkimrGroupByFactor.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverSecondSkimrGroupByFactor.Size = New System.Drawing.Size(180, 30)
         Me.ucrReceiverSecondSkimrGroupByFactor.strNcFilePath = ""
         Me.ucrReceiverSecondSkimrGroupByFactor.TabIndex = 34
         Me.ucrReceiverSecondSkimrGroupByFactor.ucrSelector = Nothing
@@ -505,30 +526,30 @@ Partial Class dlgDescribeTwoVariable
         Me.ucrSelectorDescribeTwoVar.bDropUnusedFilterLevels = False
         Me.ucrSelectorDescribeTwoVar.bShowHiddenColumns = False
         Me.ucrSelectorDescribeTwoVar.bUseCurrentFilter = True
-        Me.ucrSelectorDescribeTwoVar.Location = New System.Drawing.Point(11, 36)
+        Me.ucrSelectorDescribeTwoVar.Location = New System.Drawing.Point(16, 54)
         Me.ucrSelectorDescribeTwoVar.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorDescribeTwoVar.Name = "ucrSelectorDescribeTwoVar"
-        Me.ucrSelectorDescribeTwoVar.Size = New System.Drawing.Size(213, 183)
+        Me.ucrSelectorDescribeTwoVar.Size = New System.Drawing.Size(320, 274)
         Me.ucrSelectorDescribeTwoVar.TabIndex = 4
         '
         'ucrPnlDescribe
         '
         Me.ucrPnlDescribe.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlDescribe.Location = New System.Drawing.Point(92, 3)
-        Me.ucrPnlDescribe.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrPnlDescribe.Location = New System.Drawing.Point(138, 4)
+        Me.ucrPnlDescribe.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrPnlDescribe.Name = "ucrPnlDescribe"
-        Me.ucrPnlDescribe.Size = New System.Drawing.Size(317, 34)
+        Me.ucrPnlDescribe.Size = New System.Drawing.Size(476, 51)
         Me.ucrPnlDescribe.TabIndex = 0
         '
         'ucrReceiverSkimrGroupByFactor
         '
         Me.ucrReceiverSkimrGroupByFactor.AutoSize = True
         Me.ucrReceiverSkimrGroupByFactor.frmParent = Me
-        Me.ucrReceiverSkimrGroupByFactor.Location = New System.Drawing.Point(310, 164)
+        Me.ucrReceiverSkimrGroupByFactor.Location = New System.Drawing.Point(465, 246)
         Me.ucrReceiverSkimrGroupByFactor.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverSkimrGroupByFactor.Name = "ucrReceiverSkimrGroupByFactor"
         Me.ucrReceiverSkimrGroupByFactor.Selector = Nothing
-        Me.ucrReceiverSkimrGroupByFactor.Size = New System.Drawing.Size(120, 20)
+        Me.ucrReceiverSkimrGroupByFactor.Size = New System.Drawing.Size(180, 30)
         Me.ucrReceiverSkimrGroupByFactor.strNcFilePath = ""
         Me.ucrReceiverSkimrGroupByFactor.TabIndex = 8
         Me.ucrReceiverSkimrGroupByFactor.ucrSelector = Nothing
@@ -537,89 +558,88 @@ Partial Class dlgDescribeTwoVariable
         '
         Me.ucrChkDisplayMargins.AutoSize = True
         Me.ucrChkDisplayMargins.Checked = False
-        Me.ucrChkDisplayMargins.Location = New System.Drawing.Point(17, 296)
-        Me.ucrChkDisplayMargins.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkDisplayMargins.Location = New System.Drawing.Point(26, 444)
+        Me.ucrChkDisplayMargins.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkDisplayMargins.Name = "ucrChkDisplayMargins"
-        Me.ucrChkDisplayMargins.Size = New System.Drawing.Size(143, 23)
+        Me.ucrChkDisplayMargins.Size = New System.Drawing.Size(214, 34)
         Me.ucrChkDisplayMargins.TabIndex = 18
         '
         'ucrChkLevSig
         '
         Me.ucrChkLevSig.AutoSize = True
         Me.ucrChkLevSig.Checked = False
-        Me.ucrChkLevSig.Location = New System.Drawing.Point(397, 186)
-        Me.ucrChkLevSig.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkLevSig.Location = New System.Drawing.Point(596, 279)
+        Me.ucrChkLevSig.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkLevSig.Name = "ucrChkLevSig"
-        Me.ucrChkLevSig.Size = New System.Drawing.Size(86, 23)
+        Me.ucrChkLevSig.Size = New System.Drawing.Size(129, 34)
         Me.ucrChkLevSig.TabIndex = 38
         '
         'ucrChkTotal
         '
         Me.ucrChkTotal.AutoSize = True
         Me.ucrChkTotal.Checked = False
-        Me.ucrChkTotal.Location = New System.Drawing.Point(310, 186)
-        Me.ucrChkTotal.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkTotal.Location = New System.Drawing.Point(465, 279)
+        Me.ucrChkTotal.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkTotal.Name = "ucrChkTotal"
-        Me.ucrChkTotal.Size = New System.Drawing.Size(97, 23)
+        Me.ucrChkTotal.Size = New System.Drawing.Size(146, 34)
         Me.ucrChkTotal.TabIndex = 44
         '
         'ucrChkMeans
         '
         Me.ucrChkMeans.AutoSize = True
         Me.ucrChkMeans.Checked = False
-        Me.ucrChkMeans.Location = New System.Drawing.Point(310, 208)
-        Me.ucrChkMeans.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkMeans.Location = New System.Drawing.Point(465, 312)
+        Me.ucrChkMeans.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkMeans.Name = "ucrChkMeans"
-        Me.ucrChkMeans.Size = New System.Drawing.Size(97, 23)
+        Me.ucrChkMeans.Size = New System.Drawing.Size(146, 34)
         Me.ucrChkMeans.TabIndex = 37
         '
         'ucrChkCorrelations
         '
         Me.ucrChkCorrelations.AutoSize = True
         Me.ucrChkCorrelations.Checked = False
-        Me.ucrChkCorrelations.Location = New System.Drawing.Point(310, 254)
-        Me.ucrChkCorrelations.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkCorrelations.Location = New System.Drawing.Point(465, 381)
+        Me.ucrChkCorrelations.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkCorrelations.Name = "ucrChkCorrelations"
-        Me.ucrChkCorrelations.Size = New System.Drawing.Size(149, 23)
+        Me.ucrChkCorrelations.Size = New System.Drawing.Size(224, 34)
         Me.ucrChkCorrelations.TabIndex = 35
         '
         'ucrChkSwapXYVar
         '
         Me.ucrChkSwapXYVar.AutoSize = True
         Me.ucrChkSwapXYVar.Checked = False
-        Me.ucrChkSwapXYVar.Location = New System.Drawing.Point(310, 231)
-        Me.ucrChkSwapXYVar.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkSwapXYVar.Location = New System.Drawing.Point(465, 346)
+        Me.ucrChkSwapXYVar.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkSwapXYVar.Name = "ucrChkSwapXYVar"
-        Me.ucrChkSwapXYVar.Size = New System.Drawing.Size(157, 23)
+        Me.ucrChkSwapXYVar.Size = New System.Drawing.Size(236, 34)
         Me.ucrChkSwapXYVar.TabIndex = 36
         '
         'ucrChkOmitMissing
         '
         Me.ucrChkOmitMissing.AutoSize = True
         Me.ucrChkOmitMissing.Checked = False
-        Me.ucrChkOmitMissing.Location = New System.Drawing.Point(310, 277)
-        Me.ucrChkOmitMissing.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkOmitMissing.Location = New System.Drawing.Point(465, 416)
+        Me.ucrChkOmitMissing.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkOmitMissing.Name = "ucrChkOmitMissing"
-        Me.ucrChkOmitMissing.Size = New System.Drawing.Size(143, 23)
+        Me.ucrChkOmitMissing.Size = New System.Drawing.Size(214, 34)
         Me.ucrChkOmitMissing.TabIndex = 0
         '
         'ucrChkInteraction
         '
         Me.ucrChkInteraction.AutoSize = True
         Me.ucrChkInteraction.Checked = False
-        Me.ucrChkInteraction.Location = New System.Drawing.Point(17, 293)
-        Me.ucrChkInteraction.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkInteraction.Location = New System.Drawing.Point(26, 440)
+        Me.ucrChkInteraction.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkInteraction.Name = "ucrChkInteraction"
-        Me.ucrChkInteraction.Size = New System.Drawing.Size(143, 23)
+        Me.ucrChkInteraction.Size = New System.Drawing.Size(214, 34)
         Me.ucrChkInteraction.TabIndex = 45
         '
         'rdoRow
         '
         Me.rdoRow.AutoSize = True
-        Me.rdoRow.Location = New System.Drawing.Point(6, 54)
-        Me.rdoRow.Margin = New System.Windows.Forms.Padding(2)
+        Me.rdoRow.Location = New System.Drawing.Point(9, 81)
         Me.rdoRow.Name = "rdoRow"
-        Me.rdoRow.Size = New System.Drawing.Size(61, 17)
+        Me.rdoRow.Size = New System.Drawing.Size(90, 24)
         Me.rdoRow.TabIndex = 46
         Me.rdoRow.TabStop = True
         Me.rdoRow.Text = "Row(%)"
@@ -628,10 +648,9 @@ Partial Class dlgDescribeTwoVariable
         'rdoTotal
         '
         Me.rdoTotal.AutoSize = True
-        Me.rdoTotal.Location = New System.Drawing.Point(149, 54)
-        Me.rdoTotal.Margin = New System.Windows.Forms.Padding(2)
+        Me.rdoTotal.Location = New System.Drawing.Point(224, 81)
         Me.rdoTotal.Name = "rdoTotal"
-        Me.rdoTotal.Size = New System.Drawing.Size(63, 17)
+        Me.rdoTotal.Size = New System.Drawing.Size(93, 24)
         Me.rdoTotal.TabIndex = 47
         Me.rdoTotal.TabStop = True
         Me.rdoTotal.Text = "Total(%)"
@@ -640,10 +659,9 @@ Partial Class dlgDescribeTwoVariable
         'rdoColumn
         '
         Me.rdoColumn.AutoSize = True
-        Me.rdoColumn.Location = New System.Drawing.Point(69, 54)
-        Me.rdoColumn.Margin = New System.Windows.Forms.Padding(2)
+        Me.rdoColumn.Location = New System.Drawing.Point(104, 81)
         Me.rdoColumn.Name = "rdoColumn"
-        Me.rdoColumn.Size = New System.Drawing.Size(74, 17)
+        Me.rdoColumn.Size = New System.Drawing.Size(112, 24)
         Me.rdoColumn.TabIndex = 48
         Me.rdoColumn.TabStop = True
         Me.rdoColumn.Text = "Column(%)"
@@ -656,11 +674,9 @@ Partial Class dlgDescribeTwoVariable
         Me.grpDisplayVars.Controls.Add(Me.rdoColumn)
         Me.grpDisplayVars.Controls.Add(Me.rdoTotal)
         Me.grpDisplayVars.Controls.Add(Me.ucrPnlDisplayVars)
-        Me.grpDisplayVars.Location = New System.Drawing.Point(252, 250)
-        Me.grpDisplayVars.Margin = New System.Windows.Forms.Padding(2)
+        Me.grpDisplayVars.Location = New System.Drawing.Point(378, 375)
         Me.grpDisplayVars.Name = "grpDisplayVars"
-        Me.grpDisplayVars.Padding = New System.Windows.Forms.Padding(2)
-        Me.grpDisplayVars.Size = New System.Drawing.Size(221, 90)
+        Me.grpDisplayVars.Size = New System.Drawing.Size(332, 135)
         Me.grpDisplayVars.TabIndex = 49
         Me.grpDisplayVars.TabStop = False
         Me.grpDisplayVars.Text = "Percentages"
@@ -669,27 +685,28 @@ Partial Class dlgDescribeTwoVariable
         '
         Me.ucrChkPercentagesVars.AutoSize = True
         Me.ucrChkPercentagesVars.Checked = False
-        Me.ucrChkPercentagesVars.Location = New System.Drawing.Point(6, 19)
-        Me.ucrChkPercentagesVars.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrChkPercentagesVars.Location = New System.Drawing.Point(9, 28)
+        Me.ucrChkPercentagesVars.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrChkPercentagesVars.Name = "ucrChkPercentagesVars"
-        Me.ucrChkPercentagesVars.Size = New System.Drawing.Size(201, 23)
+        Me.ucrChkPercentagesVars.Size = New System.Drawing.Size(302, 51)
         Me.ucrChkPercentagesVars.TabIndex = 19
         '
         'ucrPnlDisplayVars
         '
         Me.ucrPnlDisplayVars.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrPnlDisplayVars.Location = New System.Drawing.Point(6, 45)
-        Me.ucrPnlDisplayVars.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrPnlDisplayVars.Location = New System.Drawing.Point(9, 68)
+        Me.ucrPnlDisplayVars.Margin = New System.Windows.Forms.Padding(9)
         Me.ucrPnlDisplayVars.Name = "ucrPnlDisplayVars"
-        Me.ucrPnlDisplayVars.Size = New System.Drawing.Size(201, 34)
+        Me.ucrPnlDisplayVars.Size = New System.Drawing.Size(302, 51)
         Me.ucrPnlDisplayVars.TabIndex = 50
         '
         'dlgDescribeTwoVariable
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ClientSize = New System.Drawing.Size(482, 550)
+        Me.ClientSize = New System.Drawing.Size(723, 825)
+        Me.Controls.Add(Me.ucrSaveTable)
         Me.Controls.Add(Me.ucrReorderSummary)
         Me.Controls.Add(Me.grpDisplayVars)
         Me.Controls.Add(Me.ucrChkDisplayMargins)
@@ -704,7 +721,6 @@ Partial Class dlgDescribeTwoVariable
         Me.Controls.Add(Me.ucrReceiverThreeVariableSecondFactor)
         Me.Controls.Add(Me.ucrReceiverSecondTwoVariableFactor)
         Me.Controls.Add(Me.ucrReceiverFirstVars)
-        Me.Controls.Add(Me.ucrSaveTable)
         Me.Controls.Add(Me.grpDisplay)
         Me.Controls.Add(Me.ucrInputMarginName)
         Me.Controls.Add(Me.lblMarginName)
@@ -731,6 +747,7 @@ Partial Class dlgDescribeTwoVariable
         Me.Controls.Add(Me.ucrChkMeans)
         Me.Controls.Add(Me.ucrChkOmitMissing)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(4)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgDescribeTwoVariable"

--- a/instat/dlgDescribeTwoVariable.Designer.vb
+++ b/instat/dlgDescribeTwoVariable.Designer.vb
@@ -69,7 +69,6 @@ Partial Class dlgDescribeTwoVariable
         Me.ucrReceiverThreeVariableSecondFactor = New instat.ucrReceiverSingle()
         Me.ucrReceiverSecondTwoVariableFactor = New instat.ucrReceiverSingle()
         Me.ucrReceiverFirstVars = New instat.ucrReceiverMultiple()
-        Me.ucrSaveTable = New instat.ucrSave()
         Me.ucrInputMarginName = New instat.ucrInputTextBox()
         Me.ucrReorderSummary = New instat.ucrReorder()
         Me.ucrBase = New instat.ucrButtons()
@@ -91,6 +90,7 @@ Partial Class dlgDescribeTwoVariable
         Me.grpDisplayVars = New System.Windows.Forms.GroupBox()
         Me.ucrChkPercentagesVars = New instat.ucrCheck()
         Me.ucrPnlDisplayVars = New instat.UcrPanel()
+        Me.ucrSaveTable = New instat.ucrSave()
         Me.grpSummaries.SuspendLayout()
         Me.grpDisplay.SuspendLayout()
         Me.grpDisplayVars.SuspendLayout()
@@ -342,7 +342,7 @@ Partial Class dlgDescribeTwoVariable
         'lblMarginName
         '
         Me.lblMarginName.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblMarginName.Location = New System.Drawing.Point(22, 480)
+        Me.lblMarginName.Location = New System.Drawing.Point(22, 489)
         Me.lblMarginName.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMarginName.Name = "lblMarginName"
         Me.lblMarginName.Size = New System.Drawing.Size(140, 22)
@@ -466,22 +466,13 @@ Partial Class dlgDescribeTwoVariable
         Me.ucrReceiverFirstVars.TabIndex = 6
         Me.ucrReceiverFirstVars.ucrSelector = Nothing
         '
-        'ucrSaveTable
-        '
-        Me.ucrSaveTable.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveTable.Location = New System.Drawing.Point(22, 676)
-        Me.ucrSaveTable.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
-        Me.ucrSaveTable.Name = "ucrSaveTable"
-        Me.ucrSaveTable.Size = New System.Drawing.Size(419, 36)
-        Me.ucrSaveTable.TabIndex = 24
-        '
         'ucrInputMarginName
         '
         Me.ucrInputMarginName.AddQuotesIfUnrecognised = True
         Me.ucrInputMarginName.AutoSize = True
         Me.ucrInputMarginName.IsMultiline = False
         Me.ucrInputMarginName.IsReadOnly = False
-        Me.ucrInputMarginName.Location = New System.Drawing.Point(171, 477)
+        Me.ucrInputMarginName.Location = New System.Drawing.Point(171, 486)
         Me.ucrInputMarginName.Margin = New System.Windows.Forms.Padding(14)
         Me.ucrInputMarginName.Name = "ucrInputMarginName"
         Me.ucrInputMarginName.Size = New System.Drawing.Size(206, 32)
@@ -700,6 +691,15 @@ Partial Class dlgDescribeTwoVariable
         Me.ucrPnlDisplayVars.Size = New System.Drawing.Size(302, 51)
         Me.ucrPnlDisplayVars.TabIndex = 50
         '
+        'ucrSaveTable
+        '
+        Me.ucrSaveTable.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSaveTable.Location = New System.Drawing.Point(26, 661)
+        Me.ucrSaveTable.Margin = New System.Windows.Forms.Padding(6, 8, 6, 8)
+        Me.ucrSaveTable.Name = "ucrSaveTable"
+        Me.ucrSaveTable.Size = New System.Drawing.Size(419, 36)
+        Me.ucrSaveTable.TabIndex = 50
+        '
         'dlgDescribeTwoVariable
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(144.0!, 144.0!)
@@ -799,7 +799,6 @@ Partial Class dlgDescribeTwoVariable
     Friend WithEvents ucrChkDisplayMargins As ucrCheck
     Friend WithEvents grpDisplay As GroupBox
     Friend WithEvents ucrChkDisplayAsPercentage As ucrCheck
-    Friend WithEvents ucrSaveTable As ucrSave
     Friend WithEvents ucrReceiverFirstVars As ucrReceiverMultiple
     Friend WithEvents ucrChkCorrelations As ucrCheck
     Friend WithEvents ucrChkSwapXYVar As ucrCheck
@@ -817,4 +816,5 @@ Partial Class dlgDescribeTwoVariable
     Friend WithEvents rdoTotal As RadioButton
     Friend WithEvents ucrChkPercentagesVars As ucrCheck
     Friend WithEvents ucrPnlDisplayVars As UcrPanel
+    Friend WithEvents ucrSaveTable As ucrSave
 End Class

--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -311,12 +311,14 @@ Public Class dlgDescribeTwoVariable
         clsCombineSwapAnova2Table.SetRCommand("c")
 
         clsMappingFunction.SetPackageName("purrr")
-        clsMappingFunction.SetRCommand("walk")
+        'clsMappingFunction.SetRCommand("walk")
+        clsMappingFunction.SetRCommand("map")
         clsMappingFunction.AddParameter(".x", clsROperatorParameter:=clsYlistOperator, iPosition:=0)
         clsMappingFunction.AddParameter(".f", clsROperatorParameter:=clsAnovaTable2Operator, iPosition:=1)
 
         clsMapping2Function.SetPackageName("purrr")
-        clsMapping2Function.SetRCommand("walk")
+        'clsMapping2Function.SetRCommand("walk")
+        clsMapping2Function.SetRCommand("map")
         clsMapping2Function.AddParameter(".x", clsROperatorParameter:=clsYlist2Operator, iPosition:=0)
         clsMapping2Function.AddParameter(".f", clsROperatorParameter:=clsAnovaSwapTable2Opeator, iPosition:=1)
 
@@ -684,7 +686,6 @@ Public Class dlgDescribeTwoVariable
             ucrChkOmitMissing.Visible = False
             clsDummyFunction.AddParameter("checked", "customize", iPosition:=0)
             If IsNumericByNumeric() Then
-                'ucrSaveTable.Reset()
                 clsMappingFunction.RemoveAssignTo()
                 If ucrChkSwapXYVar.Checked Then
                     ucrBase.clsRsyntax.SetBaseRFunction(clsMapping2Function)
@@ -712,13 +713,13 @@ Public Class dlgDescribeTwoVariable
                 ucrChkMeans.Location = New Point(310, 210)
 
             ElseIf IsNumericByFactor() Then
+                ucrSaveTable.Visible = True
                 ucrBase.clsRsyntax.SetBaseRFunction(clsMappingFunction)
                 ucrChkInteraction.Visible = False
                 ucrChkMeans.Visible = True
                 ucrChkLevSig.Visible = True
                 ucrChkTotal.Visible = True
-                ucrSaveTable.Visible = True
-                ucrSaveTable.Location = New Point(23, 450)
+                ucrSaveTable.Location = New Point(iUcrBaseXLocation, 450)
                 ucrChkTotal.Location = New Point(310, 189)
                 ucrChkMeans.Location = New Point(310, 210)
                 ucrChkLevSig.Location = New Point(397, 186)
@@ -727,7 +728,6 @@ Public Class dlgDescribeTwoVariable
                 ucrSaveTable.SetSaveType(RObjectTypeLabel.Model, strRObjectFormat:=RObjectFormat.Text)
                 ucrSaveTable.SetAssignToIfUncheckedValue("last_model")
                 ucrSaveTable.SetCheckBoxText("Store Model")
-
             ElseIf IsFactorByFactor() Then
                 ucrSaveTable.Visible = True
                 cmdFormatTable.Visible = True
@@ -813,6 +813,7 @@ Public Class dlgDescribeTwoVariable
                                                   strRDataFrameNameToAddObjectTo:=ucrSelectorDescribeTwoVar.strCurrentDataFrame,
                                                     strObjectName:="last_table")
             ElseIf IsFactorByNumericByNumeric() Then
+
                 cmdFormatTable.Visible = True
                 ucrSaveTable.Visible = True
                 ucrSaveTable.Location = New Point(iUcrBaseXLocation, 300)
@@ -969,6 +970,13 @@ Public Class dlgDescribeTwoVariable
         ChangeBaseRCode()
     End Sub
 
+    'Private Sub CheckSaveControlVisibility()
+    '    If (Not ucrReceiverFirstVars.IsEmpty AndAlso Not ucrReceiverSecondTwoVariableFactor.IsEmpty) OrElse Not ucrReceiverSkimrGroupByFactor.IsEmpty OrElse
+    '        Not ucrReceiverSecondSkimrGroupByFactor.IsEmpty OrElse Not ucrReceiverThreeVariableThirdVariable.IsEmpty Then
+    '        ChangeBaseRCode()
+    '    End If
+    'End Sub
+
     Private Sub ucrPnlDescribe_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlDescribe.ControlValueChanged
 
         ucrReceiverFirstVars.SetMeAsReceiver()
@@ -1023,8 +1031,8 @@ Public Class dlgDescribeTwoVariable
                     cmdFormatTable.Location = New Point(330, 450)
                 End If
             ElseIf IsNumericByFactor() Then
-                ucrSaveTable.Location = New Point(iUcrBaseXLocation, 329)
-                ucrSaveTable.Size = New Point(350, 30)
+                ucrSaveTable.Location = New Point(iUcrBaseXLocation, 349)
+                ucrSaveTable.Size = New Point(350, 20)
                 ucrBase.Location = New Point(iUcrBaseXLocation, 369)
                 Me.Size = New Point(iDialogueXsize, 465)
             ElseIf IsFactorByFactor() Then

--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -33,16 +33,15 @@ Public Class dlgDescribeTwoVariable
     Private clsCombineFrequencyParametersFunction, clsCombineFrequencyColParametersFunction, clsCombineFunction, clsCombineSwapAnova2Table, clsCombineAnova2Function, clsSummariseFunction,
        clsDummyFunction, clsGroupByFunction, clsRAnovaFunction, clsCorrFunction, clsRAnovaTableFunction,
         clsRCorrelationFunction, clsSkimrFunction, clsSummariesListFunction, clsCombineAnovaFunction,
-        clsSummaryTableCombineFactorsFunction, clsSummaryTableFunction, clsRAnovaSwapTable2Funtion,
-        clsThreeVariableCombineFrequencyParametersFunction, clsPivotWiderFunction, clsMappingFunction, clsMapping2Function, clsRAnovaTable2Function,
-        clsNamesFunction, clsAddObjectFunction, clsGetObjectFunction As New RFunction
+        clsSummaryTableCombineFactorsFunction, clsSummaryTableFunction, clsRAnovaSwapTable2Funtion, clsMapSetNamesFunction,
+        clsThreeVariableCombineFrequencyParametersFunction, clsPivotWiderFunction, clsMappingFunction, clsMapping2Function, clsRAnovaTable2Function As New RFunction
 
     'FORMAT TABLE FUNCTIONS
     Private clsgtExtrasThemesFuction, clsCrossDfFunction, clsListFunction, clsGtRFunction As New RFunction
 
     Private clsGroupByPipeOperator, clsSummaryOperator, clsGroupByPipeOperator2, clsGroupByPipeOperator3, clsGroupByPipeOperator4, clsGroupByPipeOperatorData As New ROperator
 
-    Private clsTildOperator, clsMapOperator, clsGtTableROperator, clsPivotOperator, clsAssignmentOperator As New ROperator
+    Private clsTildOperator, clsMapOperator, clsGtTableROperator, clsPivotOperator As New ROperator
 
     Private clsgtFunction, clsMapSummaryFunction, clsMap2SummaryFunction, clsMapGtFunction As New RFunction
     'Frequency Parameters
@@ -51,7 +50,7 @@ Public Class dlgDescribeTwoVariable
                                                           "signif_fig", "include_margins"})
 
     'Format Operators
-    Private clsPipeOperator, clsFactorOperator, clsSummariesOperator, clsTabFootnoteOperator,
+    Private clsPipeOperator, clsFactorOperator, clsSummariesOperator, clsTabFootnoteOperator, clsMapPipeOperator,
             clsJoiningPipeOperator, clsMutableOperator, clsAnovaSwapTable2Opeator, clsAnovaTable2Operator, clsYlist2Operator, clsYlistOperator As New ROperator
     Private iUcrBaseXLocation, iDialogueXsize As Integer
 
@@ -222,7 +221,9 @@ Public Class dlgDescribeTwoVariable
         clsJoiningPipeOperator = New ROperator
         clsPipeOperator = New ROperator
         clsTabFootnoteOperator = New ROperator
+        clsMapPipeOperator = New ROperator
         clsgtFunction = New RFunction
+        clsMapSetNamesFunction = New RFunction
 
         clsSummaryOperator = New ROperator
         clsMapOperator = New ROperator
@@ -251,9 +252,6 @@ Public Class dlgDescribeTwoVariable
         clsCrossDfFunction = New RFunction
         clsListFunction = New RFunction
         clsMap2SummaryFunction = New RFunction
-        clsNamesFunction = New RFunction
-        clsAddObjectFunction = New RFunction
-        clsGetObjectFunction = New RFunction
 
         clsTildOperator = New ROperator
         clsMapSummaryFunction = New RFunction
@@ -262,8 +260,6 @@ Public Class dlgDescribeTwoVariable
         clsFactorOperator = New ROperator
         clsSummariesOperator = New ROperator
         clsGtTableROperator = New ROperator
-        clsAssignmentOperator = New ROperator
-
 
         ucrSelectorDescribeTwoVar.Reset()
         ucrReceiverFirstVars.SetMeAsReceiver()
@@ -454,23 +450,14 @@ Public Class dlgDescribeTwoVariable
         clsMapOperator.AddParameter("right", clsROperatorParameter:=clsPivotOperator)
         clsMapOperator.bBrackets = False
 
-        clsNamesFunction.SetRCommand("names")
+        clsMapSetNamesFunction.SetPackageName("purrr")
+        clsMapSetNamesFunction.SetRCommand("set_names")
+        clsMapSetNamesFunction.AddParameter("x", "y_col_names_list", iPosition:=0, bIncludeArgumentName:=False)
 
-        clsAssignmentOperator.SetOperation("<-")
-        clsAssignmentOperator.AddParameter("left", clsRFunctionParameter:=clsNamesFunction, iPosition:=0, bIncludeArgumentName:=False)
-        clsAssignmentOperator.AddParameter("right", "y_col_names_list", iPosition:=1, bIncludeArgumentName:=False)
-
-        clsAddObjectFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_object")
-        clsAddObjectFunction.AddParameter("data_name", Chr(34) & ucrSelectorDescribeTwoVar.strCurrentDataFrame & Chr(34), iPosition:=0)
-        clsAddObjectFunction.AddParameter("object_name", Chr(34) & ucrSaveTable.GetText() & Chr(34), iPosition:=1)
-        clsAddObjectFunction.AddParameter("object_type_label", Chr(34) & "model" & Chr(34), iPosition:=2)
-        clsAddObjectFunction.AddParameter("object_format", Chr(34) & "text" & Chr(34), iPosition:=3)
-        clsAddObjectFunction.AddParameter("object", ucrSaveTable.GetText(), iPosition:=4)
-
-        clsGetObjectFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_object_data")
-        clsGetObjectFunction.AddParameter("data_name", Chr(34) & ucrSelectorDescribeTwoVar.strCurrentDataFrame & Chr(34), iPosition:=0)
-        clsGetObjectFunction.AddParameter("object_name", Chr(34) & ucrSaveTable.GetText() & Chr(34), iPosition:=1)
-        clsGetObjectFunction.AddParameter("as_file", "TRUE", iPosition:=2)
+        clsMapPipeOperator.SetOperation("%>%")
+        clsMapPipeOperator.AddParameter("left", clsRFunctionParameter:=clsMappingFunction, iPosition:=0, bIncludeArgumentName:=False)
+        clsMapPipeOperator.AddParameter("right", clsRFunctionParameter:=clsMapSetNamesFunction, iPosition:=1, bIncludeArgumentName:=False)
+        clsMapPipeOperator.bSpaceAroundOperation = True
 
         clsJoiningPipeOperator.SetOperation("%>%")
         clsJoiningPipeOperator.AddParameter("gtable", clsROperatorParameter:=clsSummaryOperator, iPosition:=0)
@@ -498,12 +485,11 @@ Public Class dlgDescribeTwoVariable
         ucrChkDisplayAsPercentage.AddAdditionalCodeParameterPair(clsCombineFrequencyColParametersFunction, New RParameter("percentage_type", iNewPosition:=1), iAdditionalPairNo:=1)
         ucrChkDisplayMargins.AddAdditionalCodeParameterPair(clsThreeVariableCombineFrequencyParametersFunction, New RParameter("include_margins", iNewPosition:=5), iAdditionalPairNo:=2)
         ucrChkInteraction.AddAdditionalCodeParameterPair(clsRAnovaSwapTable2Funtion, New RParameter("interaction", iNewPosition:=7), iAdditionalPairNo:=1)
-        'ucrSaveTable.AddAdditionalCodeParameterPair(clsNamesFunction, New RParameter("x", iNewPosition:=0, bNewIncludeArgumentName:=False), iAdditionalPairNo:=4)
 
         ucrSelectorDescribeTwoVar.AddAdditionalCodeParameterPair(clsSummaryTableFunction, ucrSelectorDescribeTwoVar.GetParameter(), iAdditionalPairNo:=1)
         ucrSaveTable.AddAdditionalRCode(clsJoiningPipeOperator, iAdditionalPairNo:=1)
         ucrSaveTable.AddAdditionalRCode(clsGroupByPipeOperator4, iAdditionalPairNo:=2)
-        'ucrSaveTable.AddAdditionalRCode(clsMappingFunction, iAdditionalPairNo:=3)
+        ucrSaveTable.AddAdditionalRCode(clsMapPipeOperator, iAdditionalPairNo:=3)
 
         ucrChkOmitMissing.SetRCode(clsSummaryTableFunction, bReset)
         ucrReceiverSecondTwoVariableFactor.SetRCode(clsDummyFunction, bReset)
@@ -546,40 +532,6 @@ Public Class dlgDescribeTwoVariable
                 AndAlso (IsFactorByFactor() OrElse IsNumericByFactor() _
                 OrElse IsFactorByNumeric() OrElse IsNumericByNumericByFactor() OrElse IsNumericByFactorByFactor() OrElse IsNumericByNumericByNumeric() _
                 OrElse IsFactorByNumericByNumeric() OrElse IsNumericByFactorByNumeric() OrElse IsFactorByFactorByFactor() OrElse IsNumericByNumeric())) AndAlso ucrSaveTable.IsComplete)
-    End Sub
-
-    Private Sub ucrSaveTable_ControlValueChanged(ucrChangedControls As ucrCore) Handles ucrSaveTable.ControlValueChanged
-        Dim strModelSaveName As String = ucrSaveTable.GetText()
-
-        If IsNumericByFactor() OrElse IsNumericByNumericByFactor() OrElse IsNumericByFactorByFactor() OrElse IsNumericByFactorByNumeric() Then
-            If ucrSaveTable.ucrChkSave.Checked Then
-                clsNamesFunction.AddParameter("x", strModelSaveName, iPosition:=0, bIncludeArgumentName:=False)
-                clsAddObjectFunction.AddParameter("object_name", Chr(34) & strModelSaveName & Chr(34), iPosition:=1)
-                clsAddObjectFunction.AddParameter("object", strModelSaveName, iPosition:=4)
-                clsGetObjectFunction.AddParameter("object_name", Chr(34) & strModelSaveName & Chr(34), iPosition:=1)
-                clsMappingFunction.SetAssignTo(strModelSaveName)
-            Else
-                Dim strLastModel As String = "last_model"
-                clsNamesFunction.AddParameter("x", strLastModel, iPosition:=0, bIncludeArgumentName:=False)
-                clsAddObjectFunction.AddParameter("object_name", Chr(34) & strLastModel & Chr(34), iPosition:=1)
-                clsAddObjectFunction.AddParameter("object", strLastModel, iPosition:=4)
-                clsGetObjectFunction.AddParameter("object_name", Chr(34) & strLastModel & Chr(34), iPosition:=1)
-                clsMappingFunction.SetAssignTo(strLastModel)
-            End If
-        End If
-        AddRemoveModelSaveCodes()
-    End Sub
-
-    Private Sub AddRemoveModelSaveCodes()
-        If IsNumericByFactor() OrElse IsNumericByNumericByFactor() OrElse IsNumericByFactorByFactor() OrElse IsNumericByFactorByNumeric() Then
-            ucrBase.clsRsyntax.AddToAfterCodes(clsAssignmentOperator, iPosition:=1)
-            ucrBase.clsRsyntax.AddToAfterCodes(clsAddObjectFunction, iPosition:=1)
-            ucrBase.clsRsyntax.AddToAfterCodes(clsGetObjectFunction, iPosition:=2)
-        Else
-            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsAssignmentOperator)
-            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsAddObjectFunction)
-            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsGetObjectFunction)
-        End If
     End Sub
 
     Private Sub RemoveAddPerTotal()
@@ -720,6 +672,7 @@ Public Class dlgDescribeTwoVariable
 
     Private Sub ChangeBaseRCode()
         clsMappingFunction.RemoveAssignTo()
+        clsMapPipeOperator.RemoveAssignTo()
         ucrSaveTable.Visible = False
         ucrReorderSummary.Visible = False
         cmdSummaries.Visible = False
@@ -749,7 +702,6 @@ Public Class dlgDescribeTwoVariable
             ucrChkOmitMissing.Visible = False
             clsDummyFunction.AddParameter("checked", "customize", iPosition:=0)
             If IsNumericByNumeric() Then
-                'clsMappingFunction.RemoveAssignTo()
                 If ucrChkSwapXYVar.Checked Then
                     ucrBase.clsRsyntax.SetBaseRFunction(clsMapping2Function)
                     clsDummyFunction.AddParameter("var", "True", iPosition:=5)
@@ -777,7 +729,7 @@ Public Class dlgDescribeTwoVariable
 
             ElseIf IsNumericByFactor() Then
                 ucrSaveTable.Visible = True
-                ucrBase.clsRsyntax.SetBaseRFunction(clsMappingFunction)
+                ucrBase.clsRsyntax.SetBaseROperator(clsMapPipeOperator)
                 ucrChkInteraction.Visible = False
                 ucrChkMeans.Visible = True
                 ucrChkLevSig.Visible = True
@@ -790,7 +742,6 @@ Public Class dlgDescribeTwoVariable
                 ucrSaveTable.SetSaveType(RObjectTypeLabel.Model, strRObjectFormat:=RObjectFormat.Text)
                 ucrSaveTable.SetAssignToIfUncheckedValue("last_model")
                 ucrSaveTable.SetCheckBoxText("Store Model")
-                AddRemoveModelSaveCodes()
             ElseIf IsFactorByFactor() Then
                 ucrSaveTable.Visible = True
                 cmdFormatTable.Visible = True
@@ -911,11 +862,9 @@ Public Class dlgDescribeTwoVariable
                     clsDummyFunction.AddParameter("var", "True", iPosition:=5)
                 Else
                     clsDummyFunction.AddParameter("var", "False", iPosition:=5)
-                    ucrBase.clsRsyntax.SetBaseRFunction(clsMappingFunction)
+                    ucrBase.clsRsyntax.SetBaseROperator(clsMapPipeOperator)
                 End If
-                AddRemoveModelSaveCodes()
             ElseIf IsNumericByNumericByNumeric() Then
-                'clsMappingFunction.RemoveAssignTo()
                 cmdFormatTable.Visible = False
                 ucrSaveTable.Visible = False
                 ucrChkMeans.Visible = True
@@ -938,12 +887,11 @@ Public Class dlgDescribeTwoVariable
                 ucrChkLevSig.Location = New Point(397, 250)
                 ucrChkInteraction.Location = New Point(310, 275)
                 ucrChkMeans.Location = New Point(310, 300)
-                ucrBase.clsRsyntax.SetBaseRFunction(clsMappingFunction)
+                ucrBase.clsRsyntax.SetBaseROperator(clsMapPipeOperator)
                 ucrSaveTable.SetPrefix("three_var_model")
                 ucrSaveTable.SetSaveType(RObjectTypeLabel.Model, strRObjectFormat:=RObjectFormat.Text)
                 ucrSaveTable.SetAssignToIfUncheckedValue("last_model")
                 ucrSaveTable.SetCheckBoxText("Store Model")
-                AddRemoveModelSaveCodes()
             ElseIf IsNumericByFactorByNumeric() Then
                 cmdFormatTable.Visible = False
                 ucrSaveTable.Visible = True
@@ -955,12 +903,11 @@ Public Class dlgDescribeTwoVariable
                 ucrChkLevSig.Location = New Point(397, 250)
                 ucrChkInteraction.Location = New Point(310, 275)
                 ucrChkMeans.Location = New Point(310, 300)
-                ucrBase.clsRsyntax.SetBaseRFunction(clsMappingFunction)
+                ucrBase.clsRsyntax.SetBaseROperator(clsMapPipeOperator)
                 ucrSaveTable.SetPrefix("three_var_model")
                 ucrSaveTable.SetSaveType(RObjectTypeLabel.Model, strRObjectFormat:=RObjectFormat.Text)
                 ucrSaveTable.SetAssignToIfUncheckedValue("last_model")
                 ucrSaveTable.SetCheckBoxText("Store Model")
-                AddRemoveModelSaveCodes()
             ElseIf IsFactorByNumericByFactor() OrElse IsFactorByFactorByNumeric() Then
                 ucrSaveTable.SetPrefix("summary_table")
                 cmdFormatTable.Visible = True
@@ -1545,9 +1492,6 @@ Public Class dlgDescribeTwoVariable
         ' Always update the data parameter for these functions
         clsRAnovaTable2Function.AddParameter("data", Chr(34) & ucrSelectorDescribeTwoVar.ucrAvailableDataFrames.cboAvailableDataFrames.Text & Chr(34), iPosition:=0)
         clsRAnovaSwapTable2Funtion.AddParameter("data", Chr(34) & ucrSelectorDescribeTwoVar.ucrAvailableDataFrames.cboAvailableDataFrames.Text & Chr(34), iPosition:=0)
-
-        clsAddObjectFunction.AddParameter("data_name", Chr(34) & ucrSelectorDescribeTwoVar.strCurrentDataFrame & Chr(34), iPosition:=0)
-        clsGetObjectFunction.AddParameter("data_name", Chr(34) & ucrSelectorDescribeTwoVar.strCurrentDataFrame & Chr(34), iPosition:=0)
 
         ' --- Clear all variable receivers to avoid referencing old variables ---
         ucrReceiverFirstVars.ResetText()

--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -34,14 +34,15 @@ Public Class dlgDescribeTwoVariable
        clsDummyFunction, clsGroupByFunction, clsRAnovaFunction, clsCorrFunction, clsRAnovaTableFunction,
         clsRCorrelationFunction, clsSkimrFunction, clsSummariesListFunction, clsCombineAnovaFunction,
         clsSummaryTableCombineFactorsFunction, clsSummaryTableFunction, clsRAnovaSwapTable2Funtion,
-        clsThreeVariableCombineFrequencyParametersFunction, clsPivotWiderFunction, clsMappingFunction, clsMapping2Function, clsRAnovaTable2Function As New RFunction
+        clsThreeVariableCombineFrequencyParametersFunction, clsPivotWiderFunction, clsMappingFunction, clsMapping2Function, clsRAnovaTable2Function,
+        clsNamesFunction, clsAddObjectFunction, clsGetObjectFunction As New RFunction
 
     'FORMAT TABLE FUNCTIONS
     Private clsgtExtrasThemesFuction, clsCrossDfFunction, clsListFunction, clsGtRFunction As New RFunction
 
     Private clsGroupByPipeOperator, clsSummaryOperator, clsGroupByPipeOperator2, clsGroupByPipeOperator3, clsGroupByPipeOperator4, clsGroupByPipeOperatorData As New ROperator
 
-    Private clsTildOperator, clsMapOperator, clsGtTableROperator, clsPivotOperator As New ROperator
+    Private clsTildOperator, clsMapOperator, clsGtTableROperator, clsPivotOperator, clsAssignmentOperator As New ROperator
 
     Private clsgtFunction, clsMapSummaryFunction, clsMap2SummaryFunction, clsMapGtFunction As New RFunction
     'Frequency Parameters
@@ -250,6 +251,9 @@ Public Class dlgDescribeTwoVariable
         clsCrossDfFunction = New RFunction
         clsListFunction = New RFunction
         clsMap2SummaryFunction = New RFunction
+        clsNamesFunction = New RFunction
+        clsAddObjectFunction = New RFunction
+        clsGetObjectFunction = New RFunction
 
         clsTildOperator = New ROperator
         clsMapSummaryFunction = New RFunction
@@ -258,6 +262,8 @@ Public Class dlgDescribeTwoVariable
         clsFactorOperator = New ROperator
         clsSummariesOperator = New ROperator
         clsGtTableROperator = New ROperator
+        clsAssignmentOperator = New ROperator
+
 
         ucrSelectorDescribeTwoVar.Reset()
         ucrReceiverFirstVars.SetMeAsReceiver()
@@ -448,6 +454,24 @@ Public Class dlgDescribeTwoVariable
         clsMapOperator.AddParameter("right", clsROperatorParameter:=clsPivotOperator)
         clsMapOperator.bBrackets = False
 
+        clsNamesFunction.SetRCommand("names")
+
+        clsAssignmentOperator.SetOperation("<-")
+        clsAssignmentOperator.AddParameter("left", clsRFunctionParameter:=clsNamesFunction, iPosition:=0, bIncludeArgumentName:=False)
+        clsAssignmentOperator.AddParameter("right", "y_col_names_list", iPosition:=1, bIncludeArgumentName:=False)
+
+        clsAddObjectFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_object")
+        clsAddObjectFunction.AddParameter("data_name", Chr(34) & ucrSelectorDescribeTwoVar.strCurrentDataFrame & Chr(34), iPosition:=0)
+        clsAddObjectFunction.AddParameter("object_name", Chr(34) & ucrSaveTable.GetText() & Chr(34), iPosition:=1)
+        clsAddObjectFunction.AddParameter("object_type_label", Chr(34) & "model" & Chr(34), iPosition:=2)
+        clsAddObjectFunction.AddParameter("object_format", Chr(34) & "text" & Chr(34), iPosition:=3)
+        clsAddObjectFunction.AddParameter("object", ucrSaveTable.GetText(), iPosition:=4)
+
+        clsGetObjectFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_object_data")
+        clsGetObjectFunction.AddParameter("data_name", Chr(34) & ucrSelectorDescribeTwoVar.strCurrentDataFrame & Chr(34), iPosition:=0)
+        clsGetObjectFunction.AddParameter("object_name", Chr(34) & ucrSaveTable.GetText() & Chr(34), iPosition:=1)
+        clsGetObjectFunction.AddParameter("as_file", "TRUE", iPosition:=2)
+
         clsJoiningPipeOperator.SetOperation("%>%")
         clsJoiningPipeOperator.AddParameter("gtable", clsROperatorParameter:=clsSummaryOperator, iPosition:=0)
         clsJoiningPipeOperator.bBrackets = False
@@ -474,11 +498,12 @@ Public Class dlgDescribeTwoVariable
         ucrChkDisplayAsPercentage.AddAdditionalCodeParameterPair(clsCombineFrequencyColParametersFunction, New RParameter("percentage_type", iNewPosition:=1), iAdditionalPairNo:=1)
         ucrChkDisplayMargins.AddAdditionalCodeParameterPair(clsThreeVariableCombineFrequencyParametersFunction, New RParameter("include_margins", iNewPosition:=5), iAdditionalPairNo:=2)
         ucrChkInteraction.AddAdditionalCodeParameterPair(clsRAnovaSwapTable2Funtion, New RParameter("interaction", iNewPosition:=7), iAdditionalPairNo:=1)
+        'ucrSaveTable.AddAdditionalCodeParameterPair(clsNamesFunction, New RParameter("x", iNewPosition:=0, bNewIncludeArgumentName:=False), iAdditionalPairNo:=4)
 
         ucrSelectorDescribeTwoVar.AddAdditionalCodeParameterPair(clsSummaryTableFunction, ucrSelectorDescribeTwoVar.GetParameter(), iAdditionalPairNo:=1)
         ucrSaveTable.AddAdditionalRCode(clsJoiningPipeOperator, iAdditionalPairNo:=1)
         ucrSaveTable.AddAdditionalRCode(clsGroupByPipeOperator4, iAdditionalPairNo:=2)
-        ucrSaveTable.AddAdditionalRCode(clsMappingFunction, iAdditionalPairNo:=3)
+        'ucrSaveTable.AddAdditionalRCode(clsMappingFunction, iAdditionalPairNo:=3)
 
         ucrChkOmitMissing.SetRCode(clsSummaryTableFunction, bReset)
         ucrReceiverSecondTwoVariableFactor.SetRCode(clsDummyFunction, bReset)
@@ -521,6 +546,30 @@ Public Class dlgDescribeTwoVariable
                 AndAlso (IsFactorByFactor() OrElse IsNumericByFactor() _
                 OrElse IsFactorByNumeric() OrElse IsNumericByNumericByFactor() OrElse IsNumericByFactorByFactor() OrElse IsNumericByNumericByNumeric() _
                 OrElse IsFactorByNumericByNumeric() OrElse IsNumericByFactorByNumeric() OrElse IsFactorByFactorByFactor() OrElse IsNumericByNumeric())) AndAlso ucrSaveTable.IsComplete)
+    End Sub
+
+    Private Sub ucrSaveTable_ControlValueChanged(ucrChangedControls As ucrCore) Handles ucrSaveTable.ControlValueChanged
+        Dim strModelSaveName As String = ucrSaveTable.GetText()
+        If ucrSaveTable.ucrChkSave.Checked Then
+            clsNamesFunction.AddParameter("x", strModelSaveName, iPosition:=0, bIncludeArgumentName:=False)
+            clsAddObjectFunction.AddParameter("object_name", Chr(34) & strModelSaveName & Chr(34), iPosition:=1)
+            clsAddObjectFunction.AddParameter("object", strModelSaveName, iPosition:=4)
+            clsGetObjectFunction.AddParameter("object_name", Chr(34) & strModelSaveName & Chr(34), iPosition:=1)
+            clsMappingFunction.SetAssignTo(strModelSaveName)
+        End If
+        AddRemoveModelSaveCodes()
+    End Sub
+
+    Private Sub AddRemoveModelSaveCodes()
+        If ucrSaveTable.ucrChkSave.Checked Then
+            ucrBase.clsRsyntax.AddToAfterCodes(clsAssignmentOperator, iPosition:=1)
+            ucrBase.clsRsyntax.AddToAfterCodes(clsAddObjectFunction, iPosition:=1)
+            ucrBase.clsRsyntax.AddToAfterCodes(clsGetObjectFunction, iPosition:=2)
+        Else
+            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsAssignmentOperator)
+            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsAddObjectFunction)
+            ucrBase.clsRsyntax.RemoveFromAfterCodes(clsGetObjectFunction)
+        End If
     End Sub
 
     Private Sub RemoveAddPerTotal()
@@ -660,6 +709,7 @@ Public Class dlgDescribeTwoVariable
     End Sub
 
     Private Sub ChangeBaseRCode()
+        clsMappingFunction.RemoveAssignTo()
         ucrSaveTable.Visible = False
         ucrReorderSummary.Visible = False
         cmdSummaries.Visible = False
@@ -689,7 +739,7 @@ Public Class dlgDescribeTwoVariable
             ucrChkOmitMissing.Visible = False
             clsDummyFunction.AddParameter("checked", "customize", iPosition:=0)
             If IsNumericByNumeric() Then
-                clsMappingFunction.RemoveAssignTo()
+                'clsMappingFunction.RemoveAssignTo()
                 If ucrChkSwapXYVar.Checked Then
                     ucrBase.clsRsyntax.SetBaseRFunction(clsMapping2Function)
                     clsDummyFunction.AddParameter("var", "True", iPosition:=5)
@@ -730,6 +780,7 @@ Public Class dlgDescribeTwoVariable
                 ucrSaveTable.SetSaveType(RObjectTypeLabel.Model, strRObjectFormat:=RObjectFormat.Text)
                 ucrSaveTable.SetAssignToIfUncheckedValue("last_model")
                 ucrSaveTable.SetCheckBoxText("Store Model")
+                AddRemoveModelSaveCodes()
             ElseIf IsFactorByFactor() Then
                 ucrSaveTable.Visible = True
                 cmdFormatTable.Visible = True
@@ -852,8 +903,9 @@ Public Class dlgDescribeTwoVariable
                     clsDummyFunction.AddParameter("var", "False", iPosition:=5)
                     ucrBase.clsRsyntax.SetBaseRFunction(clsMappingFunction)
                 End If
+                AddRemoveModelSaveCodes()
             ElseIf IsNumericByNumericByNumeric() Then
-                clsMappingFunction.RemoveAssignTo()
+                'clsMappingFunction.RemoveAssignTo()
                 cmdFormatTable.Visible = False
                 ucrSaveTable.Visible = False
                 ucrChkMeans.Visible = True
@@ -881,6 +933,7 @@ Public Class dlgDescribeTwoVariable
                 ucrSaveTable.SetSaveType(RObjectTypeLabel.Model, strRObjectFormat:=RObjectFormat.Text)
                 ucrSaveTable.SetAssignToIfUncheckedValue("last_model")
                 ucrSaveTable.SetCheckBoxText("Store Model")
+                AddRemoveModelSaveCodes()
             ElseIf IsNumericByFactorByNumeric() Then
                 cmdFormatTable.Visible = False
                 ucrSaveTable.Visible = True
@@ -897,6 +950,7 @@ Public Class dlgDescribeTwoVariable
                 ucrSaveTable.SetSaveType(RObjectTypeLabel.Model, strRObjectFormat:=RObjectFormat.Text)
                 ucrSaveTable.SetAssignToIfUncheckedValue("last_model")
                 ucrSaveTable.SetCheckBoxText("Store Model")
+                AddRemoveModelSaveCodes()
             ElseIf IsFactorByNumericByFactor() OrElse IsFactorByFactorByNumeric() Then
                 ucrSaveTable.SetPrefix("summary_table")
                 cmdFormatTable.Visible = True
@@ -1481,6 +1535,9 @@ Public Class dlgDescribeTwoVariable
         ' Always update the data parameter for these functions
         clsRAnovaTable2Function.AddParameter("data", Chr(34) & ucrSelectorDescribeTwoVar.ucrAvailableDataFrames.cboAvailableDataFrames.Text & Chr(34), iPosition:=0)
         clsRAnovaSwapTable2Funtion.AddParameter("data", Chr(34) & ucrSelectorDescribeTwoVar.ucrAvailableDataFrames.cboAvailableDataFrames.Text & Chr(34), iPosition:=0)
+
+        clsAddObjectFunction.AddParameter("data_name", Chr(34) & ucrSelectorDescribeTwoVar.strCurrentDataFrame & Chr(34), iPosition:=0)
+        clsGetObjectFunction.AddParameter("data_name", Chr(34) & ucrSelectorDescribeTwoVar.strCurrentDataFrame & Chr(34), iPosition:=0)
 
         ' --- Clear all variable receivers to avoid referencing old variables ---
         ucrReceiverFirstVars.ResetText()

--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -866,7 +866,7 @@ Public Class dlgDescribeTwoVariable
                 End If
             ElseIf IsNumericByNumericByNumeric() Then
                 cmdFormatTable.Visible = False
-                ucrSaveTable.Visible = False
+                ucrSaveTable.Visible = True
                 ucrChkMeans.Visible = True
                 ucrChkLevSig.Visible = True
                 ucrChkTotal.Visible = True
@@ -875,7 +875,12 @@ Public Class dlgDescribeTwoVariable
                 ucrChkLevSig.Location = New Point(397, 250)
                 ucrChkInteraction.Location = New Point(310, 275)
                 ucrChkMeans.Location = New Point(310, 300)
-                ucrBase.clsRsyntax.SetBaseRFunction(clsMappingFunction)
+                'ucrBase.clsRsyntax.SetBaseRFunction(clsMappingFunction)
+                ucrBase.clsRsyntax.SetBaseROperator(clsMapPipeOperator)
+                ucrSaveTable.SetPrefix("three_var_model")
+                ucrSaveTable.SetSaveType(RObjectTypeLabel.Model, strRObjectFormat:=RObjectFormat.Text)
+                ucrSaveTable.SetAssignToIfUncheckedValue("last_model")
+                ucrSaveTable.SetCheckBoxText("Store Model")
             ElseIf IsNumericByFactorByFactor() Then
                 cmdFormatTable.Visible = False
                 ucrSaveTable.Visible = True

--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -313,13 +313,11 @@ Public Class dlgDescribeTwoVariable
         clsCombineSwapAnova2Table.SetRCommand("c")
 
         clsMappingFunction.SetPackageName("purrr")
-        'clsMappingFunction.SetRCommand("walk")
         clsMappingFunction.SetRCommand("map")
         clsMappingFunction.AddParameter(".x", clsROperatorParameter:=clsYlistOperator, iPosition:=0)
         clsMappingFunction.AddParameter(".f", clsROperatorParameter:=clsAnovaTable2Operator, iPosition:=1)
 
         clsMapping2Function.SetPackageName("purrr")
-        'clsMapping2Function.SetRCommand("walk")
         clsMapping2Function.SetRCommand("map")
         clsMapping2Function.AddParameter(".x", clsROperatorParameter:=clsYlist2Operator, iPosition:=0)
         clsMapping2Function.AddParameter(".f", clsROperatorParameter:=clsAnovaSwapTable2Opeator, iPosition:=1)
@@ -875,7 +873,6 @@ Public Class dlgDescribeTwoVariable
                 ucrChkLevSig.Location = New Point(397, 250)
                 ucrChkInteraction.Location = New Point(310, 275)
                 ucrChkMeans.Location = New Point(310, 300)
-                'ucrBase.clsRsyntax.SetBaseRFunction(clsMappingFunction)
                 ucrBase.clsRsyntax.SetBaseROperator(clsMapPipeOperator)
                 ucrSaveTable.SetPrefix("three_var_model")
                 ucrSaveTable.SetSaveType(RObjectTypeLabel.Model, strRObjectFormat:=RObjectFormat.Text)

--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -550,18 +550,28 @@ Public Class dlgDescribeTwoVariable
 
     Private Sub ucrSaveTable_ControlValueChanged(ucrChangedControls As ucrCore) Handles ucrSaveTable.ControlValueChanged
         Dim strModelSaveName As String = ucrSaveTable.GetText()
-        If ucrSaveTable.ucrChkSave.Checked Then
-            clsNamesFunction.AddParameter("x", strModelSaveName, iPosition:=0, bIncludeArgumentName:=False)
-            clsAddObjectFunction.AddParameter("object_name", Chr(34) & strModelSaveName & Chr(34), iPosition:=1)
-            clsAddObjectFunction.AddParameter("object", strModelSaveName, iPosition:=4)
-            clsGetObjectFunction.AddParameter("object_name", Chr(34) & strModelSaveName & Chr(34), iPosition:=1)
-            clsMappingFunction.SetAssignTo(strModelSaveName)
+
+        If IsNumericByFactor() OrElse IsNumericByNumericByFactor() OrElse IsNumericByFactorByFactor() OrElse IsNumericByFactorByNumeric() Then
+            If ucrSaveTable.ucrChkSave.Checked Then
+                clsNamesFunction.AddParameter("x", strModelSaveName, iPosition:=0, bIncludeArgumentName:=False)
+                clsAddObjectFunction.AddParameter("object_name", Chr(34) & strModelSaveName & Chr(34), iPosition:=1)
+                clsAddObjectFunction.AddParameter("object", strModelSaveName, iPosition:=4)
+                clsGetObjectFunction.AddParameter("object_name", Chr(34) & strModelSaveName & Chr(34), iPosition:=1)
+                clsMappingFunction.SetAssignTo(strModelSaveName)
+            Else
+                Dim strLastModel As String = "last_model"
+                clsNamesFunction.AddParameter("x", strLastModel, iPosition:=0, bIncludeArgumentName:=False)
+                clsAddObjectFunction.AddParameter("object_name", Chr(34) & strLastModel & Chr(34), iPosition:=1)
+                clsAddObjectFunction.AddParameter("object", strLastModel, iPosition:=4)
+                clsGetObjectFunction.AddParameter("object_name", Chr(34) & strLastModel & Chr(34), iPosition:=1)
+                clsMappingFunction.SetAssignTo(strLastModel)
+            End If
         End If
         AddRemoveModelSaveCodes()
     End Sub
 
     Private Sub AddRemoveModelSaveCodes()
-        If ucrSaveTable.ucrChkSave.Checked Then
+        If IsNumericByFactor() OrElse IsNumericByNumericByFactor() OrElse IsNumericByFactorByFactor() OrElse IsNumericByFactorByNumeric() Then
             ucrBase.clsRsyntax.AddToAfterCodes(clsAssignmentOperator, iPosition:=1)
             ucrBase.clsRsyntax.AddToAfterCodes(clsAddObjectFunction, iPosition:=1)
             ucrBase.clsRsyntax.AddToAfterCodes(clsGetObjectFunction, iPosition:=2)

--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -476,6 +476,7 @@ Public Class dlgDescribeTwoVariable
         ucrSelectorDescribeTwoVar.AddAdditionalCodeParameterPair(clsSummaryTableFunction, ucrSelectorDescribeTwoVar.GetParameter(), iAdditionalPairNo:=1)
         ucrSaveTable.AddAdditionalRCode(clsJoiningPipeOperator, iAdditionalPairNo:=1)
         ucrSaveTable.AddAdditionalRCode(clsGroupByPipeOperator4, iAdditionalPairNo:=2)
+        ucrSaveTable.AddAdditionalRCode(clsMappingFunction, iAdditionalPairNo:=3)
 
         ucrChkOmitMissing.SetRCode(clsSummaryTableFunction, bReset)
         ucrReceiverSecondTwoVariableFactor.SetRCode(clsDummyFunction, bReset)
@@ -683,6 +684,8 @@ Public Class dlgDescribeTwoVariable
             ucrChkOmitMissing.Visible = False
             clsDummyFunction.AddParameter("checked", "customize", iPosition:=0)
             If IsNumericByNumeric() Then
+                'ucrSaveTable.Reset()
+                clsMappingFunction.RemoveAssignTo()
                 If ucrChkSwapXYVar.Checked Then
                     ucrBase.clsRsyntax.SetBaseRFunction(clsMapping2Function)
                     clsDummyFunction.AddParameter("var", "True", iPosition:=5)
@@ -720,10 +723,10 @@ Public Class dlgDescribeTwoVariable
                 ucrChkMeans.Location = New Point(310, 210)
                 ucrChkLevSig.Location = New Point(397, 186)
                 clsDummyFunction.AddParameter("factor_cols", "Sum", iPosition:=1)
-                ucrSaveTable.SetPrefix("summary_table")
-                ucrSaveTable.SetSaveType(RObjectTypeLabel.Table, strRObjectFormat:=RObjectFormat.Html)
-                ucrSaveTable.SetAssignToIfUncheckedValue("last_table")
-                ucrSaveTable.SetCheckBoxText("Store Table")
+                ucrSaveTable.SetPrefix("two_var_model")
+                ucrSaveTable.SetSaveType(RObjectTypeLabel.Model, strRObjectFormat:=RObjectFormat.Text)
+                ucrSaveTable.SetAssignToIfUncheckedValue("last_model")
+                ucrSaveTable.SetCheckBoxText("Store Model")
 
             ElseIf IsFactorByFactor() Then
                 ucrSaveTable.Visible = True
@@ -732,7 +735,7 @@ Public Class dlgDescribeTwoVariable
                 ucrChkLevSig.Visible = False
                 ucrChkTotal.Visible = False
                 ucrChkInteraction.Visible = False
-                ucrSaveTable.Location = New Point(23, 370)
+                ucrSaveTable.Location = New Point(iUcrBaseXLocation, 371)
                 clsDummyFunction.AddParameter("factor_cols", "FactorVar", iPosition:=1)
                 ucrBase.clsRsyntax.SetBaseROperator(clsJoiningPipeOperator)
                 ucrSaveTable.SetPrefix("frequency_table")
@@ -774,7 +777,7 @@ Public Class dlgDescribeTwoVariable
                     ucrChkLevSig.Visible = False
                     ucrChkTotal.Visible = False
                     ucrChkInteraction.Visible = False
-                    ucrSaveTable.Location = New Point(23, 450)
+                    ucrSaveTable.Location = New Point(iUcrBaseXLocation, 450)
                     ucrChkOmitMissing.Location = New Point(15, 365)
                     clsDummyFunction.AddParameter("factor_cols", "Sum", iPosition:=1)
                     ucrBase.clsRsyntax.SetBaseROperator(clsJoiningPipeOperator)
@@ -797,7 +800,7 @@ Public Class dlgDescribeTwoVariable
             ucrBase.clsRsyntax.RemoveFromBeforeCodes(clsCrossDfFunction)
             If IsFactorByFactorByFactor() Then
                 cmdFormatTable.Visible = True
-                ucrSaveTable.Location = New Point(23, 341)
+                ucrSaveTable.Location = New Point(iUcrBaseXLocation, 342)
                 ucrSaveTable.Visible = True
                 ucrSaveTable.SetPrefix("frequency_table")
                 ucrSaveTable.SetSaveType(RObjectTypeLabel.Table, strRObjectFormat:=RObjectFormat.Html)
@@ -812,7 +815,7 @@ Public Class dlgDescribeTwoVariable
             ElseIf IsFactorByNumericByNumeric() Then
                 cmdFormatTable.Visible = True
                 ucrSaveTable.Visible = True
-                ucrSaveTable.Location = New Point(23, 300)
+                ucrSaveTable.Location = New Point(iUcrBaseXLocation, 300)
                 ucrSaveTable.SetPrefix("cor_table")
                 ucrSaveTable.SetSaveType(RObjectTypeLabel.Table, strRObjectFormat:=RObjectFormat.Html)
                 ucrSaveTable.SetAssignToIfUncheckedValue("last_table")
@@ -826,7 +829,7 @@ Public Class dlgDescribeTwoVariable
 
             ElseIf IsNumericByNumericByFactor() Then
                 cmdFormatTable.Visible = False
-                ucrSaveTable.Visible = False
+                ucrSaveTable.Visible = True
                 ucrChkMeans.Visible = True
                 ucrChkLevSig.Visible = True
                 ucrChkTotal.Visible = True
@@ -835,6 +838,10 @@ Public Class dlgDescribeTwoVariable
                 ucrChkLevSig.Location = New Point(397, 250)
                 ucrChkInteraction.Location = New Point(310, 275)
                 ucrChkMeans.Location = New Point(310, 300)
+                ucrSaveTable.SetPrefix("three_var_model")
+                ucrSaveTable.SetSaveType(RObjectTypeLabel.Model, strRObjectFormat:=RObjectFormat.Text)
+                ucrSaveTable.SetAssignToIfUncheckedValue("last_model")
+                ucrSaveTable.SetCheckBoxText("Store Model")
                 If ucrChkSwapXYVar.Checked Then
                     ucrBase.clsRsyntax.SetBaseRFunction(clsMapping2Function)
                     clsDummyFunction.AddParameter("var", "True", iPosition:=5)
@@ -843,6 +850,7 @@ Public Class dlgDescribeTwoVariable
                     ucrBase.clsRsyntax.SetBaseRFunction(clsMappingFunction)
                 End If
             ElseIf IsNumericByNumericByNumeric() Then
+                clsMappingFunction.RemoveAssignTo()
                 cmdFormatTable.Visible = False
                 ucrSaveTable.Visible = False
                 ucrChkMeans.Visible = True
@@ -856,7 +864,7 @@ Public Class dlgDescribeTwoVariable
                 ucrBase.clsRsyntax.SetBaseRFunction(clsMappingFunction)
             ElseIf IsNumericByFactorByFactor() Then
                 cmdFormatTable.Visible = False
-                ucrSaveTable.Visible = False
+                ucrSaveTable.Visible = True
                 ucrChkMeans.Visible = True
                 ucrChkLevSig.Visible = True
                 ucrChkTotal.Visible = True
@@ -866,9 +874,13 @@ Public Class dlgDescribeTwoVariable
                 ucrChkInteraction.Location = New Point(310, 275)
                 ucrChkMeans.Location = New Point(310, 300)
                 ucrBase.clsRsyntax.SetBaseRFunction(clsMappingFunction)
+                ucrSaveTable.SetPrefix("three_var_model")
+                ucrSaveTable.SetSaveType(RObjectTypeLabel.Model, strRObjectFormat:=RObjectFormat.Text)
+                ucrSaveTable.SetAssignToIfUncheckedValue("last_model")
+                ucrSaveTable.SetCheckBoxText("Store Model")
             ElseIf IsNumericByFactorByNumeric() Then
                 cmdFormatTable.Visible = False
-                ucrSaveTable.Visible = False
+                ucrSaveTable.Visible = True
                 ucrChkMeans.Visible = True
                 ucrChkLevSig.Visible = True
                 ucrChkTotal.Visible = True
@@ -878,6 +890,10 @@ Public Class dlgDescribeTwoVariable
                 ucrChkInteraction.Location = New Point(310, 275)
                 ucrChkMeans.Location = New Point(310, 300)
                 ucrBase.clsRsyntax.SetBaseRFunction(clsMappingFunction)
+                ucrSaveTable.SetPrefix("three_var_model")
+                ucrSaveTable.SetSaveType(RObjectTypeLabel.Model, strRObjectFormat:=RObjectFormat.Text)
+                ucrSaveTable.SetAssignToIfUncheckedValue("last_model")
+                ucrSaveTable.SetCheckBoxText("Store Model")
             ElseIf IsFactorByNumericByFactor() OrElse IsFactorByFactorByNumeric() Then
                 ucrSaveTable.SetPrefix("summary_table")
                 cmdFormatTable.Visible = True
@@ -897,7 +913,7 @@ Public Class dlgDescribeTwoVariable
                 cmdSummaries.Visible = True
                 ucrSaveTable.Visible = True
                 ucrChkOmitMissing.Visible = True
-                ucrSaveTable.Location = New Point(23, 440)
+                ucrSaveTable.Location = New Point(iUcrBaseXLocation, 442)
                 ucrChkOmitMissing.Location = New Point(15, 365)
             End If
         End If
@@ -996,6 +1012,7 @@ Public Class dlgDescribeTwoVariable
 
     Private Sub ChangeLocations()
         If rdoTwoVariable.Checked Then
+            ucrSaveTable.Size = New Point(310, 30)
             If IsFactorByNumeric() Then
                 If ucrChkSwapXYVar.Checked Then
                     ucrBase.Location = New Point(iUcrBaseXLocation, 400)
@@ -1006,9 +1023,12 @@ Public Class dlgDescribeTwoVariable
                     cmdFormatTable.Location = New Point(330, 450)
                 End If
             ElseIf IsNumericByFactor() Then
-                ucrBase.Location = New Point(iUcrBaseXLocation, 319)
-                Me.Size = New Point(iDialogueXsize, 415)
+                ucrSaveTable.Location = New Point(iUcrBaseXLocation, 329)
+                ucrSaveTable.Size = New Point(350, 30)
+                ucrBase.Location = New Point(iUcrBaseXLocation, 369)
+                Me.Size = New Point(iDialogueXsize, 465)
             ElseIf IsFactorByFactor() Then
+                ucrSaveTable.Size = New Point(310, 20)
                 ucrBase.Location = New Point(iUcrBaseXLocation, 395)
                 Me.Size = New Point(iDialogueXsize, 485)
                 cmdFormatTable.Location = New Point(330, 370)
@@ -1017,10 +1037,12 @@ Public Class dlgDescribeTwoVariable
                 Me.Size = New Point(iDialogueXsize, 425)
             End If
         ElseIf rdoThreeVariable.Checked Then
-
+            ucrSaveTable.Size = New Point(310, 20)
             If IsNumericByNumericByFactor() OrElse IsNumericByNumericByNumeric() OrElse IsNumericByFactorByFactor() OrElse IsNumericByFactorByNumeric() Then
-                ucrBase.Location = New Point(iUcrBaseXLocation, 353)
-                Me.Size = New Point(iDialogueXsize, 450)
+                ucrSaveTable.Location = New Point(iUcrBaseXLocation, 363)
+                ucrSaveTable.Size = New Point(350, 30)
+                ucrBase.Location = New Point(iUcrBaseXLocation, 403)
+                Me.Size = New Point(iDialogueXsize, 500)
             ElseIf IsFactorByFactorByFactor() Then
                 ucrBase.Location = New Point(iUcrBaseXLocation, 370)
                 Me.Size = New Point(iDialogueXsize, 465)
@@ -1036,6 +1058,8 @@ Public Class dlgDescribeTwoVariable
                 cmdFormatTable.Location = New Point(330, 300)
             End If
         Else
+            ucrSaveTable.Location = New Point(iUcrBaseXLocation, 290)
+            ucrSaveTable.Size = New Point(350, 30)
             ucrBase.Location = New Point(iUcrBaseXLocation, 333)
             Me.Size = New Point(iDialogueXsize, 430)
         End If

--- a/instat/dlgDescribeTwoVariable.vb
+++ b/instat/dlgDescribeTwoVariable.vb
@@ -634,6 +634,9 @@ Public Class dlgDescribeTwoVariable
             ucrChkSwapXYVar.Visible = IsNumericByNumeric() OrElse IsFactorByNumeric()
             ucrChkCorrelations.Visible = IsNumericByNumeric()
             cmdMissingOptions.Visible = ucrChkOmitMissing.Checked
+            If IsNumericByFactor() Then
+                ucrSaveTable.Visible = True
+            End If
         End If
         If rdoThreeVariable.Checked Then
 
@@ -719,7 +722,6 @@ Public Class dlgDescribeTwoVariable
                 ucrChkMeans.Visible = True
                 ucrChkLevSig.Visible = True
                 ucrChkTotal.Visible = True
-                ucrSaveTable.Location = New Point(iUcrBaseXLocation, 450)
                 ucrChkTotal.Location = New Point(310, 189)
                 ucrChkMeans.Location = New Point(310, 210)
                 ucrChkLevSig.Location = New Point(397, 186)
@@ -970,13 +972,6 @@ Public Class dlgDescribeTwoVariable
         ChangeBaseRCode()
     End Sub
 
-    'Private Sub CheckSaveControlVisibility()
-    '    If (Not ucrReceiverFirstVars.IsEmpty AndAlso Not ucrReceiverSecondTwoVariableFactor.IsEmpty) OrElse Not ucrReceiverSkimrGroupByFactor.IsEmpty OrElse
-    '        Not ucrReceiverSecondSkimrGroupByFactor.IsEmpty OrElse Not ucrReceiverThreeVariableThirdVariable.IsEmpty Then
-    '        ChangeBaseRCode()
-    '    End If
-    'End Sub
-
     Private Sub ucrPnlDescribe_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlDescribe.ControlValueChanged
 
         ucrReceiverFirstVars.SetMeAsReceiver()
@@ -1031,7 +1026,7 @@ Public Class dlgDescribeTwoVariable
                     cmdFormatTable.Location = New Point(330, 450)
                 End If
             ElseIf IsNumericByFactor() Then
-                ucrSaveTable.Location = New Point(iUcrBaseXLocation, 349)
+                ucrSaveTable.Location = New Point(iUcrBaseXLocation, 339)
                 ucrSaveTable.Size = New Point(350, 20)
                 ucrBase.Location = New Point(iUcrBaseXLocation, 369)
                 Me.Size = New Point(iDialogueXsize, 465)


### PR DESCRIPTION
@rdstern @lilyclements @fran2or @berylwaswa @Vitalis95 
This PR adds the `Store Model` save control to the 2/3 Summarise dialog.

### Before asking for review

**Developer Testing Checklist**
- [x] Runs without errors  
- [x] OK disabled when dialog is incomplete or invalid  
- [x] OK enabled only when required inputs are valid
- [x] Reset returns dialog to its default/sensible state
- [x] Invalid inputs are handled cleanly (e.g. negative, too-large, empty, impossible combos)
- [x] Running twice with different settings behaves consistently (e.g., open → run → close → reopen → change options checked → run again)
- [ ] All AI/bot comments addressed (fixed, intentionally ignored with explanation, or queried)
