### PR TITLE
Adjusted `Save Table` Checkbox Visibility in the 2/3 Summary Dialog

### DIFF
--- a/instat/dlgDescribeTwoVariable.Designer.vb
+++ b/instat/dlgDescribeTwoVariable.Designer.vb
@@ -690,6 +690,7 @@ Partial Class dlgDescribeTwoVariable
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ClientSize = New System.Drawing.Size(482, 550)
+        Me.Controls.Add(Me.ucrSaveTable)
         Me.Controls.Add(Me.ucrReorderSummary)
         Me.Controls.Add(Me.grpDisplayVars)
         Me.Controls.Add(Me.ucrChkDisplayMargins)
@@ -704,7 +705,6 @@ Partial Class dlgDescribeTwoVariable
         Me.Controls.Add(Me.ucrReceiverThreeVariableSecondFactor)
         Me.Controls.Add(Me.ucrReceiverSecondTwoVariableFactor)
         Me.Controls.Add(Me.ucrReceiverFirstVars)
-        Me.Controls.Add(Me.ucrSaveTable)
         Me.Controls.Add(Me.grpDisplay)
         Me.Controls.Add(Me.ucrInputMarginName)
         Me.Controls.Add(Me.lblMarginName)


### PR DESCRIPTION
This PR adjusts the Save Table checkbox visibility in the 2/3 Summary dialog so it is fully visible. Fixes issue https://github.com/IDEMSInternational/R-Instat/issues/10421
And also corrects the mistakes in PR #10432

@lilyclements @Vitalis95 @berylwaswa @rdstern Kindly review