### PR TITLE
Created dummy empty dialogs for each

### DIFF
--- a/instat/dlgExperimentsDesign.Designer.vb
+++ b/instat/dlgExperimentsDesign.Designer.vb
@@ -1,0 +1,115 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
+Partial Class dlgExperimentsDesign
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()>
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()>
+    Private Sub InitializeComponent()
+        Me.lblFirstVariables = New System.Windows.Forms.Label()
+        Me.ucrSaveExperimentsDesign = New instat.ucrSave()
+        Me.ucrReceiverFirstVariables = New instat.ucrReceiverMultiple()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.ucrSelectorExperimentsDesign = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.SuspendLayout()
+        '
+        'lblFirstVariables
+        '
+        Me.lblFirstVariables.AutoSize = True
+        Me.lblFirstVariables.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblFirstVariables.Location = New System.Drawing.Point(377, 64)
+        Me.lblFirstVariables.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblFirstVariables.Name = "lblFirstVariables"
+        Me.lblFirstVariables.Size = New System.Drawing.Size(68, 16)
+        Me.lblFirstVariables.TabIndex = 25
+        Me.lblFirstVariables.Tag = ""
+        Me.lblFirstVariables.Text = "Variables:"
+        '
+        'ucrSaveExperimentsDesign
+        '
+        Me.ucrSaveExperimentsDesign.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSaveExperimentsDesign.Location = New System.Drawing.Point(12, 368)
+        Me.ucrSaveExperimentsDesign.Margin = New System.Windows.Forms.Padding(5, 6, 5, 6)
+        Me.ucrSaveExperimentsDesign.Name = "ucrSaveExperimentsDesign"
+        Me.ucrSaveExperimentsDesign.Size = New System.Drawing.Size(408, 30)
+        Me.ucrSaveExperimentsDesign.TabIndex = 27
+        '
+        'ucrReceiverFirstVariables
+        '
+        Me.ucrReceiverFirstVariables.AutoSize = True
+        Me.ucrReceiverFirstVariables.frmParent = Me
+        Me.ucrReceiverFirstVariables.Location = New System.Drawing.Point(377, 82)
+        Me.ucrReceiverFirstVariables.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverFirstVariables.Name = "ucrReceiverFirstVariables"
+        Me.ucrReceiverFirstVariables.Selector = Nothing
+        Me.ucrReceiverFirstVariables.Size = New System.Drawing.Size(160, 97)
+        Me.ucrReceiverFirstVariables.strNcFilePath = ""
+        Me.ucrReceiverFirstVariables.TabIndex = 26
+        Me.ucrReceiverFirstVariables.ucrSelector = Nothing
+        '
+        'ucrBase
+        '
+        Me.ucrBase.AutoSize = True
+        Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrBase.Location = New System.Drawing.Point(12, 425)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(8, 7, 8, 7)
+        Me.ucrBase.Name = "ucrBase"
+        Me.ucrBase.Size = New System.Drawing.Size(511, 65)
+        Me.ucrBase.TabIndex = 24
+        '
+        'ucrSelectorExperimentsDesign
+        '
+        Me.ucrSelectorExperimentsDesign.AutoSize = True
+        Me.ucrSelectorExperimentsDesign.bDropUnusedFilterLevels = False
+        Me.ucrSelectorExperimentsDesign.bShowHiddenColumns = False
+        Me.ucrSelectorExperimentsDesign.bUseCurrentFilter = True
+        Me.ucrSelectorExperimentsDesign.Location = New System.Drawing.Point(12, 43)
+        Me.ucrSelectorExperimentsDesign.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrSelectorExperimentsDesign.Name = "ucrSelectorExperimentsDesign"
+        Me.ucrSelectorExperimentsDesign.Size = New System.Drawing.Size(284, 227)
+        Me.ucrSelectorExperimentsDesign.TabIndex = 5
+        '
+        'dlgExperimentsDesign
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 16.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(568, 507)
+        Me.Controls.Add(Me.ucrSaveExperimentsDesign)
+        Me.Controls.Add(Me.ucrReceiverFirstVariables)
+        Me.Controls.Add(Me.lblFirstVariables)
+        Me.Controls.Add(Me.ucrBase)
+        Me.Controls.Add(Me.ucrSelectorExperimentsDesign)
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.MaximizeBox = False
+        Me.MinimizeBox = False
+        Me.Name = "dlgExperimentsDesign"
+        Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
+        Me.Text = "dlgExperimentsGreaterthanDesign"
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents ucrSelectorExperimentsDesign As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrBase As ucrButtons
+    Friend WithEvents ucrReceiverFirstVariables As ucrReceiverMultiple
+    Friend WithEvents lblFirstVariables As Label
+    Friend WithEvents ucrSaveExperimentsDesign As ucrSave
+End Class

--- a/instat/dlgExperimentsDesign.resx
+++ b/instat/dlgExperimentsDesign.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/instat/dlgExperimentsDesign.vb
+++ b/instat/dlgExperimentsDesign.vb
@@ -1,0 +1,74 @@
+﻿' R- Instat
+' Copyright (C) 2015-2017
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License 
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Imports instat
+Imports instat.Translations
+Public Class dlgExperimentsDesign
+
+    Private bFirstLoad As Boolean = True
+
+    Private Sub dlgExperimentsDesign_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        If bFirstLoad Then
+            InitialiseDialog()
+            bFirstLoad = False
+        End If
+
+    End Sub
+
+    Private Sub InitialiseDialog()
+
+
+    End Sub
+
+    Private Sub SetDefaults()
+
+        TestOkEnabled()
+    End Sub
+
+    Public Sub SetRCodeForControls(bReset As Boolean)
+
+
+    End Sub
+
+    Private Sub TestOkEnabled()
+
+    End Sub
+
+    Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
+        SetDefaults()
+        SetRCodeForControls(True)
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrReceiverFirstVariables_Load(sender As Object, e As EventArgs) Handles ucrReceiverFirstVariables.Load
+
+    End Sub
+
+    Private Sub ucrBase_Load(sender As Object, e As EventArgs) Handles ucrBase.Load
+
+    End Sub
+
+    Private Sub ucrSaveExperimentsDesign_Load(sender As Object, e As EventArgs) Handles ucrSaveExperimentsDesign.Load
+
+    End Sub
+
+    Private Sub ucrSelectorExperimentsDesign_Load(sender As Object, e As EventArgs) Handles ucrSelectorExperimentsDesign.Load
+
+    End Sub
+End Class
+
+
+

