### PR TITLE
Devtools update

### DIFF
--- a/instat/DlgUseDate.vb
+++ b/instat/DlgUseDate.vb
@@ -213,7 +213,6 @@ Public Class dlgUseDate
         SetRCodeforControls(True)
         TestOKEnabled()
     End Sub
-
     Private Sub SetDefaultColumn()
         If strDefaultDataFrame <> "" Then
             ucrSelectorUseDate.SetDataframe(strDefaultDataFrame)

--- a/instat/dlgRPackages.vb
+++ b/instat/dlgRPackages.vb
@@ -86,9 +86,9 @@ Public Class dlgInstallRPackage
         clsDetachFunction.SetRCommand("detach_package")
         clsDetachFunction.AddParameter("unload ", "TRUE", iPosition:=1)
 
-        clsRepositoryFunction.SetRCommand("install_github")
-        clsRepositoryFunction.SetPackageName("devtools")
-        clsRepositoryFunction.AddParameter("upgrade", Chr(34) & "never" & Chr(34), iPosition:=1)
+        clsRepositoryFunction.SetRCommand("pak")
+        clsRepositoryFunction.SetPackageName("pak")
+        clsRepositoryFunction.AddParameter("ask", "FALSE", iPosition:=1)
 
         clsAfterOptionsFunc.SetRCommand("options")
         clsAfterOptionsFunc.AddParameter(strParameterName:="warn", strParameterValue:="0")

--- a/scripts/generate_r_scripts.py
+++ b/scripts/generate_r_scripts.py
@@ -31,7 +31,7 @@ Package types
 
 Package options (optional JSON fields)
 --------------------------------------
-    force               bool  — adds force = TRUE to pak::pak()
+    force               bool  — adds ask = FALSE to pak::pak()
     install_dependencies  bool  — sets the dependencies argument.
                           Defaults to FALSE if not present in the JSON entry.
 """
@@ -91,8 +91,8 @@ def _github_line(pkg: dict) -> str:
     deps_r = "TRUE" if _install_deps(pkg) else "FALSE"
     parts = [f'pak::pak("{pkg["installed_from"]}"']
     parts.append(f"dependencies = {deps_r}")
-    if pkg.get("force"):
-        parts.append("force = TRUE")
+    if pkg.get("ask"):
+        parts.append("ask = FALSE")
     parts.append("ask = FALSE")
     return ", ".join(parts) + ")"
 

--- a/scripts/generate_r_scripts.py
+++ b/scripts/generate_r_scripts.py
@@ -91,8 +91,6 @@ def _github_line(pkg: dict) -> str:
     deps_r = "TRUE" if _install_deps(pkg) else "FALSE"
     parts = [f'pak::pak("{pkg["installed_from"]}"']
     parts.append(f"dependencies = {deps_r}")
-    if pkg.get("ask"):
-        parts.append("ask = FALSE")
     parts.append("ask = FALSE")
     return ", ".join(parts) + ")"
 

--- a/scripts/generate_r_scripts.py
+++ b/scripts/generate_r_scripts.py
@@ -25,13 +25,13 @@ Package types
                 Packages sharing the same priority + repo are batched into a
                 single install.packages(c(...)) call.
     github      GitHub package; installed via
-                    devtools::install_github(repo, ...)
+                    pak::pak(repo, ...)
                 The .libPaths() internal-library block is inserted automatically
                 before the first github-type package.
 
 Package options (optional JSON fields)
 --------------------------------------
-    force               bool  — adds force = TRUE to devtools::install_github()
+    force               bool  — adds force = TRUE to pak::pak()
     install_dependencies  bool  — sets the dependencies argument.
                           Defaults to FALSE if not present in the JSON entry.
 """
@@ -89,11 +89,11 @@ def _group_key(pkg):
 
 def _github_line(pkg: dict) -> str:
     deps_r = "TRUE" if _install_deps(pkg) else "FALSE"
-    parts = [f'devtools::install_github("{pkg["installed_from"]}"']
+    parts = [f'pak::pak("{pkg["installed_from"]}"']
     parts.append(f"dependencies = {deps_r}")
     if pkg.get("force"):
         parts.append("force = TRUE")
-    parts.append('upgrade = "never"')
+    parts.append("ask = FALSE")
     return ", ".join(parts) + ")"
 
 

--- a/scripts/generate_r_scripts.py
+++ b/scripts/generate_r_scripts.py
@@ -31,7 +31,7 @@ Package types
 
 Package options (optional JSON fields)
 --------------------------------------
-    force               bool  — adds ask = FALSE to pak::pak()
+    force                 (to remove now) bool  for devtools::install_github with force = TRUE. No equivalent needed now we are using pak::pak
     install_dependencies  bool  — sets the dependencies argument.
                           Defaults to FALSE if not present in the JSON entry.
 """


### PR DESCRIPTION
Switched from devtools to pak for GitHub package installs

Replaced the use of `devtools` with `pak` for installing GitHub 
packages in both `dlgRPackages.vb` and `generate_r_scripts.py`. 

In `dlgRPackages.vb`:
- Updated `SetRCommand` to use `"pak"` instead of `"install_github"`.
- Updated `SetPackageName` to `"pak"`.
- Replaced `"upgrade = 'never'"` with `"ask = FALSE"`.

In `generate_r_scripts.py`:
- Changed GitHub package installation logic to use `pak::pak()`.
- Updated `_github_line` to reflect `pak` syntax.
- Removed `upgrade = "never"` and added `ask = FALSE`.

These changes modernize the package installation process by adopting 
`pak`, which offers better performance and dependency handling.

fully addressing issue #10431 