--- a/instat/dlgExperimentsOneButton.Designer.vb
+++ b/instat/dlgExperimentsOneButton.Designer.vb
@@ -1,0 +1,116 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
+Partial Class dlgExperimentsOneButton
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()>
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()>
+    Private Sub InitializeComponent()
+        Me.lblFirstVariables = New System.Windows.Forms.Label()
+        Me.ucrSaveExperimentsOneButton = New instat.ucrSave()
+        Me.ucrReceiverFirstVariables = New instat.ucrReceiverMultiple()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.ucrSelectorExperimentsOneButton = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.SuspendLayout()
+        '
+        'lblFirstVariables
+        '
+        Me.lblFirstVariables.AutoSize = True
+        Me.lblFirstVariables.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblFirstVariables.Location = New System.Drawing.Point(377, 64)
+        Me.lblFirstVariables.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblFirstVariables.Name = "lblFirstVariables"
+        Me.lblFirstVariables.Size = New System.Drawing.Size(68, 16)
+        Me.lblFirstVariables.TabIndex = 25
+        Me.lblFirstVariables.Tag = ""
+        Me.lblFirstVariables.Text = "Variables:"
+        '
+        'ucrSaveExperimentsOneButton
+        '
+        Me.ucrSaveExperimentsOneButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSaveExperimentsOneButton.Location = New System.Drawing.Point(12, 368)
+        Me.ucrSaveExperimentsOneButton.Margin = New System.Windows.Forms.Padding(5, 6, 5, 6)
+        Me.ucrSaveExperimentsOneButton.Name = "ucrSaveExperimentsOneButton"
+        Me.ucrSaveExperimentsOneButton.Size = New System.Drawing.Size(408, 30)
+        Me.ucrSaveExperimentsOneButton.TabIndex = 27
+        '
+        'ucrReceiverFirstVariables
+        '
+        Me.ucrReceiverFirstVariables.AutoSize = True
+        Me.ucrReceiverFirstVariables.frmParent = Me
+        Me.ucrReceiverFirstVariables.Location = New System.Drawing.Point(377, 82)
+        Me.ucrReceiverFirstVariables.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverFirstVariables.Name = "ucrReceiverFirstVariables"
+        Me.ucrReceiverFirstVariables.Selector = Nothing
+        Me.ucrReceiverFirstVariables.Size = New System.Drawing.Size(160, 97)
+        Me.ucrReceiverFirstVariables.strNcFilePath = ""
+        Me.ucrReceiverFirstVariables.TabIndex = 26
+        Me.ucrReceiverFirstVariables.ucrSelector = Nothing
+        '
+        'ucrBase
+        '
+        Me.ucrBase.AutoSize = True
+        Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrBase.Location = New System.Drawing.Point(12, 425)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(8, 7, 8, 7)
+        Me.ucrBase.Name = "ucrBase"
+        Me.ucrBase.Size = New System.Drawing.Size(511, 65)
+        Me.ucrBase.TabIndex = 24
+        '
+        'ucrSelectorExperimentsOneButton
+        '
+        Me.ucrSelectorExperimentsOneButton.AutoSize = True
+        Me.ucrSelectorExperimentsOneButton.bDropUnusedFilterLevels = False
+        Me.ucrSelectorExperimentsOneButton.bShowHiddenColumns = False
+        Me.ucrSelectorExperimentsOneButton.bUseCurrentFilter = True
+        Me.ucrSelectorExperimentsOneButton.Location = New System.Drawing.Point(12, 43)
+        Me.ucrSelectorExperimentsOneButton.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrSelectorExperimentsOneButton.Name = "ucrSelectorExperimentsOneButton"
+        Me.ucrSelectorExperimentsOneButton.Size = New System.Drawing.Size(284, 227)
+        Me.ucrSelectorExperimentsOneButton.TabIndex = 5
+        '
+        'dlgExperimentsOneButton
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 16.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(568, 507)
+        Me.Controls.Add(Me.ucrSaveExperimentsOneButton)
+        Me.Controls.Add(Me.ucrReceiverFirstVariables)
+        Me.Controls.Add(Me.lblFirstVariables)
+        Me.Controls.Add(Me.ucrBase)
+        Me.Controls.Add(Me.ucrSelectorExperimentsOneButton)
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.MaximizeBox = False
+        Me.MinimizeBox = False
+        Me.Name = "dlgExperimentsOneButton"
+        Me.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show
+        Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
+        Me.Text = "One Button"
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents ucrSelectorExperimentsOneButton As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrBase As ucrButtons
+    Friend WithEvents ucrReceiverFirstVariables As ucrReceiverMultiple
+    Friend WithEvents lblFirstVariables As Label
+    Friend WithEvents ucrSaveExperimentsOneButton As ucrSave
+End Class

--- a/instat/dlgExperimentsOneButton.resx
+++ b/instat/dlgExperimentsOneButton.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/instat/dlgExperimentsOneButton.vb
+++ b/instat/dlgExperimentsOneButton.vb
@@ -1,0 +1,77 @@
+﻿' R- Instat
+' Copyright (C) 2015-2017
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License 
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Imports instat
+Imports instat.Translations
+Public Class dlgExperimentsOneButton
+
+    Private bFirstLoad As Boolean = True
+
+    Private Sub dlgExperimentsOneButton_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        If bFirstLoad Then
+            InitialiseDialog()
+            bFirstLoad = False
+        End If
+
+    End Sub
+
+    Private Sub InitialiseDialog()
+
+
+    End Sub
+
+    Private Sub SetDefaults()
+
+        TestOkEnabled()
+    End Sub
+
+    Public Sub SetRCodeForControls(bReset As Boolean)
+
+
+    End Sub
+
+    Private Sub TestOkEnabled()
+
+    End Sub
+
+    Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
+        SetDefaults()
+        SetRCodeForControls(True)
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrReceiverFirstVariables_Load(sender As Object, e As EventArgs) Handles ucrReceiverFirstVariables.Load
+
+    End Sub
+
+    Private Sub ucrBase_Load(sender As Object, e As EventArgs) Handles ucrBase.Load
+
+    End Sub
+
+    Private Sub ucrSaveExperimentsOneButton_Load(sender As Object, e As EventArgs) Handles ucrSaveExperimentsOneButton.Load
+
+    End Sub
+
+    Private Sub ucrSelectorExperimentsOneButton_Load(sender As Object, e As EventArgs) Handles ucrSelectorExperimentsOneButton.Load
+
+    End Sub
+End Class
+
+
+
+
+
+

--- a/instat/dlgModelMultipleComparisons.Designer.vb
+++ b/instat/dlgModelMultipleComparisons.Designer.vb
@@ -1,0 +1,114 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
+Partial Class dlgModelMultipleComparisons
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()>
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()>
+    Private Sub InitializeComponent()
+        Me.lblFirstVariables = New System.Windows.Forms.Label()
+        Me.ucrSaveModelMultipleComparisons = New instat.ucrSave()
+        Me.ucrReceiverFirstVariables = New instat.ucrReceiverMultiple()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.ucrSelectorModelMultipleComparisons = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.SuspendLayout()
+        '
+        'lblFirstVariables
+        '
+        Me.lblFirstVariables.AutoSize = True
+        Me.lblFirstVariables.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblFirstVariables.Location = New System.Drawing.Point(377, 64)
+        Me.lblFirstVariables.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblFirstVariables.Name = "lblFirstVariables"
+        Me.lblFirstVariables.Size = New System.Drawing.Size(68, 16)
+        Me.lblFirstVariables.TabIndex = 25
+        Me.lblFirstVariables.Tag = ""
+        Me.lblFirstVariables.Text = "Variables:"
+        '
+        'ucrSaveModelMultipleComparisons
+        '
+        Me.ucrSaveModelMultipleComparisons.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSaveModelMultipleComparisons.Location = New System.Drawing.Point(12, 368)
+        Me.ucrSaveModelMultipleComparisons.Margin = New System.Windows.Forms.Padding(5, 6, 5, 6)
+        Me.ucrSaveModelMultipleComparisons.Name = "ucrSaveModelMultipleComparisons"
+        Me.ucrSaveModelMultipleComparisons.Size = New System.Drawing.Size(408, 30)
+        Me.ucrSaveModelMultipleComparisons.TabIndex = 27
+        '
+        'ucrReceiverFirstVariables
+        '
+        Me.ucrReceiverFirstVariables.AutoSize = True
+        Me.ucrReceiverFirstVariables.frmParent = Me
+        Me.ucrReceiverFirstVariables.Location = New System.Drawing.Point(377, 82)
+        Me.ucrReceiverFirstVariables.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverFirstVariables.Name = "ucrReceiverFirstVariables"
+        Me.ucrReceiverFirstVariables.Selector = Nothing
+        Me.ucrReceiverFirstVariables.Size = New System.Drawing.Size(160, 97)
+        Me.ucrReceiverFirstVariables.strNcFilePath = ""
+        Me.ucrReceiverFirstVariables.TabIndex = 26
+        Me.ucrReceiverFirstVariables.ucrSelector = Nothing
+        '
+        'ucrBase
+        '
+        Me.ucrBase.AutoSize = True
+        Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrBase.Location = New System.Drawing.Point(12, 425)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(8, 7, 8, 7)
+        Me.ucrBase.Name = "ucrBase"
+        Me.ucrBase.Size = New System.Drawing.Size(511, 65)
+        Me.ucrBase.TabIndex = 24
+        '
+        'ucrSelectorModelMultipleComparisons
+        '
+        Me.ucrSelectorModelMultipleComparisons.AutoSize = True
+        Me.ucrSelectorModelMultipleComparisons.bDropUnusedFilterLevels = False
+        Me.ucrSelectorModelMultipleComparisons.bShowHiddenColumns = False
+        Me.ucrSelectorModelMultipleComparisons.bUseCurrentFilter = True
+        Me.ucrSelectorModelMultipleComparisons.Location = New System.Drawing.Point(12, 43)
+        Me.ucrSelectorModelMultipleComparisons.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrSelectorModelMultipleComparisons.Name = "ucrSelectorModelMultipleComparisons"
+        Me.ucrSelectorModelMultipleComparisons.Size = New System.Drawing.Size(284, 227)
+        Me.ucrSelectorModelMultipleComparisons.TabIndex = 5
+        '
+        'dlgModelMultipleComparisons
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 16.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(568, 507)
+        Me.Controls.Add(Me.ucrSaveModelMultipleComparisons)
+        Me.Controls.Add(Me.ucrReceiverFirstVariables)
+        Me.Controls.Add(Me.lblFirstVariables)
+        Me.Controls.Add(Me.ucrBase)
+        Me.Controls.Add(Me.ucrSelectorModelMultipleComparisons)
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(4)
+        Me.MinimizeBox = False
+        Me.Name = "dlgModelMultipleComparisons"
+        Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
+        Me.Text = "Multiple Comparisons"
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents ucrSelectorModelMultipleComparisons As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrBase As ucrButtons
+    Friend WithEvents ucrReceiverFirstVariables As ucrReceiverMultiple
+    Friend WithEvents lblFirstVariables As Label
+    Friend WithEvents ucrSaveModelMultipleComparisons As ucrSave
+End Class

--- a/instat/dlgModelMultipleComparisons.resx
+++ b/instat/dlgModelMultipleComparisons.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/instat/dlgModelMultipleComparisons.vb
+++ b/instat/dlgModelMultipleComparisons.vb
@@ -1,0 +1,79 @@
+﻿' R- Instat
+' Copyright (C) 2015-2017
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License 
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Imports instat
+Imports instat.Translations
+Public Class dlgModelMultipleComparisons
+
+
+    Private bFirstLoad As Boolean = True
+
+    Private Sub dlgModelMultipleComparisons_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        If bFirstLoad Then
+            InitialiseDialog()
+            bFirstLoad = False
+        End If
+
+    End Sub
+
+    Private Sub InitialiseDialog()
+
+
+    End Sub
+
+    Private Sub SetDefaults()
+
+        TestOkEnabled()
+    End Sub
+
+    Public Sub SetRCodeForControls(bReset As Boolean)
+
+
+    End Sub
+
+    Private Sub TestOkEnabled()
+
+    End Sub
+
+    Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
+        SetDefaults()
+        SetRCodeForControls(True)
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrReceiverFirstVariables_Load(sender As Object, e As EventArgs) Handles ucrReceiverFirstVariables.Load
+
+    End Sub
+
+    Private Sub ucrBase_Load(sender As Object, e As EventArgs) Handles ucrBase.Load
+
+    End Sub
+
+    Private Sub ucrSaveModelMultipleComparisons_Load(sender As Object, e As EventArgs) Handles ucrSaveModelMultipleComparisons.Load
+
+    End Sub
+
+    Private Sub ucrModelMultipleComparisons_Load(sender As Object, e As EventArgs) Handles ucrSelectorModelMultipleComparisons.Load
+
+    End Sub
+End Class
+
+
+
+
+
+
+

--- a/instat/dlgPrepareDataReshapeUnnest.Designer.vb
+++ b/instat/dlgPrepareDataReshapeUnnest.Designer.vb
@@ -1,0 +1,118 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
+Partial Class dlgPrepareDataReshapeUnnest
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()>
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()>
+    Private Sub InitializeComponent()
+        Me.lblFirstVariables = New System.Windows.Forms.Label()
+        Me.ucrSavePrepareDataReshapeUnnest = New instat.ucrSave()
+        Me.ucrReceiverFirstVariables = New instat.ucrReceiverMultiple()
+        Me.ucrBase = New instat.ucrButtons()
+        Me.ucrSelectorPrepareDataReshapeUnnest = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.SuspendLayout()
+        '
+        'lblFirstVariables
+        '
+        Me.lblFirstVariables.AutoSize = True
+        Me.lblFirstVariables.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblFirstVariables.Location = New System.Drawing.Point(377, 64)
+        Me.lblFirstVariables.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblFirstVariables.Name = "lblFirstVariables"
+        Me.lblFirstVariables.Size = New System.Drawing.Size(68, 16)
+        Me.lblFirstVariables.TabIndex = 25
+        Me.lblFirstVariables.Tag = ""
+        Me.lblFirstVariables.Text = "Variables:"
+        '
+        'ucrSavePrepareDataReshapeUnnest
+        '
+        Me.ucrSavePrepareDataReshapeUnnest.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSavePrepareDataReshapeUnnest.Location = New System.Drawing.Point(12, 368)
+        Me.ucrSavePrepareDataReshapeUnnest.Margin = New System.Windows.Forms.Padding(5, 6, 5, 6)
+        Me.ucrSavePrepareDataReshapeUnnest.Name = "ucrSavePrepareDataReshapeUnnest"
+        Me.ucrSavePrepareDataReshapeUnnest.Size = New System.Drawing.Size(408, 30)
+        Me.ucrSavePrepareDataReshapeUnnest.TabIndex = 27
+        '
+        'ucrReceiverFirstVariables
+        '
+        Me.ucrReceiverFirstVariables.AutoSize = True
+        Me.ucrReceiverFirstVariables.frmParent = Me
+        Me.ucrReceiverFirstVariables.Location = New System.Drawing.Point(377, 82)
+        Me.ucrReceiverFirstVariables.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverFirstVariables.Name = "ucrReceiverFirstVariables"
+        Me.ucrReceiverFirstVariables.Selector = Nothing
+        Me.ucrReceiverFirstVariables.Size = New System.Drawing.Size(160, 97)
+        Me.ucrReceiverFirstVariables.strNcFilePath = ""
+        Me.ucrReceiverFirstVariables.TabIndex = 26
+        Me.ucrReceiverFirstVariables.ucrSelector = Nothing
+        '
+        'ucrBase
+        '
+        Me.ucrBase.AutoSize = True
+        Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrBase.Location = New System.Drawing.Point(12, 425)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(8, 7, 8, 7)
+        Me.ucrBase.Name = "ucrBase"
+        Me.ucrBase.Size = New System.Drawing.Size(511, 65)
+        Me.ucrBase.TabIndex = 24
+        '
+        'ucrSelectorPrepareDataReshapeUnnest
+        '
+        Me.ucrSelectorPrepareDataReshapeUnnest.AutoSize = True
+        Me.ucrSelectorPrepareDataReshapeUnnest.bDropUnusedFilterLevels = False
+        Me.ucrSelectorPrepareDataReshapeUnnest.bShowHiddenColumns = False
+        Me.ucrSelectorPrepareDataReshapeUnnest.bUseCurrentFilter = True
+        Me.ucrSelectorPrepareDataReshapeUnnest.Location = New System.Drawing.Point(12, 43)
+        Me.ucrSelectorPrepareDataReshapeUnnest.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrSelectorPrepareDataReshapeUnnest.Name = "ucrSelectorPrepareDataReshapeUnnest"
+        Me.ucrSelectorPrepareDataReshapeUnnest.Size = New System.Drawing.Size(284, 227)
+        Me.ucrSelectorPrepareDataReshapeUnnest.TabIndex = 5
+        '
+        'dlgPrepareDataReshapeUnnest
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 16.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(568, 507)
+        Me.Controls.Add(Me.ucrSavePrepareDataReshapeUnnest)
+        Me.Controls.Add(Me.ucrReceiverFirstVariables)
+        Me.Controls.Add(Me.lblFirstVariables)
+        Me.Controls.Add(Me.ucrBase)
+        Me.Controls.Add(Me.ucrSelectorPrepareDataReshapeUnnest)
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
+        Me.MaximizeBox = False
+        Me.MinimizeBox = False
+        Me.Name = "dlgPrepareDataReshapeUnnest"
+        Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
+        Me.Text = "Unnest"
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents ucrSelectorPrepareDataReshapeUnnest As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrBase As ucrButtons
+    Friend WithEvents ucrReceiverFirstVariables As ucrReceiverMultiple
+    Friend WithEvents lblFirstVariables As Label
+    Friend WithEvents ucrSavePrepareDataReshapeUnnest As ucrSave
+End Class
+
+
+

--- a/instat/dlgPrepareDataReshapeUnnest.resx
+++ b/instat/dlgPrepareDataReshapeUnnest.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/instat/dlgPrepareDataReshapeUnnest.vb
+++ b/instat/dlgPrepareDataReshapeUnnest.vb
@@ -1,0 +1,71 @@
+﻿' R- Instat
+' Copyright (C) 2015-2017
+'
+' This program is free software: you can redistribute it and/or modify
+' it under the terms of the GNU General Public License as published by
+' the Free Software Foundation, either version 3 of the License, or
+' (at your option) any later version.
+'
+' This program is distributed in the hope that it will be useful,
+' but WITHOUT ANY WARRANTY; without even the implied warranty of
+' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+' GNU General Public License for more details.
+'
+' You should have received a copy of the GNU General Public License 
+' along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Imports instat
+Imports instat.Translations
+Public Class dlgPrepareDataReshapeUnnest
+
+    Private bFirstLoad As Boolean = True
+
+    Private Sub dlgPrepareDataReshapeUnnest_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        If bFirstLoad Then
+            InitialiseDialog()
+            bFirstLoad = False
+        End If
+
+    End Sub
+
+    Private Sub InitialiseDialog()
+
+
+    End Sub
+
+    Private Sub SetDefaults()
+
+        TestOkEnabled()
+    End Sub
+
+    Public Sub SetRCodeForControls(bReset As Boolean)
+
+
+    End Sub
+
+    Private Sub TestOkEnabled()
+
+    End Sub
+
+    Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
+        SetDefaults()
+        SetRCodeForControls(True)
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrReceiverFirstVariables_Load(sender As Object, e As EventArgs) Handles ucrReceiverFirstVariables.Load
+
+    End Sub
+
+    Private Sub ucrBase_Load(sender As Object, e As EventArgs) Handles ucrBase.Load
+
+    End Sub
+
+    Private Sub ucrSavePrepareDataReshapeUnnest_Load(sender As Object, e As EventArgs) Handles ucrSavePrepareDataReshapeUnnest.Load
+
+    End Sub
+End Class
+
+
+
+

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -565,6 +565,7 @@ Partial Class frmMain
         Me.mnuPrepareColumnReshapeStack = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuPrepareColumnReshapeUnstack = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuPrepareColumnReshapeMerge = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuUnnest = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator11 = New System.Windows.Forms.ToolStripSeparator()
         Me.mnuPrepareAppendDataFrame = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuPrepareColumnReshapeSubset = New System.Windows.Forms.ToolStripMenuItem()
@@ -706,9 +707,12 @@ Partial Class frmMain
         Me.mnuOptionsByContextDescribeCompareTwoTreatments = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuOptionsByContextDescribeCompareMultipleTreatments = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuOptionsByContextDescribeBoxplot = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuExperimentsDesign = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuOptionsByContextModel = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuOptionsByContextModelFitModel = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuOptionsByContextGeneralFitModel = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuExperimentsOneButton = New System.Windows.Forms.ToolStripMenuItem()
+        Me.mnuMultipleComparisons = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuOptionsByContextCropModel = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuOptionsByContextCropModelApsimxExamples = New System.Windows.Forms.ToolStripMenuItem()
         Me.mnuProcurement = New System.Windows.Forms.ToolStripMenuItem()
@@ -2304,13 +2308,13 @@ Partial Class frmMain
         'mnuClimaticPrepareStartoftheRains
         '
         Me.mnuClimaticPrepareStartoftheRains.Name = "mnuClimaticPrepareStartoftheRains"
-        Me.mnuClimaticPrepareStartoftheRains.Size = New System.Drawing.Size(189, 22)
+        Me.mnuClimaticPrepareStartoftheRains.Size = New System.Drawing.Size(232, 26)
         Me.mnuClimaticPrepareStartoftheRains.Text = "Start of the Season..."
         '
         'mnuClimaticPrepareEndOfRains
         '
         Me.mnuClimaticPrepareEndOfRains.Name = "mnuClimaticPrepareEndOfRains"
-        Me.mnuClimaticPrepareEndOfRains.Size = New System.Drawing.Size(189, 22)
+        Me.mnuClimaticPrepareEndOfRains.Size = New System.Drawing.Size(232, 26)
         Me.mnuClimaticPrepareEndOfRains.Text = "End of the Season..."
         '
         'mnuClimaticPrepareLengthOfSeason
@@ -3743,7 +3747,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataFrame.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataFrameViewData, Me.mnuPrepareDataFrameRenameColumn, Me.mnuPrepareDataFrameDuplicateColumn, Me.mnuPrepareDataFrameRowNumbersNames, Me.ToolStripSeparator1, Me.mnuPrepareDataFrameSort, Me.mnuPrepareDataFrameFilterRows, Me.mnuPrepareDataFrameSelectColumns, Me.mnuPrepareDataFrameReplaceValues, Me.mnuPrepareDataFrameConvertColumns, Me.ToolStripSeparator2, Me.mnuPrepareDataFrameReorderColumns, Me.mnuPrepareDataFrameAddMergeColumns, Me.mnuPrepareDataFrameInsertColumnsRows, Me.mnuPrepareDataFrameDeleteColumnsRows, Me.mnuPrepareDataFrameProtectColumn, Me.mnuPrepareDataFrameFreezeColumns, Me.mnuPrepareDataframeColourByProperty})
         Me.mnuPrepareDataFrame.Name = "mnuPrepareDataFrame"
-        Me.mnuPrepareDataFrame.Size = New System.Drawing.Size(206, 26)
+        Me.mnuPrepareDataFrame.Size = New System.Drawing.Size(224, 26)
         Me.mnuPrepareDataFrame.Tag = "Data_Frame"
         Me.mnuPrepareDataFrame.Text = "Data Frame"
         '
@@ -3874,7 +3878,7 @@ Partial Class frmMain
         Me.mnuPrepareCheckData.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right
         Me.mnuPrepareCheckData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareCheckDataVisualiseData, Me.mnuPrepareCheckDataPivotTable, Me.ToolStripSeparator50, Me.mnuPrepareCheckDataDuplicates, Me.mnuPrepareCheckDataCompareColumns, Me.mnuPrepareCheckDataNonNumericCases, Me.ToolStripSeparator49, Me.mnuPrepareCheckDataBoxplot, Me.mnuPrepareCheckDataOneVariableSummarise, Me.mnuPrepareCheckDataOneVariableGraph, Me.mnuPrepareCheckDataOneWayFrequencies, Me.mnuPrepareCheckDataViewDeleteLabels, Me.ToolStripSeparator41, Me.mnuPrepareCheckDataExportOpenRefine, Me.mnuPrepareCheckDataImportOpenRefine, Me.ToolStripSeparator40, Me.mnuPreparePrepareToShareJitter, Me.mnuPrepareCheckDataPrePareToShareSdcPackage, Me.mnuPrepareCheckDataAnonymiseIDColumn})
         Me.mnuPrepareCheckData.Name = "mnuPrepareCheckData"
-        Me.mnuPrepareCheckData.Size = New System.Drawing.Size(206, 26)
+        Me.mnuPrepareCheckData.Size = New System.Drawing.Size(224, 26)
         Me.mnuPrepareCheckData.Text = "Check Data"
         '
         'mnuPrepareCheckDataVisualiseData
@@ -3997,25 +4001,25 @@ Partial Class frmMain
         'ToolStripSeparator6
         '
         Me.ToolStripSeparator6.Name = "ToolStripSeparator6"
-        Me.ToolStripSeparator6.Size = New System.Drawing.Size(203, 6)
+        Me.ToolStripSeparator6.Size = New System.Drawing.Size(221, 6)
         '
         'mnuPrepareCalculator
         '
         Me.mnuPrepareCalculator.Name = "mnuPrepareCalculator"
-        Me.mnuPrepareCalculator.Size = New System.Drawing.Size(206, 26)
+        Me.mnuPrepareCalculator.Size = New System.Drawing.Size(224, 26)
         Me.mnuPrepareCalculator.Tag = "Calculator..."
         Me.mnuPrepareCalculator.Text = "Calculator..."
         '
         'ToolStripSeparator79
         '
         Me.ToolStripSeparator79.Name = "ToolStripSeparator79"
-        Me.ToolStripSeparator79.Size = New System.Drawing.Size(203, 6)
+        Me.ToolStripSeparator79.Size = New System.Drawing.Size(221, 6)
         '
         'mnuPrepareColumnCalculate
         '
         Me.mnuPrepareColumnCalculate.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnNumericRegularSequence, Me.mnuPrepareColumnNumericEnter, Me.ToolStripSeparator25, Me.mnuPrepareColumnNumericRowSummaries, Me.mnuPrepareColumnNumericTransform, Me.mnuPrepareColumnNumericPolynomials, Me.ToolStripSeparator56, Me.mnuPrepareColumnNumericRandomSamples, Me.mnuPrepareColumnNumericPermuteRows})
         Me.mnuPrepareColumnCalculate.Name = "mnuPrepareColumnCalculate"
-        Me.mnuPrepareColumnCalculate.Size = New System.Drawing.Size(206, 26)
+        Me.mnuPrepareColumnCalculate.Size = New System.Drawing.Size(224, 26)
         Me.mnuPrepareColumnCalculate.Tag = "Column:_Calculate"
         Me.mnuPrepareColumnCalculate.Text = "Column: Numeric"
         '
@@ -4080,7 +4084,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnFactor.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnFactorConvertToFactor, Me.mnuPrepareColumnFactorRecodeNumeric, Me.mnuPrepareColumnFactorCountInFactor, Me.ToolStripSeparator12, Me.mnuPrepareColumnFactorRecodeFactor, Me.mnuPrepareColumnFactorCombineFactors, Me.mnuPrepareColumnFactorDummyVariables, Me.ToolStripSeparator14, Me.mnuPrepareColumnFactorLevelsLabels, Me.mnuPrepareColumnFactorReorderLevels, Me.mnuPrepareColumnFactorReferenceLevel, Me.mnuPrepareColumnFactorUnusedLevels, Me.mnuPrepareColumnFactorContrasts, Me.ToolStripSeparator19, Me.mnuPrepareColumnFactorFactorDataFrame})
         Me.mnuPrepareColumnFactor.Name = "mnuPrepareColumnFactor"
-        Me.mnuPrepareColumnFactor.Size = New System.Drawing.Size(206, 26)
+        Me.mnuPrepareColumnFactor.Size = New System.Drawing.Size(224, 26)
         Me.mnuPrepareColumnFactor.Tag = "Column:_Factor"
         Me.mnuPrepareColumnFactor.Text = "Column: Factor"
         '
@@ -4186,7 +4190,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnText.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnTextFindReplace, Me.mnuPrepareColumnTextSearch, Me.mnuPrepareColumnTextTransform, Me.mnuPrepareColumnTextSplit, Me.mnuPrepareColumnTextCombine, Me.mnuPrepareColumnTextMatch, Me.mnuPrepareColumnTextDistance})
         Me.mnuPrepareColumnText.Name = "mnuPrepareColumnText"
-        Me.mnuPrepareColumnText.Size = New System.Drawing.Size(206, 26)
+        Me.mnuPrepareColumnText.Size = New System.Drawing.Size(224, 26)
         Me.mnuPrepareColumnText.Tag = "Column:_Text"
         Me.mnuPrepareColumnText.Text = "Column: Text"
         '
@@ -4245,7 +4249,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnDate.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnDateGenerateDate, Me.mnuPrepareColumnDateMakeDate, Me.mnuPrepareColumnDateInfillMissingDates, Me.mnuPrepareColumnDateUseDate, Me.mnuPrepareColumnDateMakeTime, Me.mnuPrepareColumnDateUseTime})
         Me.mnuPrepareColumnDate.Name = "mnuPrepareColumnDate"
-        Me.mnuPrepareColumnDate.Size = New System.Drawing.Size(206, 26)
+        Me.mnuPrepareColumnDate.Size = New System.Drawing.Size(224, 26)
         Me.mnuPrepareColumnDate.Text = "Column: Date"
         '
         'mnuPrepareColumnDateGenerateDate
@@ -4292,7 +4296,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnDefine.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnDefineConvertColumns, Me.ToolStripSeparator55, Me.mnuPrepareColumnDefineCircular})
         Me.mnuPrepareColumnDefine.Name = "mnuPrepareColumnDefine"
-        Me.mnuPrepareColumnDefine.Size = New System.Drawing.Size(206, 26)
+        Me.mnuPrepareColumnDefine.Size = New System.Drawing.Size(224, 26)
         Me.mnuPrepareColumnDefine.Text = "Column: Define"
         '
         'mnuPrepareColumnDefineConvertColumns
@@ -4315,13 +4319,13 @@ Partial Class frmMain
         'ToolStripSeparator4
         '
         Me.ToolStripSeparator4.Name = "ToolStripSeparator4"
-        Me.ToolStripSeparator4.Size = New System.Drawing.Size(203, 6)
+        Me.ToolStripSeparator4.Size = New System.Drawing.Size(221, 6)
         '
         'mnuPrepareDataReshape
         '
-        Me.mnuPrepareDataReshape.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnReshapeColumnSummaries, Me.mnuPrepareColumnReshapeGeneralSummaries, Me.ToolStripSeparator10, Me.mnuPrepareColumnReshapeStack, Me.mnuPrepareColumnReshapeUnstack, Me.mnuPrepareColumnReshapeMerge, Me.ToolStripSeparator11, Me.mnuPrepareAppendDataFrame, Me.mnuPrepareColumnReshapeSubset, Me.mnuPrepareColumnReshapeRandomSubset, Me.mnuPrepareColumnReshapeTranspose, Me.mnuPrepareDataReshapeScaleOrDistance, Me.mnuPrepareDataReshapeRandomSplit})
+        Me.mnuPrepareDataReshape.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnReshapeColumnSummaries, Me.mnuPrepareColumnReshapeGeneralSummaries, Me.ToolStripSeparator10, Me.mnuPrepareColumnReshapeStack, Me.mnuPrepareColumnReshapeUnstack, Me.mnuPrepareColumnReshapeMerge, Me.mnuUnnest, Me.ToolStripSeparator11, Me.mnuPrepareAppendDataFrame, Me.mnuPrepareColumnReshapeSubset, Me.mnuPrepareColumnReshapeRandomSubset, Me.mnuPrepareColumnReshapeTranspose, Me.mnuPrepareDataReshapeScaleOrDistance, Me.mnuPrepareDataReshapeRandomSplit})
         Me.mnuPrepareDataReshape.Name = "mnuPrepareDataReshape"
-        Me.mnuPrepareDataReshape.Size = New System.Drawing.Size(206, 26)
+        Me.mnuPrepareDataReshape.Size = New System.Drawing.Size(224, 26)
         Me.mnuPrepareDataReshape.Tag = ""
         Me.mnuPrepareDataReshape.Text = "Data Reshape"
         '
@@ -4363,6 +4367,12 @@ Partial Class frmMain
         Me.mnuPrepareColumnReshapeMerge.Size = New System.Drawing.Size(243, 26)
         Me.mnuPrepareColumnReshapeMerge.Tag = "Merge (Join)..."
         Me.mnuPrepareColumnReshapeMerge.Text = "Merge (Join)..."
+        '
+        'mnuUnnest
+        '
+        Me.mnuUnnest.Name = "mnuUnnest"
+        Me.mnuUnnest.Size = New System.Drawing.Size(243, 26)
+        Me.mnuUnnest.Text = "Unnest..."
         '
         'ToolStripSeparator11
         '
@@ -4411,13 +4421,13 @@ Partial Class frmMain
         'ToolStripSeparator7
         '
         Me.ToolStripSeparator7.Name = "ToolStripSeparator7"
-        Me.ToolStripSeparator7.Size = New System.Drawing.Size(203, 6)
+        Me.ToolStripSeparator7.Size = New System.Drawing.Size(221, 6)
         '
         'mnuPrepareKeysAndLinks
         '
         Me.mnuPrepareKeysAndLinks.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareKeysAndLinksAddKey, Me.mnuPrepareKeysAndLinksViewAndRemoveKey, Me.mnuPrepareKeysAndLinksAddLink, Me.mnuPrepareKeysAndLinksViewAndRemoveKeys, Me.mnuPrepareKeysAndLinksAddComment})
         Me.mnuPrepareKeysAndLinks.Name = "mnuPrepareKeysAndLinks"
-        Me.mnuPrepareKeysAndLinks.Size = New System.Drawing.Size(206, 26)
+        Me.mnuPrepareKeysAndLinks.Size = New System.Drawing.Size(224, 26)
         Me.mnuPrepareKeysAndLinks.Text = "Keys and Links"
         '
         'mnuPrepareKeysAndLinksAddKey
@@ -4454,7 +4464,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataBook.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataObjectDataFrameMetadata, Me.mnuPrepareDataObjectRenameDataFrame, Me.mnuPrepareDataObjectReorderDataFrames, Me.mnuPrepareDataObjectCopyDataFrame, Me.mnuPrepareDataObjectDeleteDataFrame, Me.ToolStripSeparator21, Me.mnuPrepareDataObjectHideDataframes, Me.mnuPrepareDataObjectMetadata, Me.mnuPrepareDataObjectRenameMetadata, Me.mnuPrepareDataObjectReorderMetadata, Me.mnuPrepareDataObjectDeleteMetadata})
         Me.mnuPrepareDataBook.Name = "mnuPrepareDataBook"
-        Me.mnuPrepareDataBook.Size = New System.Drawing.Size(206, 26)
+        Me.mnuPrepareDataBook.Size = New System.Drawing.Size(224, 26)
         Me.mnuPrepareDataBook.Tag = "Data_Object"
         Me.mnuPrepareDataBook.Text = "Data Book"
         '
@@ -4544,7 +4554,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareRObjects.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareRObjectsView, Me.mnuPrepareRObjectsRename, Me.mnuPrepareRObjectsReorder, Me.mnuPrepareRObjectsDelete})
         Me.mnuPrepareRObjects.Name = "mnuPrepareRObjects"
-        Me.mnuPrepareRObjects.Size = New System.Drawing.Size(206, 26)
+        Me.mnuPrepareRObjects.Size = New System.Drawing.Size(224, 26)
         Me.mnuPrepareRObjects.Tag = "R_Objects"
         Me.mnuPrepareRObjects.Text = "R Objects"
         '
@@ -5129,7 +5139,7 @@ Partial Class frmMain
         '
         'mnuOptionsByContext
         '
-        Me.mnuOptionsByContext.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCheckData, Me.mnuOptionsByContextDefine, Me.mnuOptionsByContextPrepare, Me.mnuOptionsByContextDescribe, Me.mnuOptionsByContextModel, Me.mnuOptionsByContextCropModel})
+        Me.mnuOptionsByContext.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCheckData, Me.mnuOptionsByContextDefine, Me.mnuOptionsByContextPrepare, Me.mnuOptionsByContextDescribe, Me.mnuExperimentsDesign, Me.mnuOptionsByContextModel, Me.mnuOptionsByContextCropModel})
         Me.mnuOptionsByContext.Name = "mnuOptionsByContext"
         Me.mnuOptionsByContext.Size = New System.Drawing.Size(104, 24)
         Me.mnuOptionsByContext.Text = "Experiments"
@@ -5257,9 +5267,15 @@ Partial Class frmMain
         Me.mnuOptionsByContextDescribeBoxplot.Size = New System.Drawing.Size(277, 26)
         Me.mnuOptionsByContextDescribeBoxplot.Text = "Boxplot..."
         '
+        'mnuExperimentsDesign
+        '
+        Me.mnuExperimentsDesign.Name = "mnuExperimentsDesign"
+        Me.mnuExperimentsDesign.Size = New System.Drawing.Size(171, 26)
+        Me.mnuExperimentsDesign.Text = "Design"
+        '
         'mnuOptionsByContextModel
         '
-        Me.mnuOptionsByContextModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextModelFitModel, Me.mnuOptionsByContextGeneralFitModel})
+        Me.mnuOptionsByContextModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextModelFitModel, Me.mnuOptionsByContextGeneralFitModel, Me.mnuExperimentsOneButton, Me.mnuMultipleComparisons})
         Me.mnuOptionsByContextModel.Name = "mnuOptionsByContextModel"
         Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(171, 26)
         Me.mnuOptionsByContextModel.Text = "Model"
@@ -5267,14 +5283,26 @@ Partial Class frmMain
         'mnuOptionsByContextModelFitModel
         '
         Me.mnuOptionsByContextModelFitModel.Name = "mnuOptionsByContextModelFitModel"
-        Me.mnuOptionsByContextModelFitModel.Size = New System.Drawing.Size(219, 26)
+        Me.mnuOptionsByContextModelFitModel.Size = New System.Drawing.Size(246, 26)
         Me.mnuOptionsByContextModelFitModel.Text = "Fit Model..."
         '
         'mnuOptionsByContextGeneralFitModel
         '
         Me.mnuOptionsByContextGeneralFitModel.Name = "mnuOptionsByContextGeneralFitModel"
-        Me.mnuOptionsByContextGeneralFitModel.Size = New System.Drawing.Size(219, 26)
+        Me.mnuOptionsByContextGeneralFitModel.Size = New System.Drawing.Size(246, 26)
         Me.mnuOptionsByContextGeneralFitModel.Text = "General Fit Model..."
+        '
+        'mnuExperimentsOneButton
+        '
+        Me.mnuExperimentsOneButton.Name = "mnuExperimentsOneButton"
+        Me.mnuExperimentsOneButton.Size = New System.Drawing.Size(246, 26)
+        Me.mnuExperimentsOneButton.Text = "One Button..."
+        '
+        'mnuMultipleComparisons
+        '
+        Me.mnuMultipleComparisons.Name = "mnuMultipleComparisons"
+        Me.mnuMultipleComparisons.Size = New System.Drawing.Size(246, 26)
+        Me.mnuMultipleComparisons.Text = "Multiple Comparisons..."
         '
         'mnuOptionsByContextCropModel
         '
@@ -5622,7 +5650,7 @@ Partial Class frmMain
         Me.splOverall.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splOverall.Panel2.Controls.Add(Me.splDataOutput)
         Me.splOverall.Size = New System.Drawing.Size(1000, 486)
-        Me.splOverall.SplitterDistance = 178
+        Me.splOverall.SplitterDistance = 177
         Me.splOverall.SplitterWidth = 8
         Me.splOverall.TabIndex = 10
         '
@@ -5643,7 +5671,7 @@ Partial Class frmMain
         '
         Me.splExtraWindows.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splExtraWindows.Panel2.Controls.Add(Me.ucrScriptWindow)
-        Me.splExtraWindows.Size = New System.Drawing.Size(1000, 178)
+        Me.splExtraWindows.Size = New System.Drawing.Size(1000, 177)
         Me.splExtraWindows.SplitterDistance = 300
         Me.splExtraWindows.SplitterWidth = 8
         Me.splExtraWindows.TabIndex = 0
@@ -5664,7 +5692,7 @@ Partial Class frmMain
         '
         Me.splMetadata.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splMetadata.Panel2.Controls.Add(Me.ucrDataFrameMeta)
-        Me.splMetadata.Size = New System.Drawing.Size(300, 178)
+        Me.splMetadata.Size = New System.Drawing.Size(300, 177)
         Me.splMetadata.SplitterDistance = 75
         Me.splMetadata.SplitterWidth = 8
         Me.splMetadata.TabIndex = 0
@@ -5679,7 +5707,7 @@ Partial Class frmMain
         Me.ucrColumnMeta.Location = New System.Drawing.Point(0, 0)
         Me.ucrColumnMeta.Margin = New System.Windows.Forms.Padding(5, 8, 5, 8)
         Me.ucrColumnMeta.Name = "ucrColumnMeta"
-        Me.ucrColumnMeta.Size = New System.Drawing.Size(75, 178)
+        Me.ucrColumnMeta.Size = New System.Drawing.Size(75, 177)
         Me.ucrColumnMeta.TabIndex = 0
         '
         'ucrDataFrameMeta
@@ -5690,7 +5718,7 @@ Partial Class frmMain
         Me.ucrDataFrameMeta.Location = New System.Drawing.Point(0, 0)
         Me.ucrDataFrameMeta.Margin = New System.Windows.Forms.Padding(5, 8, 5, 8)
         Me.ucrDataFrameMeta.Name = "ucrDataFrameMeta"
-        Me.ucrDataFrameMeta.Size = New System.Drawing.Size(217, 178)
+        Me.ucrDataFrameMeta.Size = New System.Drawing.Size(217, 177)
         Me.ucrDataFrameMeta.TabIndex = 0
         '
         'ucrScriptWindow
@@ -5701,7 +5729,7 @@ Partial Class frmMain
         Me.ucrScriptWindow.Location = New System.Drawing.Point(0, 0)
         Me.ucrScriptWindow.Margin = New System.Windows.Forms.Padding(5, 8, 5, 8)
         Me.ucrScriptWindow.Name = "ucrScriptWindow"
-        Me.ucrScriptWindow.Size = New System.Drawing.Size(692, 178)
+        Me.ucrScriptWindow.Size = New System.Drawing.Size(692, 177)
         Me.ucrScriptWindow.strActiveTabText = ""
         Me.ucrScriptWindow.TabIndex = 2
         Me.ucrScriptWindow.Tag = "Script_Window"
@@ -5723,7 +5751,7 @@ Partial Class frmMain
         '
         Me.splDataOutput.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splDataOutput.Panel2.Controls.Add(Me.ucrOutput)
-        Me.splDataOutput.Size = New System.Drawing.Size(1000, 300)
+        Me.splDataOutput.Size = New System.Drawing.Size(1000, 301)
         Me.splDataOutput.SplitterDistance = 450
         Me.splDataOutput.SplitterWidth = 8
         Me.splDataOutput.TabIndex = 0
@@ -5737,7 +5765,7 @@ Partial Class frmMain
         Me.ucrDataViewer.Location = New System.Drawing.Point(0, 0)
         Me.ucrDataViewer.Margin = New System.Windows.Forms.Padding(5, 8, 5, 8)
         Me.ucrDataViewer.Name = "ucrDataViewer"
-        Me.ucrDataViewer.Size = New System.Drawing.Size(450, 300)
+        Me.ucrDataViewer.Size = New System.Drawing.Size(450, 301)
         Me.ucrDataViewer.TabIndex = 0
         Me.ucrDataViewer.Tag = "Data_View"
         '
@@ -5749,7 +5777,7 @@ Partial Class frmMain
         Me.ucrOutput.Location = New System.Drawing.Point(0, 0)
         Me.ucrOutput.Margin = New System.Windows.Forms.Padding(5, 8, 5, 8)
         Me.ucrOutput.Name = "ucrOutput"
-        Me.ucrOutput.Size = New System.Drawing.Size(542, 300)
+        Me.ucrOutput.Size = New System.Drawing.Size(542, 301)
         Me.ucrOutput.TabIndex = 0
         '
         'mnuPlotly
@@ -6591,4 +6619,8 @@ Partial Class frmMain
     Friend WithEvents mnuDescribeTwoThreeVariablesMoreLikert As ToolStripMenuItem
     Friend WithEvents InsertColumnRowsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents CheckSummaryToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents mnuUnnest As ToolStripMenuItem
+    Friend WithEvents mnuExperimentsDesign As ToolStripMenuItem
+    Friend WithEvents mnuExperimentsOneButton As ToolStripMenuItem
+    Friend WithEvents mnuMultipleComparisons As ToolStripMenuItem
 End Class

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -4370,6 +4370,7 @@ Partial Class frmMain
         '
         'mnuUnnest
         '
+        Me.mnuUnnest.Enabled = False
         Me.mnuUnnest.Name = "mnuUnnest"
         Me.mnuUnnest.Size = New System.Drawing.Size(243, 26)
         Me.mnuUnnest.Text = "Unnest..."
@@ -5148,7 +5149,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextCheckData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCheckDataDuplicateRows, Me.mnuOptionsByContextCheckDataCompareColumns, Me.ToolStripSeparator47, Me.mnuOptionsByContextCheckDataOneVariableSummarise, Me.mnuOptionsByContextCheckDataOneVariableGraph, Me.mnuOptionsByContextCheckDataOneVariableFrequencies})
         Me.mnuOptionsByContextCheckData.Name = "mnuOptionsByContextCheckData"
-        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(171, 26)
+        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(224, 26)
         Me.mnuOptionsByContextCheckData.Text = "Check Data"
         '
         'mnuOptionsByContextCheckDataDuplicateRows
@@ -5190,7 +5191,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextDefine.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDefineOnStation, Me.mnuOptionsByContextDefineOnFarm})
         Me.mnuOptionsByContextDefine.Name = "mnuOptionsByContextDefine"
-        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(171, 26)
+        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(224, 26)
         Me.mnuOptionsByContextDefine.Text = "Define"
         '
         'mnuOptionsByContextDefineOnStation
@@ -5209,7 +5210,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions, Me.ToolStripSeparator48, Me.mnuOptionsByContextMergeAdditionalData, Me.mnuOptionsByContextPrepareStack, Me.mnuOptionsByContextPrepareUnstack})
         Me.mnuOptionsByContextPrepare.Name = "mnuOptionsByContextPrepare"
-        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(171, 26)
+        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(224, 26)
         Me.mnuOptionsByContextPrepare.Text = "Prepare"
         '
         'mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions
@@ -5245,7 +5246,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDescribeCompareTwoTreatments, Me.mnuOptionsByContextDescribeCompareMultipleTreatments, Me.mnuOptionsByContextDescribeBoxplot})
         Me.mnuOptionsByContextDescribe.Name = "mnuOptionsByContextDescribe"
-        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(171, 26)
+        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(224, 26)
         Me.mnuOptionsByContextDescribe.Text = "Describe"
         '
         'mnuOptionsByContextDescribeCompareTwoTreatments
@@ -5269,15 +5270,16 @@ Partial Class frmMain
         '
         'mnuExperimentsDesign
         '
+        Me.mnuExperimentsDesign.Enabled = False
         Me.mnuExperimentsDesign.Name = "mnuExperimentsDesign"
-        Me.mnuExperimentsDesign.Size = New System.Drawing.Size(171, 26)
+        Me.mnuExperimentsDesign.Size = New System.Drawing.Size(224, 26)
         Me.mnuExperimentsDesign.Text = "Design"
         '
         'mnuOptionsByContextModel
         '
         Me.mnuOptionsByContextModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextModelFitModel, Me.mnuOptionsByContextGeneralFitModel, Me.mnuExperimentsOneButton, Me.mnuMultipleComparisons})
         Me.mnuOptionsByContextModel.Name = "mnuOptionsByContextModel"
-        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(171, 26)
+        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(224, 26)
         Me.mnuOptionsByContextModel.Text = "Model"
         '
         'mnuOptionsByContextModelFitModel
@@ -5294,12 +5296,14 @@ Partial Class frmMain
         '
         'mnuExperimentsOneButton
         '
+        Me.mnuExperimentsOneButton.Enabled = False
         Me.mnuExperimentsOneButton.Name = "mnuExperimentsOneButton"
         Me.mnuExperimentsOneButton.Size = New System.Drawing.Size(246, 26)
         Me.mnuExperimentsOneButton.Text = "One Button..."
         '
         'mnuMultipleComparisons
         '
+        Me.mnuMultipleComparisons.Enabled = False
         Me.mnuMultipleComparisons.Name = "mnuMultipleComparisons"
         Me.mnuMultipleComparisons.Size = New System.Drawing.Size(246, 26)
         Me.mnuMultipleComparisons.Text = "Multiple Comparisons..."
@@ -5308,7 +5312,7 @@ Partial Class frmMain
         '
         Me.mnuOptionsByContextCropModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCropModelApsimxExamples})
         Me.mnuOptionsByContextCropModel.Name = "mnuOptionsByContextCropModel"
-        Me.mnuOptionsByContextCropModel.Size = New System.Drawing.Size(171, 26)
+        Me.mnuOptionsByContextCropModel.Size = New System.Drawing.Size(224, 26)
         Me.mnuOptionsByContextCropModel.Text = "Crop Model"
         '
         'mnuOptionsByContextCropModelApsimxExamples

--- a/instat/frmMain.vb
+++ b/instat/frmMain.vb
@@ -3275,4 +3275,20 @@ Public Class frmMain
     Private Sub mnuDescribeTwoThreeVariablesMoreLikert_Click(sender As Object, e As EventArgs) Handles mnuDescribeTwoThreeVariablesMoreLikert.Click
         dlgDescribeTwoVariableMoreLikertGraphs.ShowDialog()
     End Sub
+
+    Private Sub mnuUnnest_Click(sender As Object, e As EventArgs) Handles mnuUnnest.Click
+        dlgPrepareDataReshapeUnnest.ShowDialog()
+    End Sub
+
+    Private Sub mnuExperimentsDesign_Click(sender As Object, e As EventArgs) Handles mnuExperimentsDesign.Click
+        dlgExperimentsDesign.ShowDialog()
+    End Sub
+
+    Private Sub mnuExperimentsOneButton_Click(sender As Object, e As EventArgs) Handles mnuExperimentsOneButton.Click
+        dlgExperimentsOneButton.ShowDialog()
+    End Sub
+
+    Private Sub mnuMultipleComparisons_Click(sender As Object, e As EventArgs) Handles mnuMultipleComparisons.Click
+        dlgModelMultipleComparisons.ShowDialog()
+    End Sub
 End Class

--- a/instat/instat.vbproj
+++ b/instat/instat.vbproj
@@ -287,6 +287,18 @@
     <Compile Include="dlgEdit.vb">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="dlgExperimentsDesign.Designer.vb">
+      <DependentUpon>dlgExperimentsDesign.vb</DependentUpon>
+    </Compile>
+    <Compile Include="dlgExperimentsDesign.vb">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="dlgExperimentsOneButton.Designer.vb">
+      <DependentUpon>dlgExperimentsOneButton.vb</DependentUpon>
+    </Compile>
+    <Compile Include="dlgExperimentsOneButton.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="dlgExportClimaticDefinitions.Designer.vb">
       <DependentUpon>dlgExportClimaticDefinitions.vb</DependentUpon>
     </Compile>
@@ -347,6 +359,12 @@
     <Compile Include="dlgModellingTree.vb">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="dlgModelMultipleComparisons.Designer.vb">
+      <DependentUpon>dlgModelMultipleComparisons.vb</DependentUpon>
+    </Compile>
+    <Compile Include="dlgModelMultipleComparisons.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="dlgPICSATrend.Designer.vb">
       <DependentUpon>dlgPICSATrend.vb</DependentUpon>
     </Compile>
@@ -357,6 +375,12 @@
       <DependentUpon>dlgPlacketLuceModel.vb</DependentUpon>
     </Compile>
     <Compile Include="dlgPlacketLuceModel.vb">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="dlgPrepareDataReshapeUnnest.Designer.vb">
+      <DependentUpon>dlgPrepareDataReshapeUnnest.vb</DependentUpon>
+    </Compile>
+    <Compile Include="dlgPrepareDataReshapeUnnest.vb">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="dlgRandomSplit.Designer.vb">
@@ -3534,6 +3558,12 @@
     <EmbeddedResource Include="dlgEdit.resx">
       <DependentUpon>dlgEdit.vb</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="dlgExperimentsDesign.resx">
+      <DependentUpon>dlgExperimentsDesign.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="dlgExperimentsOneButton.resx">
+      <DependentUpon>dlgExperimentsOneButton.vb</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="dlgExportClimaticDefinitions.resx">
       <DependentUpon>dlgExportClimaticDefinitions.vb</DependentUpon>
     </EmbeddedResource>
@@ -3585,6 +3615,9 @@
     <EmbeddedResource Include="dlgModellingTree.resx">
       <DependentUpon>dlgModellingTree.vb</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="dlgModelMultipleComparisons.resx">
+      <DependentUpon>dlgModelMultipleComparisons.vb</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="dlgOtherRosePlots.resx">
       <DependentUpon>dlgOtherRosePlots.vb</DependentUpon>
     </EmbeddedResource>
@@ -3596,6 +3629,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="dlgPlacketLuceModel.resx">
       <DependentUpon>dlgPlacketLuceModel.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="dlgPrepareDataReshapeUnnest.resx">
+      <DependentUpon>dlgPrepareDataReshapeUnnest.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="dlgRandomSplit.resx">
       <DependentUpon>dlgRandomSplit.vb</DependentUpon>

--- a/instat/translations/en/r_instat_menus.json
+++ b/instat/translations/en/r_instat_menus.json
@@ -548,5 +548,11 @@
   "Load from File...": "Load from File...",
   "Save to File...": "Save to File...",
   "Likert Graphs...": "Likert Graphs...",
-  "More Likert...": "More Likert..."
+  "More Likert...": "More Likert...",
+  "Start of the Season...": "Start of the Season...",
+  "End of the Season...": "End of the Season...",
+  "Unnest...": "Unnest...",
+  "Design": "Design",
+  "One Button...": "One Button...",
+  "Multiple Comparisons...": "Multiple Comparisons..."
 }

--- a/instat/translations/en/r_instat_not_menus.json
+++ b/instat/translations/en/r_instat_not_menus.json
@@ -6908,5 +6908,10 @@
   "Save and Reopen Workspace:": "Save and Reopen Workspace:",
   "Fraction": "Fraction",
   "Zero": "Zero",
-  "Scientific": "Scientific"
+  "Scientific": "Scientific",
+  "dlgExperimentsGreaterthanDesign": "dlgExperimentsGreaterthanDesign",
+  "One Button": "One Button",
+  "Multiple Comparisons": "Multiple Comparisons",
+  "Variable Names": "Variable Names",
+  "Limit Length": "Limit Length"
 }


### PR DESCRIPTION
@lilyclements @berylwaswa @Vitalis95 

Fixes #10442

This is a replacement of this pr #10447 cause i was getting conflicts

This is just putting names of the diaogs in the frmMain and making empty Dialogs at frmMain
Created dummy empty dialogs for each so that whoever is working on those can fill in.

a) Experiments > Design is the first.
b) Experiments > Model > Multiple Comparisons is the second, and is below the two entries that are there now.
c) Experiments > Model > One button is the third and is below b.
d) Prepare Data Reshape > Unnest is the forth and is in Prepare > Data Reshape and below the current Merge dialog

<img width="585" height="642" alt="image" src="https://github.com/user-attachments/assets/df64a68e-24eb-416e-a176-9af8cf8b8598" />
<img width="636" height="317" alt="image" src="https://github.com/user-attachments/assets/5f2e0659-8c56-4ab7-ab5c-8bb73369a909" />

