### PR TITLE
Added  "One Button" dialog that runs a complete RBD  or Factorial RBD…

### DIFF
--- a/instat/dlgExperimentsOneButton.Designer.vb
+++ b/instat/dlgExperimentsOneButton.Designer.vb
@@ -22,85 +22,309 @@ Partial Class dlgExperimentsOneButton
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
-        Me.lblFirstVariables = New System.Windows.Forms.Label()
-        Me.ucrSaveExperimentsOneButton = New instat.ucrSave()
-        Me.ucrReceiverFirstVariables = New instat.ucrReceiverMultiple()
-        Me.ucrBase = New instat.ucrButtons()
-        Me.ucrSelectorExperimentsOneButton = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.rdoGeneral = New System.Windows.Forms.RadioButton()
+        Me.rdoSpecial = New System.Windows.Forms.RadioButton()
+        Me.rdoFactorial = New System.Windows.Forms.RadioButton()
+        Me.rdorbd = New System.Windows.Forms.RadioButton()
+        Me.lblResponse = New System.Windows.Forms.Label()
+        Me.lblRep = New System.Windows.Forms.Label()
+        Me.lblFactorA = New System.Windows.Forms.Label()
+        Me.lblFactorB = New System.Windows.Forms.Label()
+        Me.lblDesign = New System.Windows.Forms.Label()
+        Me.lblApha = New System.Windows.Forms.Label()
+        Me.lblTreat = New System.Windows.Forms.Label()
+        Me.UcrBaseExperimentsOneButton = New instat.ucrButtons()
+        Me.ucrSave = New instat.ucrSave()
+        Me.ucrReceiverResponse = New instat.ucrReceiverSingle()
+        Me.ucrRep = New instat.ucrReceiverSingle()
+        Me.ucrReceiverFactorA = New instat.ucrReceiverSingle()
+        Me.ucrReceiverFactorB = New instat.ucrReceiverSingle()
+        Me.ucrChkPlot = New instat.ucrCheck()
+        Me.ucrAlpha = New instat.ucrInputComboBox()
+        Me.ucrSelectorForRank = New instat.ucrSelectorByDataFrameAddRemove()
+        Me.ucrPnlExperimentsOneButtonOptions = New instat.UcrPanel()
+        Me.UcrReceiverTreat = New instat.ucrReceiverSingle()
         Me.SuspendLayout()
         '
-        'lblFirstVariables
+        'rdoGeneral
         '
-        Me.lblFirstVariables.AutoSize = True
-        Me.lblFirstVariables.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblFirstVariables.Location = New System.Drawing.Point(377, 64)
-        Me.lblFirstVariables.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblFirstVariables.Name = "lblFirstVariables"
-        Me.lblFirstVariables.Size = New System.Drawing.Size(68, 16)
-        Me.lblFirstVariables.TabIndex = 25
-        Me.lblFirstVariables.Tag = ""
-        Me.lblFirstVariables.Text = "Variables:"
+        Me.rdoGeneral.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoGeneral.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoGeneral.FlatAppearance.BorderSize = 2
+        Me.rdoGeneral.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoGeneral.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoGeneral.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoGeneral.Location = New System.Drawing.Point(56, 12)
+        Me.rdoGeneral.Name = "rdoGeneral"
+        Me.rdoGeneral.Size = New System.Drawing.Size(129, 27)
+        Me.rdoGeneral.TabIndex = 21
+        Me.rdoGeneral.TabStop = True
+        Me.rdoGeneral.Text = "General"
+        Me.rdoGeneral.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoGeneral.UseVisualStyleBackColor = True
         '
-        'ucrSaveExperimentsOneButton
+        'rdoSpecial
         '
-        Me.ucrSaveExperimentsOneButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveExperimentsOneButton.Location = New System.Drawing.Point(12, 368)
-        Me.ucrSaveExperimentsOneButton.Margin = New System.Windows.Forms.Padding(5, 6, 5, 6)
-        Me.ucrSaveExperimentsOneButton.Name = "ucrSaveExperimentsOneButton"
-        Me.ucrSaveExperimentsOneButton.Size = New System.Drawing.Size(408, 30)
-        Me.ucrSaveExperimentsOneButton.TabIndex = 27
+        Me.rdoSpecial.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoSpecial.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoSpecial.FlatAppearance.BorderSize = 2
+        Me.rdoSpecial.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoSpecial.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoSpecial.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoSpecial.Location = New System.Drawing.Point(183, 12)
+        Me.rdoSpecial.Name = "rdoSpecial"
+        Me.rdoSpecial.Size = New System.Drawing.Size(129, 27)
+        Me.rdoSpecial.TabIndex = 20
+        Me.rdoSpecial.TabStop = True
+        Me.rdoSpecial.Text = "Special"
+        Me.rdoSpecial.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoSpecial.UseVisualStyleBackColor = True
         '
-        'ucrReceiverFirstVariables
+        'rdoFactorial
         '
-        Me.ucrReceiverFirstVariables.AutoSize = True
-        Me.ucrReceiverFirstVariables.frmParent = Me
-        Me.ucrReceiverFirstVariables.Location = New System.Drawing.Point(377, 82)
-        Me.ucrReceiverFirstVariables.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverFirstVariables.Name = "ucrReceiverFirstVariables"
-        Me.ucrReceiverFirstVariables.Selector = Nothing
-        Me.ucrReceiverFirstVariables.Size = New System.Drawing.Size(160, 97)
-        Me.ucrReceiverFirstVariables.strNcFilePath = ""
-        Me.ucrReceiverFirstVariables.TabIndex = 26
-        Me.ucrReceiverFirstVariables.ucrSelector = Nothing
+        Me.rdoFactorial.AutoSize = True
+        Me.rdoFactorial.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoFactorial.Location = New System.Drawing.Point(115, 54)
+        Me.rdoFactorial.Name = "rdoFactorial"
+        Me.rdoFactorial.Size = New System.Drawing.Size(65, 17)
+        Me.rdoFactorial.TabIndex = 70
+        Me.rdoFactorial.TabStop = True
+        Me.rdoFactorial.Text = "Factorial"
+        Me.rdoFactorial.UseVisualStyleBackColor = True
         '
-        'ucrBase
+        'rdorbd
         '
-        Me.ucrBase.AutoSize = True
-        Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(12, 425)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(8, 7, 8, 7)
-        Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(511, 65)
-        Me.ucrBase.TabIndex = 24
+        Me.rdorbd.AutoSize = True
+        Me.rdorbd.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdorbd.Location = New System.Drawing.Point(67, 54)
+        Me.rdorbd.Name = "rdorbd"
+        Me.rdorbd.Size = New System.Drawing.Size(40, 17)
+        Me.rdorbd.TabIndex = 69
+        Me.rdorbd.TabStop = True
+        Me.rdorbd.Text = "rbd"
+        Me.rdorbd.UseVisualStyleBackColor = True
         '
-        'ucrSelectorExperimentsOneButton
+        'lblResponse
         '
-        Me.ucrSelectorExperimentsOneButton.AutoSize = True
-        Me.ucrSelectorExperimentsOneButton.bDropUnusedFilterLevels = False
-        Me.ucrSelectorExperimentsOneButton.bShowHiddenColumns = False
-        Me.ucrSelectorExperimentsOneButton.bUseCurrentFilter = True
-        Me.ucrSelectorExperimentsOneButton.Location = New System.Drawing.Point(12, 43)
-        Me.ucrSelectorExperimentsOneButton.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrSelectorExperimentsOneButton.Name = "ucrSelectorExperimentsOneButton"
-        Me.ucrSelectorExperimentsOneButton.Size = New System.Drawing.Size(284, 227)
-        Me.ucrSelectorExperimentsOneButton.TabIndex = 5
+        Me.lblResponse.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblResponse.Location = New System.Drawing.Point(246, 76)
+        Me.lblResponse.Name = "lblResponse"
+        Me.lblResponse.Size = New System.Drawing.Size(60, 18)
+        Me.lblResponse.TabIndex = 74
+        Me.lblResponse.Text = "Response:"
+        '
+        'lblRep
+        '
+        Me.lblRep.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblRep.Location = New System.Drawing.Point(246, 197)
+        Me.lblRep.Name = "lblRep"
+        Me.lblRep.Size = New System.Drawing.Size(124, 13)
+        Me.lblRep.TabIndex = 80
+        Me.lblRep.Text = "Rep :"
+        '
+        'lblFactorA
+        '
+        Me.lblFactorA.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblFactorA.Location = New System.Drawing.Point(246, 117)
+        Me.lblFactorA.Name = "lblFactorA"
+        Me.lblFactorA.Size = New System.Drawing.Size(60, 16)
+        Me.lblFactorA.TabIndex = 76
+        Me.lblFactorA.Text = "Factor A:"
+        '
+        'lblFactorB
+        '
+        Me.lblFactorB.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblFactorB.Location = New System.Drawing.Point(246, 155)
+        Me.lblFactorB.Name = "lblFactorB"
+        Me.lblFactorB.Size = New System.Drawing.Size(60, 17)
+        Me.lblFactorB.TabIndex = 78
+        Me.lblFactorB.Text = "Factor B:"
+        '
+        'lblDesign
+        '
+        Me.lblDesign.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblDesign.Location = New System.Drawing.Point(10, 56)
+        Me.lblDesign.Name = "lblDesign"
+        Me.lblDesign.Size = New System.Drawing.Size(43, 13)
+        Me.lblDesign.TabIndex = 84
+        Me.lblDesign.Text = "Design:"
+        '
+        'lblApha
+        '
+        Me.lblApha.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblApha.Location = New System.Drawing.Point(9, 276)
+        Me.lblApha.Name = "lblApha"
+        Me.lblApha.Size = New System.Drawing.Size(43, 13)
+        Me.lblApha.TabIndex = 85
+        Me.lblApha.Text = "Alpha:"
+        '
+        'lblTreat
+        '
+        Me.lblTreat.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.lblTreat.Location = New System.Drawing.Point(246, 119)
+        Me.lblTreat.Name = "lblTreat"
+        Me.lblTreat.Size = New System.Drawing.Size(60, 16)
+        Me.lblTreat.TabIndex = 88
+        Me.lblTreat.Text = "Treat :"
+        '
+        'UcrBaseExperimentsOneButton
+        '
+        Me.UcrBaseExperimentsOneButton.AutoSize = True
+        Me.UcrBaseExperimentsOneButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.UcrBaseExperimentsOneButton.Location = New System.Drawing.Point(9, 336)
+        Me.UcrBaseExperimentsOneButton.Margin = New System.Windows.Forms.Padding(4)
+        Me.UcrBaseExperimentsOneButton.Name = "UcrBaseExperimentsOneButton"
+        Me.UcrBaseExperimentsOneButton.Size = New System.Drawing.Size(408, 52)
+        Me.UcrBaseExperimentsOneButton.TabIndex = 83
+        '
+        'ucrSave
+        '
+        Me.ucrSave.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSave.Location = New System.Drawing.Point(9, 308)
+        Me.ucrSave.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrSave.Name = "ucrSave"
+        Me.ucrSave.Size = New System.Drawing.Size(388, 24)
+        Me.ucrSave.TabIndex = 82
+        '
+        'ucrReceiverResponse
+        '
+        Me.ucrReceiverResponse.AutoSize = True
+        Me.ucrReceiverResponse.frmParent = Me
+        Me.ucrReceiverResponse.Location = New System.Drawing.Point(246, 97)
+        Me.ucrReceiverResponse.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverResponse.Name = "ucrReceiverResponse"
+        Me.ucrReceiverResponse.Selector = Nothing
+        Me.ucrReceiverResponse.Size = New System.Drawing.Size(123, 20)
+        Me.ucrReceiverResponse.strNcFilePath = ""
+        Me.ucrReceiverResponse.TabIndex = 75
+        Me.ucrReceiverResponse.ucrSelector = Nothing
+        '
+        'ucrRep
+        '
+        Me.ucrRep.AutoSize = True
+        Me.ucrRep.frmParent = Me
+        Me.ucrRep.Location = New System.Drawing.Point(246, 213)
+        Me.ucrRep.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrRep.Name = "ucrRep"
+        Me.ucrRep.Selector = Nothing
+        Me.ucrRep.Size = New System.Drawing.Size(123, 20)
+        Me.ucrRep.strNcFilePath = ""
+        Me.ucrRep.TabIndex = 81
+        Me.ucrRep.ucrSelector = Nothing
+        '
+        'ucrReceiverFactorA
+        '
+        Me.ucrReceiverFactorA.AutoSize = True
+        Me.ucrReceiverFactorA.frmParent = Me
+        Me.ucrReceiverFactorA.Location = New System.Drawing.Point(246, 137)
+        Me.ucrReceiverFactorA.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverFactorA.Name = "ucrReceiverFactorA"
+        Me.ucrReceiverFactorA.Selector = Nothing
+        Me.ucrReceiverFactorA.Size = New System.Drawing.Size(123, 20)
+        Me.ucrReceiverFactorA.strNcFilePath = ""
+        Me.ucrReceiverFactorA.TabIndex = 77
+        Me.ucrReceiverFactorA.ucrSelector = Nothing
+        '
+        'ucrReceiverFactorB
+        '
+        Me.ucrReceiverFactorB.AutoSize = True
+        Me.ucrReceiverFactorB.frmParent = Me
+        Me.ucrReceiverFactorB.Location = New System.Drawing.Point(246, 174)
+        Me.ucrReceiverFactorB.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverFactorB.Name = "ucrReceiverFactorB"
+        Me.ucrReceiverFactorB.Selector = Nothing
+        Me.ucrReceiverFactorB.Size = New System.Drawing.Size(123, 20)
+        Me.ucrReceiverFactorB.strNcFilePath = ""
+        Me.ucrReceiverFactorB.TabIndex = 79
+        Me.ucrReceiverFactorB.ucrSelector = Nothing
+        '
+        'ucrChkPlot
+        '
+        Me.ucrChkPlot.AutoSize = True
+        Me.ucrChkPlot.Checked = False
+        Me.ucrChkPlot.Location = New System.Drawing.Point(246, 260)
+        Me.ucrChkPlot.Margin = New System.Windows.Forms.Padding(5)
+        Me.ucrChkPlot.Name = "ucrChkPlot"
+        Me.ucrChkPlot.Size = New System.Drawing.Size(120, 23)
+        Me.ucrChkPlot.TabIndex = 91
+        '
+        'ucrAlpha
+        '
+        Me.ucrAlpha.AddQuotesIfUnrecognised = True
+        Me.ucrAlpha.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrAlpha.GetSetSelectedIndex = -1
+        Me.ucrAlpha.IsReadOnly = False
+        Me.ucrAlpha.Location = New System.Drawing.Point(60, 271)
+        Me.ucrAlpha.Margin = New System.Windows.Forms.Padding(5)
+        Me.ucrAlpha.Name = "ucrAlpha"
+        Me.ucrAlpha.Size = New System.Drawing.Size(72, 20)
+        Me.ucrAlpha.TabIndex = 73
+        '
+        'ucrSelectorForRank
+        '
+        Me.ucrSelectorForRank.AutoSize = True
+        Me.ucrSelectorForRank.bDropUnusedFilterLevels = False
+        Me.ucrSelectorForRank.bShowHiddenColumns = False
+        Me.ucrSelectorForRank.bUseCurrentFilter = True
+        Me.ucrSelectorForRank.Location = New System.Drawing.Point(9, 75)
+        Me.ucrSelectorForRank.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrSelectorForRank.Name = "ucrSelectorForRank"
+        Me.ucrSelectorForRank.Size = New System.Drawing.Size(213, 183)
+        Me.ucrSelectorForRank.TabIndex = 71
+        '
+        'ucrPnlExperimentsOneButtonOptions
+        '
+        Me.ucrPnlExperimentsOneButtonOptions.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrPnlExperimentsOneButtonOptions.Location = New System.Drawing.Point(12, 4)
+        Me.ucrPnlExperimentsOneButtonOptions.Margin = New System.Windows.Forms.Padding(5)
+        Me.ucrPnlExperimentsOneButtonOptions.Name = "ucrPnlExperimentsOneButtonOptions"
+        Me.ucrPnlExperimentsOneButtonOptions.Size = New System.Drawing.Size(404, 42)
+        Me.ucrPnlExperimentsOneButtonOptions.TabIndex = 90
+        '
+        'UcrReceiverTreat
+        '
+        Me.UcrReceiverTreat.AutoSize = True
+        Me.UcrReceiverTreat.frmParent = Me
+        Me.UcrReceiverTreat.Location = New System.Drawing.Point(246, 138)
+        Me.UcrReceiverTreat.Margin = New System.Windows.Forms.Padding(0)
+        Me.UcrReceiverTreat.Name = "UcrReceiverTreat"
+        Me.UcrReceiverTreat.Selector = Nothing
+        Me.UcrReceiverTreat.Size = New System.Drawing.Size(123, 20)
+        Me.UcrReceiverTreat.strNcFilePath = ""
+        Me.UcrReceiverTreat.TabIndex = 89
+        Me.UcrReceiverTreat.ucrSelector = Nothing
         '
         'dlgExperimentsOneButton
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 16.0!)
-        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(568, 507)
-        Me.Controls.Add(Me.ucrSaveExperimentsOneButton)
-        Me.Controls.Add(Me.ucrReceiverFirstVariables)
-        Me.Controls.Add(Me.lblFirstVariables)
-        Me.Controls.Add(Me.ucrBase)
-        Me.Controls.Add(Me.ucrSelectorExperimentsOneButton)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
+        Me.ClientSize = New System.Drawing.Size(423, 398)
+        Me.Controls.Add(Me.lblApha)
+        Me.Controls.Add(Me.lblDesign)
+        Me.Controls.Add(Me.UcrBaseExperimentsOneButton)
+        Me.Controls.Add(Me.ucrSave)
+        Me.Controls.Add(Me.lblResponse)
+        Me.Controls.Add(Me.ucrReceiverResponse)
+        Me.Controls.Add(Me.lblRep)
+        Me.Controls.Add(Me.ucrRep)
+        Me.Controls.Add(Me.lblFactorA)
+        Me.Controls.Add(Me.ucrReceiverFactorA)
+        Me.Controls.Add(Me.lblFactorB)
+        Me.Controls.Add(Me.ucrReceiverFactorB)
+        Me.Controls.Add(Me.ucrChkPlot)
+        Me.Controls.Add(Me.ucrAlpha)
+        Me.Controls.Add(Me.ucrSelectorForRank)
+        Me.Controls.Add(Me.rdoFactorial)
+        Me.Controls.Add(Me.rdorbd)
+        Me.Controls.Add(Me.rdoGeneral)
+        Me.Controls.Add(Me.rdoSpecial)
+        Me.Controls.Add(Me.ucrPnlExperimentsOneButtonOptions)
+        Me.Controls.Add(Me.lblTreat)
+        Me.Controls.Add(Me.UcrReceiverTreat)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
-        Me.Margin = New System.Windows.Forms.Padding(4, 4, 4, 4)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "dlgExperimentsOneButton"
-        Me.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
         Me.Text = "One Button"
         Me.ResumeLayout(False)
@@ -113,4 +337,26 @@ Partial Class dlgExperimentsOneButton
     Friend WithEvents ucrReceiverFirstVariables As ucrReceiverMultiple
     Friend WithEvents lblFirstVariables As Label
     Friend WithEvents ucrSaveExperimentsOneButton As ucrSave
+    Friend WithEvents rdoGeneral As RadioButton
+    Friend WithEvents rdoSpecial As RadioButton
+    Friend WithEvents rdoFactorial As RadioButton
+    Friend WithEvents rdorbd As RadioButton
+    Friend WithEvents ucrSelectorForRank As ucrSelectorByDataFrameAddRemove
+    Friend WithEvents ucrAlpha As ucrInputComboBox
+    Friend WithEvents lblResponse As Label
+    Friend WithEvents ucrReceiverResponse As ucrReceiverSingle
+    Friend WithEvents lblRep As Label
+    Friend WithEvents ucrRep As ucrReceiverSingle
+    Friend WithEvents lblFactorA As Label
+    Friend WithEvents ucrReceiverFactorA As ucrReceiverSingle
+    Friend WithEvents lblFactorB As Label
+    Friend WithEvents ucrReceiverFactorB As ucrReceiverSingle
+    Friend WithEvents ucrChkPlot As ucrCheck
+    Friend WithEvents ucrSave As ucrSave
+    Friend WithEvents UcrBaseExperimentsOneButton As ucrButtons
+    Friend WithEvents lblDesign As Label
+    Friend WithEvents lblApha As Label
+    Friend WithEvents lblTreat As Label
+    Friend WithEvents UcrReceiverTreat As ucrReceiverSingle
+    Friend WithEvents ucrPnlExperimentsOneButtonOptions As UcrPanel
 End Class

--- a/instat/dlgExperimentsOneButton.vb
+++ b/instat/dlgExperimentsOneButton.vb
@@ -11,67 +11,302 @@
 ' MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ' GNU General Public License for more details.
 '
-' You should have received a copy of the GNU General Public License 
+' You should have received a copy of the GNU General Public License
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-Imports instat
 Imports instat.Translations
 Public Class dlgExperimentsOneButton
 
     Private bFirstLoad As Boolean = True
+    Private bReset As Boolean = True
+    Private bRCodeSet As Boolean = True
+
+    Private clsBkRbdFunction As New RFunction
+    Private clsBkFrbdFunction As New RFunction
+
+    Private clsBkPlotFunction As New RFunction
+    Private clsCheckGraphFunction As New RFunction
+    Private clsAddPlotObjectFunction As New RFunction
+    Private clsGetPlotObjectDataFunction As New RFunction
+    Private clsDummyFunction As New RFunction
+
+    Private clsCurrentDataFrameFunction As New RFunction
+    Private ReadOnly strLastModel As String = "last_model"
+    Private ReadOnly strLastGraph As String = "last_graph"
 
     Private Sub dlgExperimentsOneButton_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
         End If
-
+        If bReset Then
+            SetDefaults()
+        End If
+        SetRCodeForControls(bReset)
+        bReset = False
+        autoTranslate(Me)
+        TestOKEnabled()
     End Sub
 
     Private Sub InitialiseDialog()
+        UcrBaseExperimentsOneButton.iHelpTopicID = 0
+        UcrBaseExperimentsOneButton.clsRsyntax.iCallType = 2
+        UcrBaseExperimentsOneButton.clsRsyntax.bExcludeAssignedFunctionOutput = False
 
+        ucrPnlExperimentsOneButtonOptions.AddRadioButton(rdoGeneral)
+        ucrPnlExperimentsOneButtonOptions.AddRadioButton(rdoSpecial)
+        ucrPnlExperimentsOneButtonOptions.AddParameterValuesCondition(rdoGeneral, "top_option", "General")
+        ucrPnlExperimentsOneButtonOptions.AddParameterValuesCondition(rdoSpecial, "top_option", "Special")
 
+        ucrSelectorForRank.SetParameter(New RParameter("data", 0))
+        ucrSelectorForRank.SetParameterIsrfunction()
+
+        ucrReceiverResponse.Selector = ucrSelectorForRank
+        ucrReceiverResponse.SetParameter(New RParameter("trait", 1))
+        ucrReceiverResponse.SetParameterIsString()
+        ucrReceiverResponse.SetDataType("numeric")
+        ucrReceiverResponse.strSelectorHeading = "Numerics"
+
+        UcrReceiverTreat.Selector = ucrSelectorForRank
+        UcrReceiverTreat.SetParameter(New RParameter("gen", 2))
+        UcrReceiverTreat.SetParameterIsString()
+        UcrReceiverTreat.SetDataType("factor")
+        UcrReceiverTreat.strSelectorHeading = "Factors"
+
+        ucrReceiverFactorA.Selector = ucrSelectorForRank
+        ucrReceiverFactorA.SetParameter(New RParameter("factorA", 2))
+        ucrReceiverFactorA.SetParameterIsString()
+        ucrReceiverFactorA.SetDataType("factor")
+        ucrReceiverFactorA.strSelectorHeading = "Factors"
+
+        ucrReceiverFactorB.Selector = ucrSelectorForRank
+        ucrReceiverFactorB.SetParameter(New RParameter("factorB", 3))
+        ucrReceiverFactorB.SetParameterIsString()
+        ucrReceiverFactorB.SetDataType("factor")
+        ucrReceiverFactorB.strSelectorHeading = "Factors"
+
+        ucrRep.Selector = ucrSelectorForRank
+        ucrRep.SetParameter(New RParameter("rep", 3))
+        ucrRep.SetParameterIsString()
+        ucrRep.SetDataType("factor")
+        ucrRep.strSelectorHeading = "Factors"
+
+        ucrChkPlot.SetText("Generate Plot")
+        ucrChkPlot.AddParameterValuesCondition(True, "plot", "True")
+        ucrChkPlot.AddParameterValuesCondition(False, "plot", "False")
+
+        ucrAlpha.SetParameter(New RParameter("alpha", 4))
+        Dim dctAlpha As New Dictionary(Of String, String)
+        dctAlpha.Add("0.001", "0.001")
+        dctAlpha.Add("0.01", "0.01")
+        dctAlpha.Add("0.02", "0.02")
+        dctAlpha.Add("0.05", "0.05")
+        dctAlpha.Add("0.1", "0.1")
+        ucrAlpha.SetItems(dctAlpha)
+        ucrAlpha.SetRDefault("0.05")
+        ucrAlpha.SetDropDownStyleAsNonEditable()
+
+        ucrSave.SetSaveTypeAsModel()
+        ucrSave.SetPrefix("one_button_model")
+        ucrSave.SetDataFrameSelector(ucrSelectorForRank.ucrAvailableDataFrames)
+        ucrSave.SetCheckBoxText("Store Model")
+        ucrSave.SetIsComboBox()
+        ucrSave.SetAssignToIfUncheckedValue(strLastModel)
     End Sub
 
     Private Sub SetDefaults()
+        bRCodeSet = False
 
-        TestOkEnabled()
+        clsBkRbdFunction = New RFunction
+        clsBkFrbdFunction = New RFunction
+        clsBkPlotFunction = New RFunction
+        clsCheckGraphFunction = New RFunction
+        clsAddPlotObjectFunction = New RFunction
+        clsGetPlotObjectDataFunction = New RFunction
+        clsDummyFunction = New RFunction
+
+        ucrSelectorForRank.Reset()
+        ucrSave.Reset()
+        ucrReceiverResponse.SetMeAsReceiver()
+
+        clsDummyFunction.AddParameter("top_option", "General", iPosition:=0)
+        clsDummyFunction.AddParameter("plot", "True", iPosition:=1)
+
+
+        clsCurrentDataFrameFunction = ucrSelectorForRank.ucrAvailableDataFrames.clsCurrDataFrame
+
+        clsBkRbdFunction.SetPackageName("BKBreed")
+        clsBkRbdFunction.SetRCommand("bk_rbd")
+        clsBkRbdFunction.AddParameter("data", clsRFunctionParameter:=clsCurrentDataFrameFunction, iPosition:=0)
+        clsBkRbdFunction.AddParameter("alpha", "0.05", iPosition:=4)
+
+        clsBkFrbdFunction.SetPackageName("BKBreed")
+        clsBkFrbdFunction.SetRCommand("bk_frbd")
+        clsBkFrbdFunction.AddParameter("data", clsRFunctionParameter:=clsCurrentDataFrameFunction, iPosition:=0)
+        clsBkFrbdFunction.AddParameter("alpha", "0.05", iPosition:=5)
+
+        clsBkPlotFunction.SetPackageName("BKBreed")
+        clsBkPlotFunction.SetRCommand("bk_plot")
+        clsBkPlotFunction.SetAssignTo(strLastGraph)
+
+        clsCheckGraphFunction.SetPackageName("instatExtras")
+        clsCheckGraphFunction.SetRCommand("check_graph")
+        clsCheckGraphFunction.AddParameter("graph_object", strLastGraph, iPosition:=0)
+
+        clsAddPlotObjectFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_object")
+        clsAddPlotObjectFunction.AddParameter("object_name", Chr(34) & strLastGraph & Chr(34), iPosition:=1)
+        clsAddPlotObjectFunction.AddParameter("object_type_label", Chr(34) & "graph" & Chr(34), iPosition:=2)
+        clsAddPlotObjectFunction.AddParameter("object_format", Chr(34) & "image" & Chr(34), iPosition:=3)
+        clsAddPlotObjectFunction.AddParameter("object", clsRFunctionParameter:=clsCheckGraphFunction, iPosition:=4)
+
+        clsGetPlotObjectDataFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_object_data")
+        clsGetPlotObjectDataFunction.AddParameter("object_name", Chr(34) & strLastGraph & Chr(34), iPosition:=1)
+        clsGetPlotObjectDataFunction.AddParameter("as_file", "TRUE", iPosition:=2)
+
+        UpdatePlotDataFrameName()
+
+        rdorbd.Checked = True
+
+        UcrBaseExperimentsOneButton.clsRsyntax.ClearCodes()
+        UcrBaseExperimentsOneButton.clsRsyntax.SetBaseRFunction(clsBkRbdFunction)
     End Sub
 
-    Public Sub SetRCodeForControls(bReset As Boolean)
+    Private Sub SetRCodeForControls(bReset As Boolean)
+        bRCodeSet = False
 
+        ucrAlpha.AddAdditionalCodeParameterPair(clsBkFrbdFunction, New RParameter("alpha", 5), iAdditionalPairNo:=1)
 
+        ucrReceiverResponse.SetRCode(clsBkRbdFunction, bReset)
+        ucrReceiverResponse.AddAdditionalCodeParameterPair(clsBkFrbdFunction, New RParameter("trait", 1), iAdditionalPairNo:=1)
+
+        UcrReceiverTreat.SetRCode(clsBkRbdFunction, bReset)
+
+        ucrReceiverFactorA.SetRCode(clsBkFrbdFunction, bReset)
+        ucrReceiverFactorB.SetRCode(clsBkFrbdFunction, bReset)
+
+        ucrRep.SetRCode(clsBkRbdFunction, bReset)
+        ucrRep.AddAdditionalCodeParameterPair(clsBkFrbdFunction, New RParameter("rep", 4), iAdditionalPairNo:=1)
+
+        ucrAlpha.SetRCode(clsBkRbdFunction, bReset)
+
+        ucrSave.SetRCode(clsBkRbdFunction, bReset)
+        ucrSave.SetRCode(clsBkFrbdFunction, bReset)
+
+        If bReset Then
+            ucrPnlExperimentsOneButtonOptions.SetRCode(clsDummyFunction, bReset)
+            ucrChkPlot.SetRCode(clsDummyFunction, bReset)
+        End If
+
+        UpdatePlotCode()
+
+        bRCodeSet = True
     End Sub
 
-    Private Sub TestOkEnabled()
-
+    Private Sub UpdatePlotDataFrameName()
+        Dim strDataFrame As String = ucrSelectorForRank.ucrAvailableDataFrames.cboAvailableDataFrames.Text
+        clsAddPlotObjectFunction.AddParameter("data_name", Chr(34) & strDataFrame & Chr(34), iPosition:=0)
+        clsGetPlotObjectDataFunction.AddParameter("data_name", Chr(34) & strDataFrame & Chr(34), iPosition:=0)
     End Sub
 
-    Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
+    Private Sub UpdatePlotCode()
+        UcrBaseExperimentsOneButton.clsRsyntax.RemoveFromAfterCodes(clsGetPlotObjectDataFunction)
+        UcrBaseExperimentsOneButton.clsRsyntax.RemoveFromAfterCodes(clsAddPlotObjectFunction)
+        UcrBaseExperimentsOneButton.clsRsyntax.RemoveFromAfterCodes(clsBkPlotFunction)
+
+        If ucrChkPlot.Checked Then
+            Dim strModelName As String = If(ucrSave.ucrChkSave.Checked, ucrSave.GetText(), strLastModel)
+
+            If Not String.IsNullOrEmpty(strModelName) Then
+                clsBkPlotFunction.ClearParameters()
+                clsBkPlotFunction.AddParameter("x", strModelName, iPosition:=0, bIncludeArgumentName:=False)
+
+                UpdatePlotDataFrameName()
+
+                UcrBaseExperimentsOneButton.clsRsyntax.AddToAfterCodes(clsBkPlotFunction)
+                UcrBaseExperimentsOneButton.clsRsyntax.AddToAfterCodes(clsAddPlotObjectFunction)
+                UcrBaseExperimentsOneButton.clsRsyntax.AddToAfterCodes(clsGetPlotObjectDataFunction)
+            End If
+        End If
+    End Sub
+
+    Private Sub TestOKEnabled()
+        If rdorbd.Checked Then
+            UcrBaseExperimentsOneButton.OKEnabled(Not ucrReceiverResponse.IsEmpty AndAlso
+                                                 Not UcrReceiverTreat.IsEmpty AndAlso
+                                                 Not ucrRep.IsEmpty AndAlso
+                                                 ucrSave.IsComplete)
+        ElseIf rdoFactorial.Checked Then
+            UcrBaseExperimentsOneButton.OKEnabled(Not ucrReceiverResponse.IsEmpty AndAlso
+                                                 Not ucrReceiverFactorA.IsEmpty AndAlso
+                                                 Not ucrReceiverFactorB.IsEmpty AndAlso
+                                                 Not ucrRep.IsEmpty AndAlso
+                                                 ucrSave.IsComplete)
+        Else
+            UcrBaseExperimentsOneButton.OKEnabled(False)
+        End If
+    End Sub
+
+    Private Sub UcrBaseExperimentsOneButton_ClickReset(sender As Object, e As EventArgs) Handles UcrBaseExperimentsOneButton.ClickReset
         SetDefaults()
         SetRCodeForControls(True)
-        TestOkEnabled()
+        SwitchDesignVisibility()
+        TestOKEnabled()
     End Sub
 
-    Private Sub ucrReceiverFirstVariables_Load(sender As Object, e As EventArgs) Handles ucrReceiverFirstVariables.Load
-
+    Private Sub rdorbd_CheckedChanged(sender As Object, e As EventArgs) Handles rdorbd.CheckedChanged
+        If rdorbd.Checked Then
+            SwitchDesignVisibility()
+            If bRCodeSet Then
+                UcrBaseExperimentsOneButton.clsRsyntax.SetBaseRFunction(clsBkRbdFunction)
+                UpdatePlotCode()
+            End If
+            TestOKEnabled()
+        End If
     End Sub
 
-    Private Sub ucrBase_Load(sender As Object, e As EventArgs) Handles ucrBase.Load
-
+    Private Sub rdoFactorial_CheckedChanged(sender As Object, e As EventArgs) Handles rdoFactorial.CheckedChanged
+        If rdoFactorial.Checked Then
+            SwitchDesignVisibility()
+            If bRCodeSet Then
+                UcrBaseExperimentsOneButton.clsRsyntax.SetBaseRFunction(clsBkFrbdFunction)
+                UpdatePlotCode()
+            End If
+            TestOKEnabled()
+        End If
     End Sub
 
-    Private Sub ucrSaveExperimentsOneButton_Load(sender As Object, e As EventArgs) Handles ucrSaveExperimentsOneButton.Load
+    Private Sub SwitchDesignVisibility()
+        Dim bIsFactorial As Boolean = rdoFactorial.Checked
 
+        lblTreat.Visible = Not bIsFactorial
+        UcrReceiverTreat.Visible = Not bIsFactorial
+
+        lblFactorA.Visible = bIsFactorial
+        ucrReceiverFactorA.Visible = bIsFactorial
+        lblFactorB.Visible = bIsFactorial
+        ucrReceiverFactorB.Visible = bIsFactorial
     End Sub
 
-    Private Sub ucrSelectorExperimentsOneButton_Load(sender As Object, e As EventArgs) Handles ucrSelectorExperimentsOneButton.Load
-
+    Private Sub ucrSelectorForRank_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSelectorForRank.ControlValueChanged
+        clsCurrentDataFrameFunction = ucrSelectorForRank.ucrAvailableDataFrames.clsCurrDataFrame
+        clsBkRbdFunction.AddParameter("data", clsRFunctionParameter:=clsCurrentDataFrameFunction, iPosition:=0)
+        clsBkFrbdFunction.AddParameter("data", clsRFunctionParameter:=clsCurrentDataFrameFunction, iPosition:=0)
+        UpdatePlotDataFrameName()
     End Sub
+
+    Private Sub ucrChkPlot_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkPlot.ControlValueChanged
+        If bRCodeSet Then
+            UpdatePlotCode()
+        End If
+    End Sub
+
+    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles ucrReceiverResponse.ControlContentsChanged,
+        UcrReceiverTreat.ControlContentsChanged, ucrReceiverFactorA.ControlContentsChanged,
+        ucrReceiverFactorB.ControlContentsChanged, ucrRep.ControlContentsChanged, ucrSave.ControlContentsChanged
+        If bRCodeSet Then
+            TestOKEnabled()
+            UpdatePlotCode()
+        End If
+    End Sub
+
 End Class
-
-
-
-
-
-

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -806,7 +806,7 @@ Partial Class frmMain
         '
         Me.mnuDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeOneVariable, Me.mnuDescribeTwoThreeVariables, Me.mnuDescribeSpecificTablesGraphs, Me.mnuDescribeSpecificTables, Me.ToolStripSeparator9, Me.mnuDescribeMultivariate, Me.ToolStripSeparator13, Me.mnuDescribeUseTable, Me.mnuDescribeUseGraph, Me.mnuDescribeCombineGraph, Me.mnuDescribeThemes, Me.mnuDescribeViewGraph})
         Me.mnuDescribe.Name = "mnuDescribe"
-        Me.mnuDescribe.Size = New System.Drawing.Size(81, 24)
+        Me.mnuDescribe.Size = New System.Drawing.Size(64, 20)
         Me.mnuDescribe.Tag = "Describe"
         Me.mnuDescribe.Text = "Describe"
         '
@@ -814,25 +814,25 @@ Partial Class frmMain
         '
         Me.mnuDescribeOneVariable.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeOneVariableVisualiseData, Me.ToolStripSeparator72, Me.mnuDescribeOneVariableSummarise, Me.mnuDescribeOneVariableGraph, Me.ToolStripSeparator33, Me.mnuDescribeOneVariableFrequencies, Me.mnuDescribeOneVariableRatingData, Me.mnuDescribeOneVariableLikertGraphs})
         Me.mnuDescribeOneVariable.Name = "mnuDescribeOneVariable"
-        Me.mnuDescribeOneVariable.Size = New System.Drawing.Size(226, 26)
+        Me.mnuDescribeOneVariable.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeOneVariable.Tag = "One_Variable"
         Me.mnuDescribeOneVariable.Text = "One Variable"
         '
         'mnuDescribeOneVariableVisualiseData
         '
         Me.mnuDescribeOneVariableVisualiseData.Name = "mnuDescribeOneVariableVisualiseData"
-        Me.mnuDescribeOneVariableVisualiseData.Size = New System.Drawing.Size(194, 26)
+        Me.mnuDescribeOneVariableVisualiseData.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableVisualiseData.Text = "Visualise Data..."
         '
         'ToolStripSeparator72
         '
         Me.ToolStripSeparator72.Name = "ToolStripSeparator72"
-        Me.ToolStripSeparator72.Size = New System.Drawing.Size(191, 6)
+        Me.ToolStripSeparator72.Size = New System.Drawing.Size(152, 6)
         '
         'mnuDescribeOneVariableSummarise
         '
         Me.mnuDescribeOneVariableSummarise.Name = "mnuDescribeOneVariableSummarise"
-        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(194, 26)
+        Me.mnuDescribeOneVariableSummarise.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableSummarise.Tag = "Summarise..."
         Me.mnuDescribeOneVariableSummarise.Text = "Summarise..."
         Me.mnuDescribeOneVariableSummarise.ToolTipText = "One Variable Summarise, Skim and Customised"
@@ -840,59 +840,59 @@ Partial Class frmMain
         'mnuDescribeOneVariableGraph
         '
         Me.mnuDescribeOneVariableGraph.Name = "mnuDescribeOneVariableGraph"
-        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(194, 26)
+        Me.mnuDescribeOneVariableGraph.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableGraph.Tag = "Graph..."
         Me.mnuDescribeOneVariableGraph.Text = "Graph..."
         '
         'ToolStripSeparator33
         '
         Me.ToolStripSeparator33.Name = "ToolStripSeparator33"
-        Me.ToolStripSeparator33.Size = New System.Drawing.Size(191, 6)
+        Me.ToolStripSeparator33.Size = New System.Drawing.Size(152, 6)
         '
         'mnuDescribeOneVariableFrequencies
         '
         Me.mnuDescribeOneVariableFrequencies.Name = "mnuDescribeOneVariableFrequencies"
-        Me.mnuDescribeOneVariableFrequencies.Size = New System.Drawing.Size(194, 26)
+        Me.mnuDescribeOneVariableFrequencies.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableFrequencies.Text = "Frequencies..."
         Me.mnuDescribeOneVariableFrequencies.ToolTipText = "Table or Graph. Also Stem and Leaf Plots"
         '
         'mnuDescribeOneVariableRatingData
         '
         Me.mnuDescribeOneVariableRatingData.Name = "mnuDescribeOneVariableRatingData"
-        Me.mnuDescribeOneVariableRatingData.Size = New System.Drawing.Size(194, 26)
+        Me.mnuDescribeOneVariableRatingData.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableRatingData.Text = "Rating Data..."
         Me.mnuDescribeOneVariableRatingData.ToolTipText = "Table, Stacked Graph or Likert Graph"
         '
         'mnuDescribeOneVariableLikertGraphs
         '
         Me.mnuDescribeOneVariableLikertGraphs.Name = "mnuDescribeOneVariableLikertGraphs"
-        Me.mnuDescribeOneVariableLikertGraphs.Size = New System.Drawing.Size(194, 26)
+        Me.mnuDescribeOneVariableLikertGraphs.Size = New System.Drawing.Size(155, 22)
         Me.mnuDescribeOneVariableLikertGraphs.Text = "Likert Graphs..."
         '
         'mnuDescribeTwoThreeVariables
         '
         Me.mnuDescribeTwoThreeVariables.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeTwoThreeVariablesPivotTable, Me.ToolStripSeparator36, Me.mnuDescribeTwoVariablesSummarise, Me.mnuDescribeTwoVariablesGraph, Me.ToolStripSeparator34, Me.mnuDescribeTwoThreeVariablesCorrelations, Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies, Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies, Me.mnuDescribeTwoThreeVariablesMoreLikert})
         Me.mnuDescribeTwoThreeVariables.Name = "mnuDescribeTwoThreeVariables"
-        Me.mnuDescribeTwoThreeVariables.Size = New System.Drawing.Size(226, 26)
+        Me.mnuDescribeTwoThreeVariables.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeTwoThreeVariables.Tag = "Two_Variables"
         Me.mnuDescribeTwoThreeVariables.Text = "Two/Three Variables"
         '
         'mnuDescribeTwoThreeVariablesPivotTable
         '
         Me.mnuDescribeTwoThreeVariablesPivotTable.Name = "mnuDescribeTwoThreeVariablesPivotTable"
-        Me.mnuDescribeTwoThreeVariablesPivotTable.Size = New System.Drawing.Size(254, 26)
+        Me.mnuDescribeTwoThreeVariablesPivotTable.Size = New System.Drawing.Size(207, 22)
         Me.mnuDescribeTwoThreeVariablesPivotTable.Text = "Pivot Table..."
         '
         'ToolStripSeparator36
         '
         Me.ToolStripSeparator36.Name = "ToolStripSeparator36"
-        Me.ToolStripSeparator36.Size = New System.Drawing.Size(251, 6)
+        Me.ToolStripSeparator36.Size = New System.Drawing.Size(204, 6)
         '
         'mnuDescribeTwoVariablesSummarise
         '
         Me.mnuDescribeTwoVariablesSummarise.DoubleClickEnabled = True
         Me.mnuDescribeTwoVariablesSummarise.Name = "mnuDescribeTwoVariablesSummarise"
-        Me.mnuDescribeTwoVariablesSummarise.Size = New System.Drawing.Size(254, 26)
+        Me.mnuDescribeTwoVariablesSummarise.Size = New System.Drawing.Size(207, 22)
         Me.mnuDescribeTwoVariablesSummarise.Tag = "Summarise..."
         Me.mnuDescribeTwoVariablesSummarise.Text = "Summarise..."
         Me.mnuDescribeTwoVariablesSummarise.ToolTipText = "Skim or Two Variables"
@@ -900,19 +900,19 @@ Partial Class frmMain
         'mnuDescribeTwoVariablesGraph
         '
         Me.mnuDescribeTwoVariablesGraph.Name = "mnuDescribeTwoVariablesGraph"
-        Me.mnuDescribeTwoVariablesGraph.Size = New System.Drawing.Size(254, 26)
+        Me.mnuDescribeTwoVariablesGraph.Size = New System.Drawing.Size(207, 22)
         Me.mnuDescribeTwoVariablesGraph.Tag = "Graph..."
         Me.mnuDescribeTwoVariablesGraph.Text = "Graph..."
         '
         'ToolStripSeparator34
         '
         Me.ToolStripSeparator34.Name = "ToolStripSeparator34"
-        Me.ToolStripSeparator34.Size = New System.Drawing.Size(251, 6)
+        Me.ToolStripSeparator34.Size = New System.Drawing.Size(204, 6)
         '
         'mnuDescribeTwoThreeVariablesCorrelations
         '
         Me.mnuDescribeTwoThreeVariablesCorrelations.Name = "mnuDescribeTwoThreeVariablesCorrelations"
-        Me.mnuDescribeTwoThreeVariablesCorrelations.Size = New System.Drawing.Size(254, 26)
+        Me.mnuDescribeTwoThreeVariablesCorrelations.Size = New System.Drawing.Size(207, 22)
         Me.mnuDescribeTwoThreeVariablesCorrelations.Text = "Correlations..."
         Me.mnuDescribeTwoThreeVariablesCorrelations.ToolTipText = "Multiple Variables or Two Variables"
         '
@@ -920,35 +920,35 @@ Partial Class frmMain
         '
         Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.DoubleClickEnabled = True
         Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Name = "mnuDescribeTwoThreeVariablesTwoWayFrequencies"
-        Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Size = New System.Drawing.Size(254, 26)
+        Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Size = New System.Drawing.Size(207, 22)
         Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.Text = "Two-Way Frequencies..."
         Me.mnuDescribeTwoThreeVariablesTwoWayFrequencies.ToolTipText = "Table or Graph"
         '
         'mnuDescribeTwoThreeVariablesThreeWayFrequencies
         '
         Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Name = "mnuDescribeTwoThreeVariablesThreeWayFrequencies"
-        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Size = New System.Drawing.Size(254, 26)
+        Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Size = New System.Drawing.Size(207, 22)
         Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.Text = "Three-Way Frequencies..."
         Me.mnuDescribeTwoThreeVariablesThreeWayFrequencies.ToolTipText = "Table or Graph"
         '
         'mnuDescribeTwoThreeVariablesMoreLikert
         '
         Me.mnuDescribeTwoThreeVariablesMoreLikert.Name = "mnuDescribeTwoThreeVariablesMoreLikert"
-        Me.mnuDescribeTwoThreeVariablesMoreLikert.Size = New System.Drawing.Size(254, 26)
+        Me.mnuDescribeTwoThreeVariablesMoreLikert.Size = New System.Drawing.Size(207, 22)
         Me.mnuDescribeTwoThreeVariablesMoreLikert.Text = "More Likert..."
         '
         'mnuDescribeSpecificTablesGraphs
         '
         Me.mnuDescribeSpecificTablesGraphs.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeSpecificBarPieChart, Me.mnuDescribeSpecificBoxplotJitterViolinPlot, Me.mnuDescribeSpecificHistogramDensityFrequencyPlot, Me.mnuDescribeSpecificPointPlot, Me.mnuDescribeSpecificLineSmoothPlot, Me.ToolStripSeparator38, Me.mnuDescribeGeneral, Me.ToolStripSeparator26, Me.mnuDescribeSpecificMapPlot, Me.mnuDescribeSpecificDotPlot, Me.mnuDescribeSpecificMosaic, Me.mnuDescribeSpecificCummulativeDistribution, Me.mnuDescribeSpecificParallelCoordinatePlot})
         Me.mnuDescribeSpecificTablesGraphs.Name = "mnuDescribeSpecificTablesGraphs"
-        Me.mnuDescribeSpecificTablesGraphs.Size = New System.Drawing.Size(226, 26)
+        Me.mnuDescribeSpecificTablesGraphs.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeSpecificTablesGraphs.Tag = "Graph_Dialogs"
         Me.mnuDescribeSpecificTablesGraphs.Text = "Graphs"
         '
         'mnuDescribeSpecificBarPieChart
         '
         Me.mnuDescribeSpecificBarPieChart.Name = "mnuDescribeSpecificBarPieChart"
-        Me.mnuDescribeSpecificBarPieChart.Size = New System.Drawing.Size(257, 26)
+        Me.mnuDescribeSpecificBarPieChart.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificBarPieChart.Tag = "Bar_Chart"
         Me.mnuDescribeSpecificBarPieChart.Text = "Bar Chart..."
         Me.mnuDescribeSpecificBarPieChart.ToolTipText = "Bar, Column, Lollipop, Pie, and Donut Charts, plus Treemaps and Wordclouds"
@@ -956,7 +956,7 @@ Partial Class frmMain
         'mnuDescribeSpecificBoxplotJitterViolinPlot
         '
         Me.mnuDescribeSpecificBoxplotJitterViolinPlot.Name = "mnuDescribeSpecificBoxplotJitterViolinPlot"
-        Me.mnuDescribeSpecificBoxplotJitterViolinPlot.Size = New System.Drawing.Size(257, 26)
+        Me.mnuDescribeSpecificBoxplotJitterViolinPlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificBoxplotJitterViolinPlot.Tag = "Boxplot..."
         Me.mnuDescribeSpecificBoxplotJitterViolinPlot.Text = "Boxplot..."
         Me.mnuDescribeSpecificBoxplotJitterViolinPlot.ToolTipText = "Boxplot (including Tufte), Jitter and Violin Plots"
@@ -964,7 +964,7 @@ Partial Class frmMain
         'mnuDescribeSpecificHistogramDensityFrequencyPlot
         '
         Me.mnuDescribeSpecificHistogramDensityFrequencyPlot.Name = "mnuDescribeSpecificHistogramDensityFrequencyPlot"
-        Me.mnuDescribeSpecificHistogramDensityFrequencyPlot.Size = New System.Drawing.Size(257, 26)
+        Me.mnuDescribeSpecificHistogramDensityFrequencyPlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificHistogramDensityFrequencyPlot.Tag = "Histogram..."
         Me.mnuDescribeSpecificHistogramDensityFrequencyPlot.Text = "Histogram..."
         Me.mnuDescribeSpecificHistogramDensityFrequencyPlot.ToolTipText = "Histograms, Dotplots, Density and Ridge Plots and Frequency Polygons"
@@ -972,7 +972,7 @@ Partial Class frmMain
         'mnuDescribeSpecificPointPlot
         '
         Me.mnuDescribeSpecificPointPlot.Name = "mnuDescribeSpecificPointPlot"
-        Me.mnuDescribeSpecificPointPlot.Size = New System.Drawing.Size(257, 26)
+        Me.mnuDescribeSpecificPointPlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificPointPlot.Tag = "Point_Plot..."
         Me.mnuDescribeSpecificPointPlot.Text = "Scatter Plot..."
         Me.mnuDescribeSpecificPointPlot.ToolTipText = "Point Plot"
@@ -980,7 +980,7 @@ Partial Class frmMain
         'mnuDescribeSpecificLineSmoothPlot
         '
         Me.mnuDescribeSpecificLineSmoothPlot.Name = "mnuDescribeSpecificLineSmoothPlot"
-        Me.mnuDescribeSpecificLineSmoothPlot.Size = New System.Drawing.Size(257, 26)
+        Me.mnuDescribeSpecificLineSmoothPlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificLineSmoothPlot.Tag = "Line_Plot..."
         Me.mnuDescribeSpecificLineSmoothPlot.Text = "Line Plot..."
         Me.mnuDescribeSpecificLineSmoothPlot.ToolTipText = "Line Plots, Smoothed Plots, Dumbbell and Slope Plots"
@@ -988,23 +988,23 @@ Partial Class frmMain
         'ToolStripSeparator38
         '
         Me.ToolStripSeparator38.Name = "ToolStripSeparator38"
-        Me.ToolStripSeparator38.Size = New System.Drawing.Size(254, 6)
+        Me.ToolStripSeparator38.Size = New System.Drawing.Size(206, 6)
         '
         'mnuDescribeGeneral
         '
         Me.mnuDescribeGeneral.Name = "mnuDescribeGeneral"
-        Me.mnuDescribeGeneral.Size = New System.Drawing.Size(257, 26)
+        Me.mnuDescribeGeneral.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeGeneral.Text = "General..."
         '
         'ToolStripSeparator26
         '
         Me.ToolStripSeparator26.Name = "ToolStripSeparator26"
-        Me.ToolStripSeparator26.Size = New System.Drawing.Size(254, 6)
+        Me.ToolStripSeparator26.Size = New System.Drawing.Size(206, 6)
         '
         'mnuDescribeSpecificMapPlot
         '
         Me.mnuDescribeSpecificMapPlot.Name = "mnuDescribeSpecificMapPlot"
-        Me.mnuDescribeSpecificMapPlot.Size = New System.Drawing.Size(257, 26)
+        Me.mnuDescribeSpecificMapPlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificMapPlot.Text = "Heatmap..."
         Me.mnuDescribeSpecificMapPlot.ToolTipText = "Heat Map and Chorolopleth Map"
         '
@@ -1012,7 +1012,7 @@ Partial Class frmMain
         '
         Me.mnuDescribeSpecificDotPlot.Enabled = False
         Me.mnuDescribeSpecificDotPlot.Name = "mnuDescribeSpecificDotPlot"
-        Me.mnuDescribeSpecificDotPlot.Size = New System.Drawing.Size(257, 26)
+        Me.mnuDescribeSpecificDotPlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificDotPlot.Tag = "Dotplot..."
         Me.mnuDescribeSpecificDotPlot.Text = "Dot Plot..."
         Me.mnuDescribeSpecificDotPlot.Visible = False
@@ -1020,28 +1020,28 @@ Partial Class frmMain
         'mnuDescribeSpecificMosaic
         '
         Me.mnuDescribeSpecificMosaic.Name = "mnuDescribeSpecificMosaic"
-        Me.mnuDescribeSpecificMosaic.Size = New System.Drawing.Size(257, 26)
+        Me.mnuDescribeSpecificMosaic.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificMosaic.Text = "Mosaic Plot..."
         Me.mnuDescribeSpecificMosaic.ToolTipText = "Mosaic Plot"
         '
         'mnuDescribeSpecificCummulativeDistribution
         '
         Me.mnuDescribeSpecificCummulativeDistribution.Name = "mnuDescribeSpecificCummulativeDistribution"
-        Me.mnuDescribeSpecificCummulativeDistribution.Size = New System.Drawing.Size(257, 26)
+        Me.mnuDescribeSpecificCummulativeDistribution.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificCummulativeDistribution.Text = "Cumulative Distribution..."
         Me.mnuDescribeSpecificCummulativeDistribution.ToolTipText = "Cumulative Graph and Exceedance Graph"
         '
         'mnuDescribeSpecificParallelCoordinatePlot
         '
         Me.mnuDescribeSpecificParallelCoordinatePlot.Name = "mnuDescribeSpecificParallelCoordinatePlot"
-        Me.mnuDescribeSpecificParallelCoordinatePlot.Size = New System.Drawing.Size(257, 26)
+        Me.mnuDescribeSpecificParallelCoordinatePlot.Size = New System.Drawing.Size(209, 22)
         Me.mnuDescribeSpecificParallelCoordinatePlot.Text = "Parallel Coordinate Plot..."
         '
         'mnuDescribeSpecificTables
         '
         Me.mnuDescribeSpecificTables.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeSummaries, Me.mnuDescribePresentation})
         Me.mnuDescribeSpecificTables.Name = "mnuDescribeSpecificTables"
-        Me.mnuDescribeSpecificTables.Size = New System.Drawing.Size(226, 26)
+        Me.mnuDescribeSpecificTables.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeSpecificTables.Tag = "Table_Dialogs"
         Me.mnuDescribeSpecificTables.Text = "Tables..."
         Me.mnuDescribeSpecificTables.ToolTipText = "Frequency tables and Summary tables"
@@ -1049,95 +1049,95 @@ Partial Class frmMain
         'mnuDescribeSummaries
         '
         Me.mnuDescribeSummaries.Name = "mnuDescribeSummaries"
-        Me.mnuDescribeSummaries.Size = New System.Drawing.Size(183, 26)
+        Me.mnuDescribeSummaries.Size = New System.Drawing.Size(149, 22)
         Me.mnuDescribeSummaries.Text = "Summaries..."
         '
         'mnuDescribePresentation
         '
         Me.mnuDescribePresentation.Name = "mnuDescribePresentation"
-        Me.mnuDescribePresentation.Size = New System.Drawing.Size(183, 26)
+        Me.mnuDescribePresentation.Size = New System.Drawing.Size(149, 22)
         Me.mnuDescribePresentation.Text = "Presentation..."
         '
         'ToolStripSeparator9
         '
         Me.ToolStripSeparator9.Name = "ToolStripSeparator9"
-        Me.ToolStripSeparator9.Size = New System.Drawing.Size(223, 6)
+        Me.ToolStripSeparator9.Size = New System.Drawing.Size(177, 6)
         '
         'mnuDescribeMultivariate
         '
         Me.mnuDescribeMultivariate.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuDescribeMultivariateCorrelations, Me.mnuDescribeMultivariateprincipalComponents, Me.mnuDescribeMultivariateCanonicalCorrelations, Me.mnuDescribeMultivariateClusterAnalysis})
         Me.mnuDescribeMultivariate.Name = "mnuDescribeMultivariate"
-        Me.mnuDescribeMultivariate.Size = New System.Drawing.Size(226, 26)
+        Me.mnuDescribeMultivariate.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeMultivariate.Text = "Multivariate"
         '
         'mnuDescribeMultivariateCorrelations
         '
         Me.mnuDescribeMultivariateCorrelations.Name = "mnuDescribeMultivariateCorrelations"
-        Me.mnuDescribeMultivariateCorrelations.Size = New System.Drawing.Size(250, 26)
+        Me.mnuDescribeMultivariateCorrelations.Size = New System.Drawing.Size(203, 22)
         Me.mnuDescribeMultivariateCorrelations.Text = "Correlations..."
         Me.mnuDescribeMultivariateCorrelations.ToolTipText = "Multiple Variables or Two Variables"
         '
         'mnuDescribeMultivariateprincipalComponents
         '
         Me.mnuDescribeMultivariateprincipalComponents.Name = "mnuDescribeMultivariateprincipalComponents"
-        Me.mnuDescribeMultivariateprincipalComponents.Size = New System.Drawing.Size(250, 26)
+        Me.mnuDescribeMultivariateprincipalComponents.Size = New System.Drawing.Size(203, 22)
         Me.mnuDescribeMultivariateprincipalComponents.Text = "Principal Components..."
         '
         'mnuDescribeMultivariateCanonicalCorrelations
         '
         Me.mnuDescribeMultivariateCanonicalCorrelations.Name = "mnuDescribeMultivariateCanonicalCorrelations"
-        Me.mnuDescribeMultivariateCanonicalCorrelations.Size = New System.Drawing.Size(250, 26)
+        Me.mnuDescribeMultivariateCanonicalCorrelations.Size = New System.Drawing.Size(203, 22)
         Me.mnuDescribeMultivariateCanonicalCorrelations.Text = "Canonical Correlations..."
         '
         'mnuDescribeMultivariateClusterAnalysis
         '
         Me.mnuDescribeMultivariateClusterAnalysis.Name = "mnuDescribeMultivariateClusterAnalysis"
-        Me.mnuDescribeMultivariateClusterAnalysis.Size = New System.Drawing.Size(250, 26)
+        Me.mnuDescribeMultivariateClusterAnalysis.Size = New System.Drawing.Size(203, 22)
         Me.mnuDescribeMultivariateClusterAnalysis.Text = "Cluster Analysis..."
         Me.mnuDescribeMultivariateClusterAnalysis.ToolTipText = "Partitioning or Hierarchical"
         '
         'ToolStripSeparator13
         '
         Me.ToolStripSeparator13.Name = "ToolStripSeparator13"
-        Me.ToolStripSeparator13.Size = New System.Drawing.Size(223, 6)
+        Me.ToolStripSeparator13.Size = New System.Drawing.Size(177, 6)
         '
         'mnuDescribeUseTable
         '
         Me.mnuDescribeUseTable.Name = "mnuDescribeUseTable"
-        Me.mnuDescribeUseTable.Size = New System.Drawing.Size(226, 26)
+        Me.mnuDescribeUseTable.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeUseTable.Text = "Use Table..."
         '
         'mnuDescribeUseGraph
         '
         Me.mnuDescribeUseGraph.Name = "mnuDescribeUseGraph"
-        Me.mnuDescribeUseGraph.Size = New System.Drawing.Size(226, 26)
+        Me.mnuDescribeUseGraph.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeUseGraph.Text = "Use Graph..."
         '
         'mnuDescribeCombineGraph
         '
         Me.mnuDescribeCombineGraph.Name = "mnuDescribeCombineGraph"
-        Me.mnuDescribeCombineGraph.Size = New System.Drawing.Size(226, 26)
+        Me.mnuDescribeCombineGraph.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeCombineGraph.Text = "Combine Graphs..."
         '
         'mnuDescribeThemes
         '
         Me.mnuDescribeThemes.Enabled = False
         Me.mnuDescribeThemes.Name = "mnuDescribeThemes"
-        Me.mnuDescribeThemes.Size = New System.Drawing.Size(226, 26)
+        Me.mnuDescribeThemes.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeThemes.Text = "Themes..."
         Me.mnuDescribeThemes.Visible = False
         '
         'mnuDescribeViewGraph
         '
         Me.mnuDescribeViewGraph.Name = "mnuDescribeViewGraph"
-        Me.mnuDescribeViewGraph.Size = New System.Drawing.Size(226, 26)
+        Me.mnuDescribeViewGraph.Size = New System.Drawing.Size(180, 22)
         Me.mnuDescribeViewGraph.Text = "View Graph..."
         '
         'mnuModel
         '
         Me.mnuModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelProbabilityDistributions, Me.ToolStripSeparator3, Me.mnuModelFitModel, Me.mnuModelCompareModels, Me.mnuModelUseModel, Me.mnuModelOtherOneVariable, Me.mnuModelOtherTwoVariables, Me.mnuModelOtherThreeVariables, Me.mnuModelOtherGeneral})
         Me.mnuModel.Name = "mnuModel"
-        Me.mnuModel.Size = New System.Drawing.Size(66, 24)
+        Me.mnuModel.Size = New System.Drawing.Size(53, 20)
         Me.mnuModel.Tag = "Model"
         Me.mnuModel.Text = "Model"
         '
@@ -1145,168 +1145,168 @@ Partial Class frmMain
         '
         Me.mnuModelProbabilityDistributions.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelProbabilityDistributionsShowModel, Me.mnuModelProbabilityDistributionsCompareModels, Me.mnuModelProbabilityDistributionsRandomSamplesUseModel})
         Me.mnuModelProbabilityDistributions.Name = "mnuModelProbabilityDistributions"
-        Me.mnuModelProbabilityDistributions.Size = New System.Drawing.Size(252, 26)
+        Me.mnuModelProbabilityDistributions.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelProbabilityDistributions.Tag = "Probability_Distributions"
         Me.mnuModelProbabilityDistributions.Text = "Probability Distributions"
         '
         'mnuModelProbabilityDistributionsShowModel
         '
         Me.mnuModelProbabilityDistributionsShowModel.Name = "mnuModelProbabilityDistributionsShowModel"
-        Me.mnuModelProbabilityDistributionsShowModel.Size = New System.Drawing.Size(221, 26)
+        Me.mnuModelProbabilityDistributionsShowModel.Size = New System.Drawing.Size(178, 22)
         Me.mnuModelProbabilityDistributionsShowModel.Text = "Show Model..."
         '
         'mnuModelProbabilityDistributionsCompareModels
         '
         Me.mnuModelProbabilityDistributionsCompareModels.Enabled = False
         Me.mnuModelProbabilityDistributionsCompareModels.Name = "mnuModelProbabilityDistributionsCompareModels"
-        Me.mnuModelProbabilityDistributionsCompareModels.Size = New System.Drawing.Size(221, 26)
+        Me.mnuModelProbabilityDistributionsCompareModels.Size = New System.Drawing.Size(178, 22)
         Me.mnuModelProbabilityDistributionsCompareModels.Tag = "Show_Models..."
         Me.mnuModelProbabilityDistributionsCompareModels.Text = "Compare Models..."
         '
         'mnuModelProbabilityDistributionsRandomSamplesUseModel
         '
         Me.mnuModelProbabilityDistributionsRandomSamplesUseModel.Name = "mnuModelProbabilityDistributionsRandomSamplesUseModel"
-        Me.mnuModelProbabilityDistributionsRandomSamplesUseModel.Size = New System.Drawing.Size(221, 26)
+        Me.mnuModelProbabilityDistributionsRandomSamplesUseModel.Size = New System.Drawing.Size(178, 22)
         Me.mnuModelProbabilityDistributionsRandomSamplesUseModel.Tag = "RandomSamples_(Use_Model)..."
         Me.mnuModelProbabilityDistributionsRandomSamplesUseModel.Text = "Random Samples ..."
         '
         'ToolStripSeparator3
         '
         Me.ToolStripSeparator3.Name = "ToolStripSeparator3"
-        Me.ToolStripSeparator3.Size = New System.Drawing.Size(249, 6)
+        Me.ToolStripSeparator3.Size = New System.Drawing.Size(198, 6)
         '
         'mnuModelFitModel
         '
         Me.mnuModelFitModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelFitModelOneVariable, Me.mnuModelFitModelTwoVariables, Me.mnuModelFitModelThreeVariables, Me.mnuModelFitModelFourVariables, Me.ToolStripSeparator24, Me.mnuModelFitModelGeneral, Me.mnuModelFitModelMachineLearning, Me.ToolStripSeparator57, Me.mnuModelFitModelHypothesisTestsKeyboard, Me.mnuModelFitModelModelKeyboard})
         Me.mnuModelFitModel.Name = "mnuModelFitModel"
-        Me.mnuModelFitModel.Size = New System.Drawing.Size(252, 26)
+        Me.mnuModelFitModel.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelFitModel.Tag = "Fit_Model..."
         Me.mnuModelFitModel.Text = "Fit Model"
         '
         'mnuModelFitModelOneVariable
         '
         Me.mnuModelFitModelOneVariable.Name = "mnuModelFitModelOneVariable"
-        Me.mnuModelFitModelOneVariable.Size = New System.Drawing.Size(284, 26)
+        Me.mnuModelFitModelOneVariable.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelOneVariable.Text = "One Variable..."
         '
         'mnuModelFitModelTwoVariables
         '
         Me.mnuModelFitModelTwoVariables.Name = "mnuModelFitModelTwoVariables"
-        Me.mnuModelFitModelTwoVariables.Size = New System.Drawing.Size(284, 26)
+        Me.mnuModelFitModelTwoVariables.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelTwoVariables.Text = "Two Variables..."
         '
         'mnuModelFitModelThreeVariables
         '
         Me.mnuModelFitModelThreeVariables.Name = "mnuModelFitModelThreeVariables"
-        Me.mnuModelFitModelThreeVariables.Size = New System.Drawing.Size(284, 26)
+        Me.mnuModelFitModelThreeVariables.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelThreeVariables.Text = "Three Variables..."
         '
         'mnuModelFitModelFourVariables
         '
         Me.mnuModelFitModelFourVariables.Name = "mnuModelFitModelFourVariables"
-        Me.mnuModelFitModelFourVariables.Size = New System.Drawing.Size(284, 26)
+        Me.mnuModelFitModelFourVariables.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelFourVariables.Text = "Four Variables..."
         '
         'ToolStripSeparator24
         '
         Me.ToolStripSeparator24.Name = "ToolStripSeparator24"
-        Me.ToolStripSeparator24.Size = New System.Drawing.Size(281, 6)
+        Me.ToolStripSeparator24.Size = New System.Drawing.Size(226, 6)
         '
         'mnuModelFitModelGeneral
         '
         Me.mnuModelFitModelGeneral.Name = "mnuModelFitModelGeneral"
-        Me.mnuModelFitModelGeneral.Size = New System.Drawing.Size(284, 26)
+        Me.mnuModelFitModelGeneral.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelGeneral.Text = "General..."
         '
         'mnuModelFitModelMachineLearning
         '
         Me.mnuModelFitModelMachineLearning.Enabled = False
         Me.mnuModelFitModelMachineLearning.Name = "mnuModelFitModelMachineLearning"
-        Me.mnuModelFitModelMachineLearning.Size = New System.Drawing.Size(284, 26)
+        Me.mnuModelFitModelMachineLearning.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelMachineLearning.Text = "Machine Learning (Caret)..."
         Me.mnuModelFitModelMachineLearning.Visible = False
         '
         'ToolStripSeparator57
         '
         Me.ToolStripSeparator57.Name = "ToolStripSeparator57"
-        Me.ToolStripSeparator57.Size = New System.Drawing.Size(281, 6)
+        Me.ToolStripSeparator57.Size = New System.Drawing.Size(226, 6)
         '
         'mnuModelFitModelHypothesisTestsKeyboard
         '
         Me.mnuModelFitModelHypothesisTestsKeyboard.Name = "mnuModelFitModelHypothesisTestsKeyboard"
-        Me.mnuModelFitModelHypothesisTestsKeyboard.Size = New System.Drawing.Size(284, 26)
+        Me.mnuModelFitModelHypothesisTestsKeyboard.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelHypothesisTestsKeyboard.Text = "Hypothesis Tests Keyboards..."
         '
         'mnuModelFitModelModelKeyboard
         '
         Me.mnuModelFitModelModelKeyboard.Name = "mnuModelFitModelModelKeyboard"
-        Me.mnuModelFitModelModelKeyboard.Size = New System.Drawing.Size(284, 26)
+        Me.mnuModelFitModelModelKeyboard.Size = New System.Drawing.Size(229, 22)
         Me.mnuModelFitModelModelKeyboard.Text = "Fit Model Keyboards..."
         '
         'mnuModelCompareModels
         '
         Me.mnuModelCompareModels.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelCompareModelsOneVariable})
         Me.mnuModelCompareModels.Name = "mnuModelCompareModels"
-        Me.mnuModelCompareModels.Size = New System.Drawing.Size(252, 26)
+        Me.mnuModelCompareModels.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelCompareModels.Text = "Compare Models"
         '
         'mnuModelCompareModelsOneVariable
         '
         Me.mnuModelCompareModelsOneVariable.Name = "mnuModelCompareModelsOneVariable"
-        Me.mnuModelCompareModelsOneVariable.Size = New System.Drawing.Size(186, 26)
+        Me.mnuModelCompareModelsOneVariable.Size = New System.Drawing.Size(149, 22)
         Me.mnuModelCompareModelsOneVariable.Text = "One Variable..."
         '
         'mnuModelUseModel
         '
         Me.mnuModelUseModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelUseModelOneVariable, Me.mnuModelUseModelTwoVariables, Me.ToolStripSeparator59, Me.mnuModelUseModelGlance, Me.mnuModelUseModelTidy, Me.mnuModelUseModelAugment, Me.ToolStripSeparator58, Me.mnuModelUseModelUseModelKeyboard})
         Me.mnuModelUseModel.Name = "mnuModelUseModel"
-        Me.mnuModelUseModel.Size = New System.Drawing.Size(252, 26)
+        Me.mnuModelUseModel.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelUseModel.Text = "Use Model"
         '
         'mnuModelUseModelOneVariable
         '
         Me.mnuModelUseModelOneVariable.Name = "mnuModelUseModelOneVariable"
-        Me.mnuModelUseModelOneVariable.Size = New System.Drawing.Size(246, 26)
+        Me.mnuModelUseModelOneVariable.Size = New System.Drawing.Size(197, 22)
         Me.mnuModelUseModelOneVariable.Text = "One Variable..."
         '
         'mnuModelUseModelTwoVariables
         '
         Me.mnuModelUseModelTwoVariables.Name = "mnuModelUseModelTwoVariables"
-        Me.mnuModelUseModelTwoVariables.Size = New System.Drawing.Size(246, 26)
+        Me.mnuModelUseModelTwoVariables.Size = New System.Drawing.Size(197, 22)
         Me.mnuModelUseModelTwoVariables.Text = "Two Variables..."
         '
         'ToolStripSeparator59
         '
         Me.ToolStripSeparator59.Name = "ToolStripSeparator59"
-        Me.ToolStripSeparator59.Size = New System.Drawing.Size(243, 6)
+        Me.ToolStripSeparator59.Size = New System.Drawing.Size(194, 6)
         '
         'mnuModelUseModelGlance
         '
         Me.mnuModelUseModelGlance.Name = "mnuModelUseModelGlance"
-        Me.mnuModelUseModelGlance.Size = New System.Drawing.Size(246, 26)
+        Me.mnuModelUseModelGlance.Size = New System.Drawing.Size(197, 22)
         Me.mnuModelUseModelGlance.Text = "Glance..."
         '
         'mnuModelUseModelTidy
         '
         Me.mnuModelUseModelTidy.Name = "mnuModelUseModelTidy"
-        Me.mnuModelUseModelTidy.Size = New System.Drawing.Size(246, 26)
+        Me.mnuModelUseModelTidy.Size = New System.Drawing.Size(197, 22)
         Me.mnuModelUseModelTidy.Text = "Tidy..."
         '
         'mnuModelUseModelAugment
         '
         Me.mnuModelUseModelAugment.Name = "mnuModelUseModelAugment"
-        Me.mnuModelUseModelAugment.Size = New System.Drawing.Size(246, 26)
+        Me.mnuModelUseModelAugment.Size = New System.Drawing.Size(197, 22)
         Me.mnuModelUseModelAugment.Text = "Augment..."
         '
         'ToolStripSeparator58
         '
         Me.ToolStripSeparator58.Name = "ToolStripSeparator58"
-        Me.ToolStripSeparator58.Size = New System.Drawing.Size(243, 6)
+        Me.ToolStripSeparator58.Size = New System.Drawing.Size(194, 6)
         '
         'mnuModelUseModelUseModelKeyboard
         '
         Me.mnuModelUseModelUseModelKeyboard.Name = "mnuModelUseModelUseModelKeyboard"
-        Me.mnuModelUseModelUseModelKeyboard.Size = New System.Drawing.Size(246, 26)
+        Me.mnuModelUseModelUseModelKeyboard.Size = New System.Drawing.Size(197, 22)
         Me.mnuModelUseModelUseModelKeyboard.Text = "Use Model Keyboards..."
         '
         'mnuModelOtherOneVariable
@@ -1314,7 +1314,7 @@ Partial Class frmMain
         Me.mnuModelOtherOneVariable.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelOtherOneVariableExactResults, Me.mnuModelOtherOneVariableSampleSummaryData, Me.mnuModelOtherOneVariableNonParametric, Me.mnuModelOtherOneVariableGoodnessofFit})
         Me.mnuModelOtherOneVariable.Enabled = False
         Me.mnuModelOtherOneVariable.Name = "mnuModelOtherOneVariable"
-        Me.mnuModelOtherOneVariable.Size = New System.Drawing.Size(252, 26)
+        Me.mnuModelOtherOneVariable.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelOtherOneVariable.Tag = "Other_(One_Variable)"
         Me.mnuModelOtherOneVariable.Text = "Other (One Variable)"
         Me.mnuModelOtherOneVariable.Visible = False
@@ -1322,7 +1322,7 @@ Partial Class frmMain
         'mnuModelOtherOneVariableExactResults
         '
         Me.mnuModelOtherOneVariableExactResults.Name = "mnuModelOtherOneVariableExactResults"
-        Me.mnuModelOtherOneVariableExactResults.Size = New System.Drawing.Size(204, 26)
+        Me.mnuModelOtherOneVariableExactResults.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherOneVariableExactResults.Tag = "Exact_Results..."
         Me.mnuModelOtherOneVariableExactResults.Text = "Exact Results..."
         '
@@ -1330,7 +1330,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherOneVariableSampleSummaryData.Enabled = False
         Me.mnuModelOtherOneVariableSampleSummaryData.Name = "mnuModelOtherOneVariableSampleSummaryData"
-        Me.mnuModelOtherOneVariableSampleSummaryData.Size = New System.Drawing.Size(204, 26)
+        Me.mnuModelOtherOneVariableSampleSummaryData.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherOneVariableSampleSummaryData.Tag = "Summary_Data..."
         Me.mnuModelOtherOneVariableSampleSummaryData.Text = "Summary Data..."
         '
@@ -1338,7 +1338,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherOneVariableNonParametric.Enabled = False
         Me.mnuModelOtherOneVariableNonParametric.Name = "mnuModelOtherOneVariableNonParametric"
-        Me.mnuModelOtherOneVariableNonParametric.Size = New System.Drawing.Size(204, 26)
+        Me.mnuModelOtherOneVariableNonParametric.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherOneVariableNonParametric.Tag = "Non_Parametric..."
         Me.mnuModelOtherOneVariableNonParametric.Text = "Non Parametric..."
         '
@@ -1346,7 +1346,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherOneVariableGoodnessofFit.Enabled = False
         Me.mnuModelOtherOneVariableGoodnessofFit.Name = "mnuModelOtherOneVariableGoodnessofFit"
-        Me.mnuModelOtherOneVariableGoodnessofFit.Size = New System.Drawing.Size(204, 26)
+        Me.mnuModelOtherOneVariableGoodnessofFit.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherOneVariableGoodnessofFit.Tag = "Goodness_of_Fit"
         Me.mnuModelOtherOneVariableGoodnessofFit.Text = "Goodness of Fit..."
         '
@@ -1355,7 +1355,7 @@ Partial Class frmMain
         Me.mnuModelOtherTwoVariables.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelOtherTwoVariablesTwoSamples, Me.mnuModelOtherTwoVariablesSummaryData, Me.mnuModelOtherTwoVariablesSimpleRegression, Me.mnuModelOtherTwoVariablesOneWayANOVA, Me.mnuModelOtherTwoVariablesNonParametricTwoSamples, Me.mnuModelOtherTwoVariablesNonParametricOneWayANOVA})
         Me.mnuModelOtherTwoVariables.Enabled = False
         Me.mnuModelOtherTwoVariables.Name = "mnuModelOtherTwoVariables"
-        Me.mnuModelOtherTwoVariables.Size = New System.Drawing.Size(252, 26)
+        Me.mnuModelOtherTwoVariables.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelOtherTwoVariables.Tag = "Other_(Two_Variables)"
         Me.mnuModelOtherTwoVariables.Text = "Other (Two Variables)"
         Me.mnuModelOtherTwoVariables.Visible = False
@@ -1364,7 +1364,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherTwoVariablesTwoSamples.Enabled = False
         Me.mnuModelOtherTwoVariablesTwoSamples.Name = "mnuModelOtherTwoVariablesTwoSamples"
-        Me.mnuModelOtherTwoVariablesTwoSamples.Size = New System.Drawing.Size(328, 26)
+        Me.mnuModelOtherTwoVariablesTwoSamples.Size = New System.Drawing.Size(266, 22)
         Me.mnuModelOtherTwoVariablesTwoSamples.Tag = "Two_Samples..."
         Me.mnuModelOtherTwoVariablesTwoSamples.Text = "Two Samples..."
         '
@@ -1372,21 +1372,21 @@ Partial Class frmMain
         '
         Me.mnuModelOtherTwoVariablesSummaryData.Enabled = False
         Me.mnuModelOtherTwoVariablesSummaryData.Name = "mnuModelOtherTwoVariablesSummaryData"
-        Me.mnuModelOtherTwoVariablesSummaryData.Size = New System.Drawing.Size(328, 26)
+        Me.mnuModelOtherTwoVariablesSummaryData.Size = New System.Drawing.Size(266, 22)
         Me.mnuModelOtherTwoVariablesSummaryData.Tag = "Summary_Data..."
         Me.mnuModelOtherTwoVariablesSummaryData.Text = "Summary Data..."
         '
         'mnuModelOtherTwoVariablesSimpleRegression
         '
         Me.mnuModelOtherTwoVariablesSimpleRegression.Name = "mnuModelOtherTwoVariablesSimpleRegression"
-        Me.mnuModelOtherTwoVariablesSimpleRegression.Size = New System.Drawing.Size(328, 26)
+        Me.mnuModelOtherTwoVariablesSimpleRegression.Size = New System.Drawing.Size(266, 22)
         Me.mnuModelOtherTwoVariablesSimpleRegression.Tag = "Simple_Regression..."
         Me.mnuModelOtherTwoVariablesSimpleRegression.Text = "Simple Regression..."
         '
         'mnuModelOtherTwoVariablesOneWayANOVA
         '
         Me.mnuModelOtherTwoVariablesOneWayANOVA.Name = "mnuModelOtherTwoVariablesOneWayANOVA"
-        Me.mnuModelOtherTwoVariablesOneWayANOVA.Size = New System.Drawing.Size(328, 26)
+        Me.mnuModelOtherTwoVariablesOneWayANOVA.Size = New System.Drawing.Size(266, 22)
         Me.mnuModelOtherTwoVariablesOneWayANOVA.Tag = "One_Way_ANOVA..."
         Me.mnuModelOtherTwoVariablesOneWayANOVA.Text = "One Way ANOVA..."
         '
@@ -1394,14 +1394,14 @@ Partial Class frmMain
         '
         Me.mnuModelOtherTwoVariablesNonParametricTwoSamples.Enabled = False
         Me.mnuModelOtherTwoVariablesNonParametricTwoSamples.Name = "mnuModelOtherTwoVariablesNonParametricTwoSamples"
-        Me.mnuModelOtherTwoVariablesNonParametricTwoSamples.Size = New System.Drawing.Size(328, 26)
+        Me.mnuModelOtherTwoVariablesNonParametricTwoSamples.Size = New System.Drawing.Size(266, 22)
         Me.mnuModelOtherTwoVariablesNonParametricTwoSamples.Tag = "Non_Parameteric_Two_Samples..."
         Me.mnuModelOtherTwoVariablesNonParametricTwoSamples.Text = "Non Parametric Two Samples..."
         '
         'mnuModelOtherTwoVariablesNonParametricOneWayANOVA
         '
         Me.mnuModelOtherTwoVariablesNonParametricOneWayANOVA.Name = "mnuModelOtherTwoVariablesNonParametricOneWayANOVA"
-        Me.mnuModelOtherTwoVariablesNonParametricOneWayANOVA.Size = New System.Drawing.Size(328, 26)
+        Me.mnuModelOtherTwoVariablesNonParametricOneWayANOVA.Size = New System.Drawing.Size(266, 22)
         Me.mnuModelOtherTwoVariablesNonParametricOneWayANOVA.Tag = "Non_Parameteric_One_Way_ANOVA..."
         Me.mnuModelOtherTwoVariablesNonParametricOneWayANOVA.Text = "Non Parameteric One Way ANOVA..."
         '
@@ -1410,7 +1410,7 @@ Partial Class frmMain
         Me.mnuModelOtherThreeVariables.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelOtherThreeVariablesSimpleWithGroups, Me.mnuModelOtherThreeVariablesNonParametricTwoWayANOVA, Me.mnuModelOtherThreeVariablesChisquareTest})
         Me.mnuModelOtherThreeVariables.Enabled = False
         Me.mnuModelOtherThreeVariables.Name = "mnuModelOtherThreeVariables"
-        Me.mnuModelOtherThreeVariables.Size = New System.Drawing.Size(252, 26)
+        Me.mnuModelOtherThreeVariables.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelOtherThreeVariables.Tag = "Other_(Three_Variable)"
         Me.mnuModelOtherThreeVariables.Text = "Other (Three Variable)"
         Me.mnuModelOtherThreeVariables.Visible = False
@@ -1419,21 +1419,21 @@ Partial Class frmMain
         '
         Me.mnuModelOtherThreeVariablesSimpleWithGroups.Enabled = False
         Me.mnuModelOtherThreeVariablesSimpleWithGroups.Name = "mnuModelOtherThreeVariablesSimpleWithGroups"
-        Me.mnuModelOtherThreeVariablesSimpleWithGroups.Size = New System.Drawing.Size(320, 26)
+        Me.mnuModelOtherThreeVariablesSimpleWithGroups.Size = New System.Drawing.Size(260, 22)
         Me.mnuModelOtherThreeVariablesSimpleWithGroups.Tag = "Simple_with_groups..."
         Me.mnuModelOtherThreeVariablesSimpleWithGroups.Text = "Simple With Groups..."
         '
         'mnuModelOtherThreeVariablesNonParametricTwoWayANOVA
         '
         Me.mnuModelOtherThreeVariablesNonParametricTwoWayANOVA.Name = "mnuModelOtherThreeVariablesNonParametricTwoWayANOVA"
-        Me.mnuModelOtherThreeVariablesNonParametricTwoWayANOVA.Size = New System.Drawing.Size(320, 26)
+        Me.mnuModelOtherThreeVariablesNonParametricTwoWayANOVA.Size = New System.Drawing.Size(260, 22)
         Me.mnuModelOtherThreeVariablesNonParametricTwoWayANOVA.Tag = "Non_Parametric_Two_Way_ANOVA..."
         Me.mnuModelOtherThreeVariablesNonParametricTwoWayANOVA.Text = "Non Parametric Two Way ANOVA..."
         '
         'mnuModelOtherThreeVariablesChisquareTest
         '
         Me.mnuModelOtherThreeVariablesChisquareTest.Name = "mnuModelOtherThreeVariablesChisquareTest"
-        Me.mnuModelOtherThreeVariablesChisquareTest.Size = New System.Drawing.Size(320, 26)
+        Me.mnuModelOtherThreeVariablesChisquareTest.Size = New System.Drawing.Size(260, 22)
         Me.mnuModelOtherThreeVariablesChisquareTest.Tag = "Chi-square_Test"
         Me.mnuModelOtherThreeVariablesChisquareTest.Text = "Chi-square Test..."
         '
@@ -1442,7 +1442,7 @@ Partial Class frmMain
         Me.mnuModelOtherGeneral.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuModelOtherGeneralANOVAGeneral, Me.mnuModelOtherGeneralRegression, Me.mnuModelOtherGeneralLogLinear})
         Me.mnuModelOtherGeneral.Enabled = False
         Me.mnuModelOtherGeneral.Name = "mnuModelOtherGeneral"
-        Me.mnuModelOtherGeneral.Size = New System.Drawing.Size(252, 26)
+        Me.mnuModelOtherGeneral.Size = New System.Drawing.Size(201, 22)
         Me.mnuModelOtherGeneral.Tag = "Other_(General)"
         Me.mnuModelOtherGeneral.Text = "Other (General)"
         Me.mnuModelOtherGeneral.Visible = False
@@ -1451,7 +1451,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherGeneralANOVAGeneral.Enabled = False
         Me.mnuModelOtherGeneralANOVAGeneral.Name = "mnuModelOtherGeneralANOVAGeneral"
-        Me.mnuModelOtherGeneralANOVAGeneral.Size = New System.Drawing.Size(206, 26)
+        Me.mnuModelOtherGeneralANOVAGeneral.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherGeneralANOVAGeneral.Tag = "ANOVA_General..."
         Me.mnuModelOtherGeneralANOVAGeneral.Text = "ANOVA General..."
         '
@@ -1459,7 +1459,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherGeneralRegression.Enabled = False
         Me.mnuModelOtherGeneralRegression.Name = "mnuModelOtherGeneralRegression"
-        Me.mnuModelOtherGeneralRegression.Size = New System.Drawing.Size(206, 26)
+        Me.mnuModelOtherGeneralRegression.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherGeneralRegression.Tag = "Regression..."
         Me.mnuModelOtherGeneralRegression.Text = "Regression..."
         '
@@ -1467,7 +1467,7 @@ Partial Class frmMain
         '
         Me.mnuModelOtherGeneralLogLinear.Enabled = False
         Me.mnuModelOtherGeneralLogLinear.Name = "mnuModelOtherGeneralLogLinear"
-        Me.mnuModelOtherGeneralLogLinear.Size = New System.Drawing.Size(206, 26)
+        Me.mnuModelOtherGeneralLogLinear.Size = New System.Drawing.Size(166, 22)
         Me.mnuModelOtherGeneralLogLinear.Tag = "Log_Linear"
         Me.mnuModelOtherGeneralLogLinear.Text = "Log Linear..."
         '
@@ -1475,7 +1475,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticExamine.Enabled = False
         Me.mnuClimaticExamine.Name = "mnuClimaticExamine"
-        Me.mnuClimaticExamine.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticExamine.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticExamine.Tag = "Examine"
         Me.mnuClimaticExamine.Text = "Examine..."
         Me.mnuClimaticExamine.Visible = False
@@ -1484,7 +1484,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticProcess.Enabled = False
         Me.mnuClimaticProcess.Name = "mnuClimaticProcess"
-        Me.mnuClimaticProcess.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticProcess.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticProcess.Tag = "Process"
         Me.mnuClimaticProcess.Text = "Process..."
         Me.mnuClimaticProcess.Visible = False
@@ -1493,7 +1493,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticEvaporation.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticEvaporationSite, Me.mnuClimaticEvaporationPenman})
         Me.mnuClimaticEvaporation.Name = "mnuClimaticEvaporation"
-        Me.mnuClimaticEvaporation.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticEvaporation.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticEvaporation.Tag = "Evaporation"
         Me.mnuClimaticEvaporation.Text = "Evaporation"
         Me.mnuClimaticEvaporation.Visible = False
@@ -1502,7 +1502,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticEvaporationSite.Enabled = False
         Me.mnuClimaticEvaporationSite.Name = "mnuClimaticEvaporationSite"
-        Me.mnuClimaticEvaporationSite.Size = New System.Drawing.Size(153, 26)
+        Me.mnuClimaticEvaporationSite.Size = New System.Drawing.Size(127, 22)
         Me.mnuClimaticEvaporationSite.Tag = "Site"
         Me.mnuClimaticEvaporationSite.Text = "Site..."
         '
@@ -1510,7 +1510,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticEvaporationPenman.Enabled = False
         Me.mnuClimaticEvaporationPenman.Name = "mnuClimaticEvaporationPenman"
-        Me.mnuClimaticEvaporationPenman.Size = New System.Drawing.Size(153, 26)
+        Me.mnuClimaticEvaporationPenman.Size = New System.Drawing.Size(127, 22)
         Me.mnuClimaticEvaporationPenman.Tag = "Penman"
         Me.mnuClimaticEvaporationPenman.Text = "Penman..."
         '
@@ -1518,7 +1518,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticCrop.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticCropCropCoefficients, Me.mnuClimaticCropWaterSatisfactionIndex})
         Me.mnuClimaticCrop.Name = "mnuClimaticCrop"
-        Me.mnuClimaticCrop.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticCrop.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticCrop.Tag = "Crop"
         Me.mnuClimaticCrop.Text = "Crop"
         Me.mnuClimaticCrop.Visible = False
@@ -1527,21 +1527,21 @@ Partial Class frmMain
         '
         Me.mnuClimaticCropCropCoefficients.Enabled = False
         Me.mnuClimaticCropCropCoefficients.Name = "mnuClimaticCropCropCoefficients"
-        Me.mnuClimaticCropCropCoefficients.Size = New System.Drawing.Size(261, 26)
+        Me.mnuClimaticCropCropCoefficients.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticCropCropCoefficients.Text = "Crop Coefficients..."
         '
         'mnuClimaticCropWaterSatisfactionIndex
         '
         Me.mnuClimaticCropWaterSatisfactionIndex.Enabled = False
         Me.mnuClimaticCropWaterSatisfactionIndex.Name = "mnuClimaticCropWaterSatisfactionIndex"
-        Me.mnuClimaticCropWaterSatisfactionIndex.Size = New System.Drawing.Size(261, 26)
+        Me.mnuClimaticCropWaterSatisfactionIndex.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticCropWaterSatisfactionIndex.Text = "Water Satisfaction Index..."
         '
         'mnuClimaticHeatSum
         '
         Me.mnuClimaticHeatSum.Enabled = False
         Me.mnuClimaticHeatSum.Name = "mnuClimaticHeatSum"
-        Me.mnuClimaticHeatSum.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticHeatSum.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticHeatSum.Tag = "Heat_Sum"
         Me.mnuClimaticHeatSum.Text = "Heat Sum..."
         Me.mnuClimaticHeatSum.Visible = False
@@ -1550,7 +1550,7 @@ Partial Class frmMain
         '
         Me.mnuView.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuViewDataView, Me.mnuViewOutput, Me.mnuViewLogScript, Me.mnuViewColumnMetadata, Me.mnuViewDataFrameMetadata, Me.ToolStripSeparator22, Me.mnuViewStructuredMenu, Me.mnuViewClimaticMenu, Me.mnuViewTricotMenu, Me.mnuViewTricotXpMenu, Me.mnuViewOptionsByContextMenu, Me.mnuViewProcurementMenu, Me.ToolStripSeparator39, Me.mnuViewResetToDefaultLayout, Me.mnuViewSwapDataAndMetadata, Me.mnuViewSwapDataAndDataframeMetadata, Me.mnuViewSwapDataAndScript})
         Me.mnuView.Name = "mnuView"
-        Me.mnuView.Size = New System.Drawing.Size(55, 24)
+        Me.mnuView.Size = New System.Drawing.Size(44, 20)
         Me.mnuView.Tag = "View"
         Me.mnuView.Text = "View"
         '
@@ -1558,7 +1558,7 @@ Partial Class frmMain
         '
         Me.mnuViewDataView.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewDataView.Name = "mnuViewDataView"
-        Me.mnuViewDataView.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewDataView.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewDataView.Tag = "Data_View"
         Me.mnuViewDataView.Text = "Data View"
         '
@@ -1566,21 +1566,21 @@ Partial Class frmMain
         '
         Me.mnuViewOutput.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewOutput.Name = "mnuViewOutput"
-        Me.mnuViewOutput.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewOutput.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewOutput.Text = "Output"
         '
         'mnuViewLogScript
         '
         Me.mnuViewLogScript.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewLogScript.Name = "mnuViewLogScript"
-        Me.mnuViewLogScript.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewLogScript.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewLogScript.Text = "Log/Script"
         '
         'mnuViewColumnMetadata
         '
         Me.mnuViewColumnMetadata.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewColumnMetadata.Name = "mnuViewColumnMetadata"
-        Me.mnuViewColumnMetadata.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewColumnMetadata.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewColumnMetadata.Tag = "Column_Metadata"
         Me.mnuViewColumnMetadata.Text = "Column Metadata"
         '
@@ -1588,27 +1588,27 @@ Partial Class frmMain
         '
         Me.mnuViewDataFrameMetadata.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewDataFrameMetadata.Name = "mnuViewDataFrameMetadata"
-        Me.mnuViewDataFrameMetadata.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewDataFrameMetadata.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewDataFrameMetadata.Tag = "Data_Frame_Metadata"
         Me.mnuViewDataFrameMetadata.Text = "Data Frame Metadata"
         '
         'ToolStripSeparator22
         '
         Me.ToolStripSeparator22.Name = "ToolStripSeparator22"
-        Me.ToolStripSeparator22.Size = New System.Drawing.Size(339, 6)
+        Me.ToolStripSeparator22.Size = New System.Drawing.Size(265, 6)
         '
         'mnuViewStructuredMenu
         '
         Me.mnuViewStructuredMenu.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewStructuredMenu.Name = "mnuViewStructuredMenu"
-        Me.mnuViewStructuredMenu.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewStructuredMenu.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewStructuredMenu.Text = "Structured Menu"
         '
         'mnuViewClimaticMenu
         '
         Me.mnuViewClimaticMenu.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewClimaticMenu.Name = "mnuViewClimaticMenu"
-        Me.mnuViewClimaticMenu.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewClimaticMenu.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewClimaticMenu.Tag = ""
         Me.mnuViewClimaticMenu.Text = "Climatic Menu"
         '
@@ -1616,275 +1616,275 @@ Partial Class frmMain
         '
         Me.mnuViewTricotMenu.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewTricotMenu.Name = "mnuViewTricotMenu"
-        Me.mnuViewTricotMenu.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewTricotMenu.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewTricotMenu.Text = "Tricot Menu"
         '
         'mnuViewTricotXpMenu
         '
         Me.mnuViewTricotXpMenu.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewTricotXpMenu.Name = "mnuViewTricotXpMenu"
-        Me.mnuViewTricotXpMenu.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewTricotXpMenu.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewTricotXpMenu.Text = "Tricot XP Menu"
         '
         'mnuViewOptionsByContextMenu
         '
         Me.mnuViewOptionsByContextMenu.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewOptionsByContextMenu.Name = "mnuViewOptionsByContextMenu"
-        Me.mnuViewOptionsByContextMenu.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewOptionsByContextMenu.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewOptionsByContextMenu.Text = "Experiments Menu"
         '
         'mnuViewProcurementMenu
         '
         Me.mnuViewProcurementMenu.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewProcurementMenu.Name = "mnuViewProcurementMenu"
-        Me.mnuViewProcurementMenu.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewProcurementMenu.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewProcurementMenu.Tag = ""
         Me.mnuViewProcurementMenu.Text = "Procurement Menu"
         '
         'ToolStripSeparator39
         '
         Me.ToolStripSeparator39.Name = "ToolStripSeparator39"
-        Me.ToolStripSeparator39.Size = New System.Drawing.Size(339, 6)
+        Me.ToolStripSeparator39.Size = New System.Drawing.Size(265, 6)
         '
         'mnuViewResetToDefaultLayout
         '
         Me.mnuViewResetToDefaultLayout.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewResetToDefaultLayout.Name = "mnuViewResetToDefaultLayout"
-        Me.mnuViewResetToDefaultLayout.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewResetToDefaultLayout.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewResetToDefaultLayout.Text = "Reset to Default Layout"
         '
         'mnuViewSwapDataAndMetadata
         '
         Me.mnuViewSwapDataAndMetadata.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewSwapDataAndMetadata.Name = "mnuViewSwapDataAndMetadata"
-        Me.mnuViewSwapDataAndMetadata.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewSwapDataAndMetadata.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewSwapDataAndMetadata.Text = "Swap Data and Metadata"
         '
         'mnuViewSwapDataAndDataframeMetadata
         '
         Me.mnuViewSwapDataAndDataframeMetadata.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewSwapDataAndDataframeMetadata.Name = "mnuViewSwapDataAndDataframeMetadata"
-        Me.mnuViewSwapDataAndDataframeMetadata.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewSwapDataAndDataframeMetadata.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewSwapDataAndDataframeMetadata.Text = "Swap Data and Data Frame Metadata"
         '
         'mnuViewSwapDataAndScript
         '
         Me.mnuViewSwapDataAndScript.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuViewSwapDataAndScript.Name = "mnuViewSwapDataAndScript"
-        Me.mnuViewSwapDataAndScript.Size = New System.Drawing.Size(342, 26)
+        Me.mnuViewSwapDataAndScript.Size = New System.Drawing.Size(268, 22)
         Me.mnuViewSwapDataAndScript.Text = "Swap Data and  Log/Script"
         '
         'mnuHelp
         '
         Me.mnuHelp.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuHelpHelpIntroduction, Me.mnuHelpFAQ, Me.mnuHelpGetingStarted, Me.mnuHelpData, Me.ToolStripSeparator28, Me.mnuHelpWindows, Me.ToolStripSeparator81, Me.mnuHelpMenus, Me.OptionalMenuToolStripMenuItem, Me.mnuHelpAboutR, Me.mnuHelpLearningStatistics, Me.mnuHelpRPackages, Me.mnuHelpGlossary, Me.mnuHelpLicence, Me.ToolStripSeparator29, Me.mnuHelpResourcesSite, Me.mnuHelpPackagesDocumentation})
         Me.mnuHelp.Name = "mnuHelp"
-        Me.mnuHelp.Size = New System.Drawing.Size(55, 24)
+        Me.mnuHelp.Size = New System.Drawing.Size(44, 20)
         Me.mnuHelp.Tag = "Help"
         Me.mnuHelp.Text = "Help"
         '
         'mnuHelpHelpIntroduction
         '
         Me.mnuHelpHelpIntroduction.Name = "mnuHelpHelpIntroduction"
-        Me.mnuHelpHelpIntroduction.Size = New System.Drawing.Size(299, 26)
+        Me.mnuHelpHelpIntroduction.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpHelpIntroduction.Text = "Introduction..."
         '
         'mnuHelpFAQ
         '
         Me.mnuHelpFAQ.Name = "mnuHelpFAQ"
-        Me.mnuHelpFAQ.Size = New System.Drawing.Size(299, 26)
+        Me.mnuHelpFAQ.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpFAQ.Text = "FAQ..."
         '
         'mnuHelpGetingStarted
         '
         Me.mnuHelpGetingStarted.Name = "mnuHelpGetingStarted"
-        Me.mnuHelpGetingStarted.Size = New System.Drawing.Size(299, 26)
+        Me.mnuHelpGetingStarted.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpGetingStarted.Text = "Getting Started..."
         '
         'mnuHelpData
         '
         Me.mnuHelpData.Name = "mnuHelpData"
-        Me.mnuHelpData.Size = New System.Drawing.Size(299, 26)
+        Me.mnuHelpData.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpData.Text = "Data..."
         '
         'ToolStripSeparator28
         '
         Me.ToolStripSeparator28.Name = "ToolStripSeparator28"
-        Me.ToolStripSeparator28.Size = New System.Drawing.Size(296, 6)
+        Me.ToolStripSeparator28.Size = New System.Drawing.Size(236, 6)
         '
         'mnuHelpWindows
         '
         Me.mnuHelpWindows.Name = "mnuHelpWindows"
-        Me.mnuHelpWindows.Size = New System.Drawing.Size(299, 26)
+        Me.mnuHelpWindows.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpWindows.Text = "Windows..."
         '
         'ToolStripSeparator81
         '
         Me.ToolStripSeparator81.Name = "ToolStripSeparator81"
-        Me.ToolStripSeparator81.Size = New System.Drawing.Size(296, 6)
+        Me.ToolStripSeparator81.Size = New System.Drawing.Size(236, 6)
         '
         'mnuHelpMenus
         '
         Me.mnuHelpMenus.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuMenusHelp, Me.ToolStripSeparator82, Me.mnuFileHelp, Me.mnuEditHelp, Me.mnuPrepareHelp, Me.mnuDescribeHelp, Me.mnuModelHelp, Me.mnuToolsHelp, Me.mnuViewHelp})
         Me.mnuHelpMenus.Name = "mnuHelpMenus"
-        Me.mnuHelpMenus.Size = New System.Drawing.Size(299, 26)
+        Me.mnuHelpMenus.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpMenus.Text = "Menus ..."
         '
         'mnuMenusHelp
         '
         Me.mnuMenusHelp.Name = "mnuMenusHelp"
-        Me.mnuMenusHelp.Size = New System.Drawing.Size(248, 26)
+        Me.mnuMenusHelp.Size = New System.Drawing.Size(200, 22)
         Me.mnuMenusHelp.Text = "Menus and Dialogues ..."
         '
         'ToolStripSeparator82
         '
         Me.ToolStripSeparator82.Name = "ToolStripSeparator82"
-        Me.ToolStripSeparator82.Size = New System.Drawing.Size(245, 6)
+        Me.ToolStripSeparator82.Size = New System.Drawing.Size(197, 6)
         '
         'mnuFileHelp
         '
         Me.mnuFileHelp.Name = "mnuFileHelp"
-        Me.mnuFileHelp.Size = New System.Drawing.Size(248, 26)
+        Me.mnuFileHelp.Size = New System.Drawing.Size(200, 22)
         Me.mnuFileHelp.Text = "File..."
         '
         'mnuEditHelp
         '
         Me.mnuEditHelp.Name = "mnuEditHelp"
-        Me.mnuEditHelp.Size = New System.Drawing.Size(248, 26)
+        Me.mnuEditHelp.Size = New System.Drawing.Size(200, 22)
         Me.mnuEditHelp.Text = "Edit..."
         '
         'mnuPrepareHelp
         '
         Me.mnuPrepareHelp.Name = "mnuPrepareHelp"
-        Me.mnuPrepareHelp.Size = New System.Drawing.Size(248, 26)
+        Me.mnuPrepareHelp.Size = New System.Drawing.Size(200, 22)
         Me.mnuPrepareHelp.Text = "Prepare..."
         '
         'mnuDescribeHelp
         '
         Me.mnuDescribeHelp.Name = "mnuDescribeHelp"
-        Me.mnuDescribeHelp.Size = New System.Drawing.Size(248, 26)
+        Me.mnuDescribeHelp.Size = New System.Drawing.Size(200, 22)
         Me.mnuDescribeHelp.Text = "Describe..."
         '
         'mnuModelHelp
         '
         Me.mnuModelHelp.Name = "mnuModelHelp"
-        Me.mnuModelHelp.Size = New System.Drawing.Size(248, 26)
+        Me.mnuModelHelp.Size = New System.Drawing.Size(200, 22)
         Me.mnuModelHelp.Text = "Model..."
         '
         'mnuToolsHelp
         '
         Me.mnuToolsHelp.Name = "mnuToolsHelp"
-        Me.mnuToolsHelp.Size = New System.Drawing.Size(248, 26)
+        Me.mnuToolsHelp.Size = New System.Drawing.Size(200, 22)
         Me.mnuToolsHelp.Text = "Tools..."
         '
         'mnuViewHelp
         '
         Me.mnuViewHelp.Name = "mnuViewHelp"
-        Me.mnuViewHelp.Size = New System.Drawing.Size(248, 26)
+        Me.mnuViewHelp.Size = New System.Drawing.Size(200, 22)
         Me.mnuViewHelp.Text = "View..."
         '
         'OptionalMenuToolStripMenuItem
         '
         Me.OptionalMenuToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredHelp, Me.mnuClimaticHelp, Me.mnuTricotMenuHelp, Me.mnuTricotXPMenuHelp, Me.mnuExperimentsHelp, Me.mnuProcurementHelp})
         Me.OptionalMenuToolStripMenuItem.Name = "OptionalMenuToolStripMenuItem"
-        Me.OptionalMenuToolStripMenuItem.Size = New System.Drawing.Size(299, 26)
+        Me.OptionalMenuToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
         Me.OptionalMenuToolStripMenuItem.Text = "Optional Menus..."
         '
         'mnuStructuredHelp
         '
         Me.mnuStructuredHelp.Name = "mnuStructuredHelp"
-        Me.mnuStructuredHelp.Size = New System.Drawing.Size(200, 26)
+        Me.mnuStructuredHelp.Size = New System.Drawing.Size(164, 22)
         Me.mnuStructuredHelp.Text = "Structured..."
         '
         'mnuClimaticHelp
         '
         Me.mnuClimaticHelp.Name = "mnuClimaticHelp"
-        Me.mnuClimaticHelp.Size = New System.Drawing.Size(200, 26)
+        Me.mnuClimaticHelp.Size = New System.Drawing.Size(164, 22)
         Me.mnuClimaticHelp.Text = "Climatic..."
         '
         'mnuTricotMenuHelp
         '
         Me.mnuTricotMenuHelp.Name = "mnuTricotMenuHelp"
-        Me.mnuTricotMenuHelp.Size = New System.Drawing.Size(200, 26)
+        Me.mnuTricotMenuHelp.Size = New System.Drawing.Size(164, 22)
         Me.mnuTricotMenuHelp.Text = "Tricot Menu..."
         '
         'mnuTricotXPMenuHelp
         '
         Me.mnuTricotXPMenuHelp.Name = "mnuTricotXPMenuHelp"
-        Me.mnuTricotXPMenuHelp.Size = New System.Drawing.Size(200, 26)
+        Me.mnuTricotXPMenuHelp.Size = New System.Drawing.Size(164, 22)
         Me.mnuTricotXPMenuHelp.Text = "Tricot XP Menu..."
         '
         'mnuExperimentsHelp
         '
         Me.mnuExperimentsHelp.Name = "mnuExperimentsHelp"
-        Me.mnuExperimentsHelp.Size = New System.Drawing.Size(200, 26)
+        Me.mnuExperimentsHelp.Size = New System.Drawing.Size(164, 22)
         Me.mnuExperimentsHelp.Text = "Experiments..."
         '
         'mnuProcurementHelp
         '
         Me.mnuProcurementHelp.Name = "mnuProcurementHelp"
-        Me.mnuProcurementHelp.Size = New System.Drawing.Size(200, 26)
+        Me.mnuProcurementHelp.Size = New System.Drawing.Size(164, 22)
         Me.mnuProcurementHelp.Text = "Procurement..."
         '
         'mnuHelpAboutR
         '
         Me.mnuHelpAboutR.Name = "mnuHelpAboutR"
-        Me.mnuHelpAboutR.Size = New System.Drawing.Size(299, 26)
+        Me.mnuHelpAboutR.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpAboutR.Text = "About R..."
         Me.mnuHelpAboutR.Visible = False
         '
         'mnuHelpLearningStatistics
         '
         Me.mnuHelpLearningStatistics.Name = "mnuHelpLearningStatistics"
-        Me.mnuHelpLearningStatistics.Size = New System.Drawing.Size(299, 26)
+        Me.mnuHelpLearningStatistics.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpLearningStatistics.Text = "Learning Statistics..."
         Me.mnuHelpLearningStatistics.Visible = False
         '
         'mnuHelpRPackages
         '
         Me.mnuHelpRPackages.Name = "mnuHelpRPackages"
-        Me.mnuHelpRPackages.Size = New System.Drawing.Size(299, 26)
+        Me.mnuHelpRPackages.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpRPackages.Text = "R Packages..."
         '
         'mnuHelpGlossary
         '
         Me.mnuHelpGlossary.Name = "mnuHelpGlossary"
-        Me.mnuHelpGlossary.Size = New System.Drawing.Size(299, 26)
+        Me.mnuHelpGlossary.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpGlossary.Text = "Glossary..."
         '
         'mnuHelpLicence
         '
         Me.mnuHelpLicence.Name = "mnuHelpLicence"
-        Me.mnuHelpLicence.Size = New System.Drawing.Size(299, 26)
+        Me.mnuHelpLicence.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpLicence.Tag = "Licence..."
         Me.mnuHelpLicence.Text = "Licence..."
         '
         'ToolStripSeparator29
         '
         Me.ToolStripSeparator29.Name = "ToolStripSeparator29"
-        Me.ToolStripSeparator29.Size = New System.Drawing.Size(296, 6)
+        Me.ToolStripSeparator29.Size = New System.Drawing.Size(236, 6)
         '
         'mnuHelpResourcesSite
         '
         Me.mnuHelpResourcesSite.Name = "mnuHelpResourcesSite"
-        Me.mnuHelpResourcesSite.Size = New System.Drawing.Size(299, 26)
+        Me.mnuHelpResourcesSite.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpResourcesSite.Text = "R-Instat Resources Site (Online)"
         '
         'mnuHelpPackagesDocumentation
         '
         Me.mnuHelpPackagesDocumentation.Name = "mnuHelpPackagesDocumentation"
-        Me.mnuHelpPackagesDocumentation.Size = New System.Drawing.Size(299, 26)
+        Me.mnuHelpPackagesDocumentation.Size = New System.Drawing.Size(239, 22)
         Me.mnuHelpPackagesDocumentation.Text = "R-Packages Documentation..."
         '
         'ToolStripSeparator16
         '
         Me.ToolStripSeparator16.Name = "ToolStripSeparator16"
-        Me.ToolStripSeparator16.Size = New System.Drawing.Size(264, 6)
+        Me.ToolStripSeparator16.Size = New System.Drawing.Size(209, 6)
         '
         'mnuClimatic
         '
         Me.mnuClimatic.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticFile, Me.ToolStripSeparator18, Me.mnuExamineEditData, Me.mnuClimaticTidyandExamine, Me.mnuClimaticDates, Me.mnuClimaticDefineClimaticData, Me.mnuClimaticCheckData, Me.mnuClimaticPrepare, Me.ToolStripSeparator30, Me.mnuClimaticDescribe, Me.mnuClimaticNCMP, Me.mnuClimaticPICSA, Me.mnuCMSAF, Me.mnuClimaticCompare, Me.mnuClimaticMapping, Me.ToolStripSeparator16, Me.mnuClimaticModel, Me.mnuClimaticExamine, Me.mnuClimaticProcess, Me.ToolStripSeparator23, Me.mnuClimaticSCF, Me.mnuClimaticEvaporation, Me.mnuClimaticCrop, Me.mnuClimaticHeatSum, Me.mnuClimaticClimateMethods})
         Me.mnuClimatic.Name = "mnuClimatic"
-        Me.mnuClimatic.Size = New System.Drawing.Size(77, 24)
+        Me.mnuClimatic.Size = New System.Drawing.Size(63, 20)
         Me.mnuClimatic.Tag = "Climatic"
         Me.mnuClimatic.Text = "Climatic"
         '
@@ -1892,300 +1892,300 @@ Partial Class frmMain
         '
         Me.mnuClimaticFile.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticFileImportSST, Me.mnuClimaticFileImportfromIRIDataLibrary, Me.mnuClimaticFileImportfromClimateDataStore, Me.mnuClimaticFileImportandTidyNetCDF, Me.mnuClimaticFileImportandTidyShapefile, Me.mnuClimateFileImportfromClimSoft, Me.mnuClimaticFileImportfromCliData, Me.mnuClimaticFileImportFromEPICSA, Me.ToolStripSeparator15, Me.mnuClimaticFileExportToClimsoft, Me.mnuClimaticFileExportToCPT, Me.mnuExportToWWRToolStrip, Me.mnuClimaticFileExportToClimpact, Me.mnuClimaticFileExportToGoogleBucketsToolStrip})
         Me.mnuClimaticFile.Name = "mnuClimaticFile"
-        Me.mnuClimaticFile.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticFile.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticFile.Text = "File"
         '
         'mnuClimaticFileImportSST
         '
         Me.mnuClimaticFileImportSST.Name = "mnuClimaticFileImportSST"
-        Me.mnuClimaticFileImportSST.Size = New System.Drawing.Size(354, 26)
+        Me.mnuClimaticFileImportSST.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileImportSST.Text = "Import SST..."
         '
         'mnuClimaticFileImportfromIRIDataLibrary
         '
         Me.mnuClimaticFileImportfromIRIDataLibrary.Name = "mnuClimaticFileImportfromIRIDataLibrary"
-        Me.mnuClimaticFileImportfromIRIDataLibrary.Size = New System.Drawing.Size(354, 26)
+        Me.mnuClimaticFileImportfromIRIDataLibrary.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileImportfromIRIDataLibrary.Text = "Import from IRI Data Library..."
         '
         'mnuClimaticFileImportfromClimateDataStore
         '
         Me.mnuClimaticFileImportfromClimateDataStore.Name = "mnuClimaticFileImportfromClimateDataStore"
-        Me.mnuClimaticFileImportfromClimateDataStore.Size = New System.Drawing.Size(354, 26)
+        Me.mnuClimaticFileImportfromClimateDataStore.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileImportfromClimateDataStore.Text = "Import from CDS (Climate Data Store)..."
         '
         'mnuClimaticFileImportandTidyNetCDF
         '
         Me.mnuClimaticFileImportandTidyNetCDF.Name = "mnuClimaticFileImportandTidyNetCDF"
-        Me.mnuClimaticFileImportandTidyNetCDF.Size = New System.Drawing.Size(354, 26)
+        Me.mnuClimaticFileImportandTidyNetCDF.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileImportandTidyNetCDF.Text = "Import and Tidy NetCDF..."
         '
         'mnuClimaticFileImportandTidyShapefile
         '
         Me.mnuClimaticFileImportandTidyShapefile.Name = "mnuClimaticFileImportandTidyShapefile"
-        Me.mnuClimaticFileImportandTidyShapefile.Size = New System.Drawing.Size(354, 26)
+        Me.mnuClimaticFileImportandTidyShapefile.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileImportandTidyShapefile.Text = "Import and Tidy Shapefile..."
         '
         'mnuClimateFileImportfromClimSoft
         '
         Me.mnuClimateFileImportfromClimSoft.Name = "mnuClimateFileImportfromClimSoft"
-        Me.mnuClimateFileImportfromClimSoft.Size = New System.Drawing.Size(354, 26)
+        Me.mnuClimateFileImportfromClimSoft.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimateFileImportfromClimSoft.Text = "Import from Climsoft..."
         '
         'mnuClimaticFileImportfromCliData
         '
         Me.mnuClimaticFileImportfromCliData.Enabled = False
         Me.mnuClimaticFileImportfromCliData.Name = "mnuClimaticFileImportfromCliData"
-        Me.mnuClimaticFileImportfromCliData.Size = New System.Drawing.Size(354, 26)
+        Me.mnuClimaticFileImportfromCliData.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileImportfromCliData.Text = "Import from CLIDATA..."
         Me.mnuClimaticFileImportfromCliData.Visible = False
         '
         'mnuClimaticFileImportFromEPICSA
         '
         Me.mnuClimaticFileImportFromEPICSA.Name = "mnuClimaticFileImportFromEPICSA"
-        Me.mnuClimaticFileImportFromEPICSA.Size = New System.Drawing.Size(354, 26)
+        Me.mnuClimaticFileImportFromEPICSA.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileImportFromEPICSA.Text = "Import from E-PICSA..."
         '
         'ToolStripSeparator15
         '
         Me.ToolStripSeparator15.Name = "ToolStripSeparator15"
-        Me.ToolStripSeparator15.Size = New System.Drawing.Size(351, 6)
+        Me.ToolStripSeparator15.Size = New System.Drawing.Size(279, 6)
         '
         'mnuClimaticFileExportToClimsoft
         '
         Me.mnuClimaticFileExportToClimsoft.Name = "mnuClimaticFileExportToClimsoft"
-        Me.mnuClimaticFileExportToClimsoft.Size = New System.Drawing.Size(354, 26)
+        Me.mnuClimaticFileExportToClimsoft.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileExportToClimsoft.Text = "Export to Climsoft..."
         '
         'mnuClimaticFileExportToCPT
         '
         Me.mnuClimaticFileExportToCPT.Name = "mnuClimaticFileExportToCPT"
-        Me.mnuClimaticFileExportToCPT.Size = New System.Drawing.Size(354, 26)
+        Me.mnuClimaticFileExportToCPT.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileExportToCPT.Tag = "Export_to_CPT"
         Me.mnuClimaticFileExportToCPT.Text = "Export to CPT..."
         '
         'mnuExportToWWRToolStrip
         '
         Me.mnuExportToWWRToolStrip.Name = "mnuExportToWWRToolStrip"
-        Me.mnuExportToWWRToolStrip.Size = New System.Drawing.Size(354, 26)
+        Me.mnuExportToWWRToolStrip.Size = New System.Drawing.Size(282, 22)
         Me.mnuExportToWWRToolStrip.Text = "Export to World Weather Records..."
         '
         'mnuClimaticFileExportToClimpact
         '
         Me.mnuClimaticFileExportToClimpact.Name = "mnuClimaticFileExportToClimpact"
-        Me.mnuClimaticFileExportToClimpact.Size = New System.Drawing.Size(354, 26)
+        Me.mnuClimaticFileExportToClimpact.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileExportToClimpact.Text = "Export to Climpact..."
         '
         'mnuClimaticFileExportToGoogleBucketsToolStrip
         '
         Me.mnuClimaticFileExportToGoogleBucketsToolStrip.Name = "mnuClimaticFileExportToGoogleBucketsToolStrip"
-        Me.mnuClimaticFileExportToGoogleBucketsToolStrip.Size = New System.Drawing.Size(354, 26)
+        Me.mnuClimaticFileExportToGoogleBucketsToolStrip.Size = New System.Drawing.Size(282, 22)
         Me.mnuClimaticFileExportToGoogleBucketsToolStrip.Text = "Export to E-PICSA..."
         '
         'ToolStripSeparator18
         '
         Me.ToolStripSeparator18.Name = "ToolStripSeparator18"
-        Me.ToolStripSeparator18.Size = New System.Drawing.Size(264, 6)
+        Me.ToolStripSeparator18.Size = New System.Drawing.Size(209, 6)
         '
         'mnuExamineEditData
         '
         Me.mnuExamineEditData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticExamineEditDataVisualiseData, Me.mnuExamineEditDataPivotTable, Me.ToolStripSeparator27, Me.mnuExamineEditDataOneVariableSummarise, Me.mnuExamineEditDataOneVariableGraph, Me.mnuExamineEditDataOneVariableFrequencies, Me.ToolStripSeparator78, Me.mnuExamineEditDataSetupForDataEditing, Me.mnuExamineEditDataDailyDataEditing, Me.mnuExamineEditDataCompareColumns})
         Me.mnuExamineEditData.Name = "mnuExamineEditData"
-        Me.mnuExamineEditData.Size = New System.Drawing.Size(267, 26)
+        Me.mnuExamineEditData.Size = New System.Drawing.Size(212, 22)
         Me.mnuExamineEditData.Text = "Examine Data"
         '
         'mnuClimaticExamineEditDataVisualiseData
         '
         Me.mnuClimaticExamineEditDataVisualiseData.Name = "mnuClimaticExamineEditDataVisualiseData"
-        Me.mnuClimaticExamineEditDataVisualiseData.Size = New System.Drawing.Size(268, 26)
+        Me.mnuClimaticExamineEditDataVisualiseData.Size = New System.Drawing.Size(215, 22)
         Me.mnuClimaticExamineEditDataVisualiseData.Text = "Visualise Data..."
         '
         'mnuExamineEditDataPivotTable
         '
         Me.mnuExamineEditDataPivotTable.Name = "mnuExamineEditDataPivotTable"
-        Me.mnuExamineEditDataPivotTable.Size = New System.Drawing.Size(268, 26)
+        Me.mnuExamineEditDataPivotTable.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataPivotTable.Text = "Pivot Table..."
         '
         'ToolStripSeparator27
         '
         Me.ToolStripSeparator27.Name = "ToolStripSeparator27"
-        Me.ToolStripSeparator27.Size = New System.Drawing.Size(265, 6)
+        Me.ToolStripSeparator27.Size = New System.Drawing.Size(212, 6)
         '
         'mnuExamineEditDataOneVariableSummarise
         '
         Me.mnuExamineEditDataOneVariableSummarise.Name = "mnuExamineEditDataOneVariableSummarise"
-        Me.mnuExamineEditDataOneVariableSummarise.Size = New System.Drawing.Size(268, 26)
+        Me.mnuExamineEditDataOneVariableSummarise.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataOneVariableSummarise.Text = "One Variable Summarise..."
         '
         'mnuExamineEditDataOneVariableGraph
         '
         Me.mnuExamineEditDataOneVariableGraph.Name = "mnuExamineEditDataOneVariableGraph"
-        Me.mnuExamineEditDataOneVariableGraph.Size = New System.Drawing.Size(268, 26)
+        Me.mnuExamineEditDataOneVariableGraph.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataOneVariableGraph.Text = "One Variable Graph..."
         '
         'mnuExamineEditDataOneVariableFrequencies
         '
         Me.mnuExamineEditDataOneVariableFrequencies.Name = "mnuExamineEditDataOneVariableFrequencies"
-        Me.mnuExamineEditDataOneVariableFrequencies.Size = New System.Drawing.Size(268, 26)
+        Me.mnuExamineEditDataOneVariableFrequencies.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataOneVariableFrequencies.Text = "One Variable Frequencies..."
         '
         'ToolStripSeparator78
         '
         Me.ToolStripSeparator78.Name = "ToolStripSeparator78"
-        Me.ToolStripSeparator78.Size = New System.Drawing.Size(265, 6)
+        Me.ToolStripSeparator78.Size = New System.Drawing.Size(212, 6)
         '
         'mnuExamineEditDataSetupForDataEditing
         '
         Me.mnuExamineEditDataSetupForDataEditing.Name = "mnuExamineEditDataSetupForDataEditing"
-        Me.mnuExamineEditDataSetupForDataEditing.Size = New System.Drawing.Size(268, 26)
+        Me.mnuExamineEditDataSetupForDataEditing.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataSetupForDataEditing.Text = "Setup for Data Editing..."
         '
         'mnuExamineEditDataDailyDataEditing
         '
         Me.mnuExamineEditDataDailyDataEditing.Name = "mnuExamineEditDataDailyDataEditing"
-        Me.mnuExamineEditDataDailyDataEditing.Size = New System.Drawing.Size(268, 26)
+        Me.mnuExamineEditDataDailyDataEditing.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataDailyDataEditing.Text = "Daily Data Editing..."
         '
         'mnuExamineEditDataCompareColumns
         '
         Me.mnuExamineEditDataCompareColumns.Name = "mnuExamineEditDataCompareColumns"
-        Me.mnuExamineEditDataCompareColumns.Size = New System.Drawing.Size(268, 26)
+        Me.mnuExamineEditDataCompareColumns.Size = New System.Drawing.Size(215, 22)
         Me.mnuExamineEditDataCompareColumns.Text = "Compare Columns..."
         '
         'mnuClimaticTidyandExamine
         '
         Me.mnuClimaticTidyandExamine.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticTidyandExamineTidyDailyData, Me.ToolStripSeparator71, Me.mnuClimaticTidyandExamineReplaceValues, Me.InsertColumnRowsToolStripMenuItem, Me.mnuClimaticTidyandExamineDuplicateRows, Me.mnuClimaticTidyandExamineNonNumericCases, Me.ToolStripSeparator54, Me.mnuClimaticTidyandExamineTransformText, Me.mnuClimaticTidyandExamineSplitText, Me.ToolStripSeparator80, Me.mnuClimaticTidyandExamineStack, Me.mnuClimaticTidyandExamineUnstack, Me.mnuClimaticTidyandExamineMerge, Me.mnuClimaticTidyandExamineAppend, Me.ToolStripSeparator69, Me.mnuClimaticTidyDataKey})
         Me.mnuClimaticTidyandExamine.Name = "mnuClimaticTidyandExamine"
-        Me.mnuClimaticTidyandExamine.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticTidyandExamine.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticTidyandExamine.Text = "Tidy Data"
         '
         'mnuClimaticTidyandExamineTidyDailyData
         '
         Me.mnuClimaticTidyandExamineTidyDailyData.Name = "mnuClimaticTidyandExamineTidyDailyData"
-        Me.mnuClimaticTidyandExamineTidyDailyData.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticTidyandExamineTidyDailyData.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineTidyDailyData.Text = "Tidy Daily Data..."
         '
         'ToolStripSeparator71
         '
         Me.ToolStripSeparator71.Name = "ToolStripSeparator71"
-        Me.ToolStripSeparator71.Size = New System.Drawing.Size(244, 6)
+        Me.ToolStripSeparator71.Size = New System.Drawing.Size(198, 6)
         '
         'mnuClimaticTidyandExamineReplaceValues
         '
         Me.mnuClimaticTidyandExamineReplaceValues.Name = "mnuClimaticTidyandExamineReplaceValues"
-        Me.mnuClimaticTidyandExamineReplaceValues.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticTidyandExamineReplaceValues.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineReplaceValues.Text = "Replace Values..."
         '
         'InsertColumnRowsToolStripMenuItem
         '
         Me.InsertColumnRowsToolStripMenuItem.Name = "InsertColumnRowsToolStripMenuItem"
-        Me.InsertColumnRowsToolStripMenuItem.Size = New System.Drawing.Size(247, 26)
+        Me.InsertColumnRowsToolStripMenuItem.Size = New System.Drawing.Size(201, 22)
         Me.InsertColumnRowsToolStripMenuItem.Text = "Insert Column/Rows..."
         '
         'mnuClimaticTidyandExamineDuplicateRows
         '
         Me.mnuClimaticTidyandExamineDuplicateRows.Name = "mnuClimaticTidyandExamineDuplicateRows"
-        Me.mnuClimaticTidyandExamineDuplicateRows.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticTidyandExamineDuplicateRows.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineDuplicateRows.Text = "Duplicate Rows..."
         '
         'mnuClimaticTidyandExamineNonNumericCases
         '
         Me.mnuClimaticTidyandExamineNonNumericCases.Name = "mnuClimaticTidyandExamineNonNumericCases"
-        Me.mnuClimaticTidyandExamineNonNumericCases.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticTidyandExamineNonNumericCases.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineNonNumericCases.Text = "Non-Numeric Values..."
         '
         'ToolStripSeparator54
         '
         Me.ToolStripSeparator54.Name = "ToolStripSeparator54"
-        Me.ToolStripSeparator54.Size = New System.Drawing.Size(244, 6)
+        Me.ToolStripSeparator54.Size = New System.Drawing.Size(198, 6)
         '
         'mnuClimaticTidyandExamineTransformText
         '
         Me.mnuClimaticTidyandExamineTransformText.Name = "mnuClimaticTidyandExamineTransformText"
-        Me.mnuClimaticTidyandExamineTransformText.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticTidyandExamineTransformText.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineTransformText.Text = "Transform Text..."
         '
         'mnuClimaticTidyandExamineSplitText
         '
         Me.mnuClimaticTidyandExamineSplitText.Name = "mnuClimaticTidyandExamineSplitText"
-        Me.mnuClimaticTidyandExamineSplitText.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticTidyandExamineSplitText.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineSplitText.Text = "Split Text..."
         '
         'ToolStripSeparator80
         '
         Me.ToolStripSeparator80.Name = "ToolStripSeparator80"
-        Me.ToolStripSeparator80.Size = New System.Drawing.Size(244, 6)
+        Me.ToolStripSeparator80.Size = New System.Drawing.Size(198, 6)
         '
         'mnuClimaticTidyandExamineStack
         '
         Me.mnuClimaticTidyandExamineStack.Name = "mnuClimaticTidyandExamineStack"
-        Me.mnuClimaticTidyandExamineStack.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticTidyandExamineStack.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineStack.Text = "Stack (Pivot Longer)..."
         '
         'mnuClimaticTidyandExamineUnstack
         '
         Me.mnuClimaticTidyandExamineUnstack.Name = "mnuClimaticTidyandExamineUnstack"
-        Me.mnuClimaticTidyandExamineUnstack.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticTidyandExamineUnstack.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineUnstack.Text = "Unstack (Pivot Wider)..."
         '
         'mnuClimaticTidyandExamineMerge
         '
         Me.mnuClimaticTidyandExamineMerge.Name = "mnuClimaticTidyandExamineMerge"
-        Me.mnuClimaticTidyandExamineMerge.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticTidyandExamineMerge.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineMerge.Text = "Add (Merge) Columns..."
         '
         'mnuClimaticTidyandExamineAppend
         '
         Me.mnuClimaticTidyandExamineAppend.Name = "mnuClimaticTidyandExamineAppend"
-        Me.mnuClimaticTidyandExamineAppend.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticTidyandExamineAppend.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyandExamineAppend.Text = "Append (Bind Rows)..."
         '
         'ToolStripSeparator69
         '
         Me.ToolStripSeparator69.Name = "ToolStripSeparator69"
-        Me.ToolStripSeparator69.Size = New System.Drawing.Size(244, 6)
+        Me.ToolStripSeparator69.Size = New System.Drawing.Size(198, 6)
         '
         'mnuClimaticTidyDataKey
         '
         Me.mnuClimaticTidyDataKey.Name = "mnuClimaticTidyDataKey"
-        Me.mnuClimaticTidyDataKey.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticTidyDataKey.Size = New System.Drawing.Size(201, 22)
         Me.mnuClimaticTidyDataKey.Text = "Add Key..."
         '
         'mnuClimaticDates
         '
         Me.mnuClimaticDates.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticDatesGenerateDates, Me.mnuClimaticDatesMakeDate, Me.mnuClimaticDatesInfillMissingDates, Me.mnuClimaticDatesUseDate, Me.mnuClimaticDatesMakeTime, Me.mnuClimaticDatesUseTime})
         Me.mnuClimaticDates.Name = "mnuClimaticDates"
-        Me.mnuClimaticDates.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticDates.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticDates.Text = "Dates"
         '
         'mnuClimaticDatesGenerateDates
         '
         Me.mnuClimaticDatesGenerateDates.Name = "mnuClimaticDatesGenerateDates"
-        Me.mnuClimaticDatesGenerateDates.Size = New System.Drawing.Size(203, 26)
+        Me.mnuClimaticDatesGenerateDates.Size = New System.Drawing.Size(162, 22)
         Me.mnuClimaticDatesGenerateDates.Text = "Generate Dates..."
         '
         'mnuClimaticDatesMakeDate
         '
         Me.mnuClimaticDatesMakeDate.Name = "mnuClimaticDatesMakeDate"
-        Me.mnuClimaticDatesMakeDate.Size = New System.Drawing.Size(203, 26)
+        Me.mnuClimaticDatesMakeDate.Size = New System.Drawing.Size(162, 22)
         Me.mnuClimaticDatesMakeDate.Text = "Make Date..."
         '
         'mnuClimaticDatesInfillMissingDates
         '
         Me.mnuClimaticDatesInfillMissingDates.Name = "mnuClimaticDatesInfillMissingDates"
-        Me.mnuClimaticDatesInfillMissingDates.Size = New System.Drawing.Size(203, 26)
+        Me.mnuClimaticDatesInfillMissingDates.Size = New System.Drawing.Size(162, 22)
         Me.mnuClimaticDatesInfillMissingDates.Text = "Fill Date Gaps..."
         '
         'mnuClimaticDatesUseDate
         '
         Me.mnuClimaticDatesUseDate.Name = "mnuClimaticDatesUseDate"
-        Me.mnuClimaticDatesUseDate.Size = New System.Drawing.Size(203, 26)
+        Me.mnuClimaticDatesUseDate.Size = New System.Drawing.Size(162, 22)
         Me.mnuClimaticDatesUseDate.Text = "Use Date..."
         '
         'mnuClimaticDatesMakeTime
         '
         Me.mnuClimaticDatesMakeTime.Enabled = False
         Me.mnuClimaticDatesMakeTime.Name = "mnuClimaticDatesMakeTime"
-        Me.mnuClimaticDatesMakeTime.Size = New System.Drawing.Size(203, 26)
+        Me.mnuClimaticDatesMakeTime.Size = New System.Drawing.Size(162, 22)
         Me.mnuClimaticDatesMakeTime.Text = "Make Time..."
         Me.mnuClimaticDatesMakeTime.Visible = False
         '
@@ -2193,175 +2193,175 @@ Partial Class frmMain
         '
         Me.mnuClimaticDatesUseTime.Enabled = False
         Me.mnuClimaticDatesUseTime.Name = "mnuClimaticDatesUseTime"
-        Me.mnuClimaticDatesUseTime.Size = New System.Drawing.Size(203, 26)
+        Me.mnuClimaticDatesUseTime.Size = New System.Drawing.Size(162, 22)
         Me.mnuClimaticDatesUseTime.Text = "Use Time..."
         Me.mnuClimaticDatesUseTime.Visible = False
         '
         'mnuClimaticDefineClimaticData
         '
         Me.mnuClimaticDefineClimaticData.Name = "mnuClimaticDefineClimaticData"
-        Me.mnuClimaticDefineClimaticData.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticDefineClimaticData.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticDefineClimaticData.Text = "Define Climatic Data..."
         '
         'mnuClimaticCheckData
         '
         Me.mnuClimaticCheckData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticCheckDataInventory, Me.mnuClimaticCheckDataDisplayDaily, Me.ToolStripSeparator65, Me.mnuClimaticCheckDataFillMissingValues, Me.mnuClimaticCheckDataBoxplot, Me.mnuClimaticCheckDataQCTemperatures, Me.mnuClimaticCheckDataQCRainfall, Me.ToolStripSeparator70, Me.mnuClimaticCheckDataHomogenization, Me.mnuClimaticCheckDataCheckStationLocations, Me.mnuClimaticCheckDataDistances})
         Me.mnuClimaticCheckData.Name = "mnuClimaticCheckData"
-        Me.mnuClimaticCheckData.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticCheckData.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticCheckData.Text = "Check Data"
         '
         'mnuClimaticCheckDataInventory
         '
         Me.mnuClimaticCheckDataInventory.Name = "mnuClimaticCheckDataInventory"
-        Me.mnuClimaticCheckDataInventory.Size = New System.Drawing.Size(258, 26)
+        Me.mnuClimaticCheckDataInventory.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataInventory.Text = "Inventory..."
         '
         'mnuClimaticCheckDataDisplayDaily
         '
         Me.mnuClimaticCheckDataDisplayDaily.Name = "mnuClimaticCheckDataDisplayDaily"
-        Me.mnuClimaticCheckDataDisplayDaily.Size = New System.Drawing.Size(258, 26)
+        Me.mnuClimaticCheckDataDisplayDaily.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataDisplayDaily.Text = "Display Daily..."
         '
         'ToolStripSeparator65
         '
         Me.ToolStripSeparator65.Name = "ToolStripSeparator65"
-        Me.ToolStripSeparator65.Size = New System.Drawing.Size(255, 6)
+        Me.ToolStripSeparator65.Size = New System.Drawing.Size(207, 6)
         '
         'mnuClimaticCheckDataFillMissingValues
         '
         Me.mnuClimaticCheckDataFillMissingValues.Name = "mnuClimaticCheckDataFillMissingValues"
-        Me.mnuClimaticCheckDataFillMissingValues.Size = New System.Drawing.Size(258, 26)
+        Me.mnuClimaticCheckDataFillMissingValues.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataFillMissingValues.Text = "Fill Missing Values..."
         '
         'mnuClimaticCheckDataBoxplot
         '
         Me.mnuClimaticCheckDataBoxplot.Name = "mnuClimaticCheckDataBoxplot"
-        Me.mnuClimaticCheckDataBoxplot.Size = New System.Drawing.Size(258, 26)
+        Me.mnuClimaticCheckDataBoxplot.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataBoxplot.Text = "Boxplot..."
         '
         'mnuClimaticCheckDataQCTemperatures
         '
         Me.mnuClimaticCheckDataQCTemperatures.Name = "mnuClimaticCheckDataQCTemperatures"
-        Me.mnuClimaticCheckDataQCTemperatures.Size = New System.Drawing.Size(258, 26)
+        Me.mnuClimaticCheckDataQCTemperatures.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataQCTemperatures.Text = "QC Temperatures..."
         '
         'mnuClimaticCheckDataQCRainfall
         '
         Me.mnuClimaticCheckDataQCRainfall.Name = "mnuClimaticCheckDataQCRainfall"
-        Me.mnuClimaticCheckDataQCRainfall.Size = New System.Drawing.Size(258, 26)
+        Me.mnuClimaticCheckDataQCRainfall.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataQCRainfall.Text = "QC Rainfall..."
         '
         'ToolStripSeparator70
         '
         Me.ToolStripSeparator70.Name = "ToolStripSeparator70"
-        Me.ToolStripSeparator70.Size = New System.Drawing.Size(255, 6)
+        Me.ToolStripSeparator70.Size = New System.Drawing.Size(207, 6)
         '
         'mnuClimaticCheckDataHomogenization
         '
         Me.mnuClimaticCheckDataHomogenization.Name = "mnuClimaticCheckDataHomogenization"
-        Me.mnuClimaticCheckDataHomogenization.Size = New System.Drawing.Size(258, 26)
+        Me.mnuClimaticCheckDataHomogenization.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataHomogenization.Text = "Homogenization..."
         '
         'mnuClimaticCheckDataCheckStationLocations
         '
         Me.mnuClimaticCheckDataCheckStationLocations.Name = "mnuClimaticCheckDataCheckStationLocations"
-        Me.mnuClimaticCheckDataCheckStationLocations.Size = New System.Drawing.Size(258, 26)
+        Me.mnuClimaticCheckDataCheckStationLocations.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataCheckStationLocations.Text = "Check Station Locations..."
         '
         'mnuClimaticCheckDataDistances
         '
         Me.mnuClimaticCheckDataDistances.Name = "mnuClimaticCheckDataDistances"
-        Me.mnuClimaticCheckDataDistances.Size = New System.Drawing.Size(258, 26)
+        Me.mnuClimaticCheckDataDistances.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticCheckDataDistances.Text = "Distances..."
         '
         'mnuClimaticPrepare
         '
         Me.mnuClimaticPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuCimaticPrepareTransform, Me.mnuClimaticPrepareConversions, Me.ToolStripSeparator37, Me.mnuClimaticPrepareClimaticSummaries, Me.mnuClimaticPrepareStartoftheRains, Me.mnuClimaticPrepareEndOfRains, Me.mnuClimaticPrepareLengthOfSeason, Me.mnuClimaticPrepareSpells, Me.mnuClimaticPrepareExtremes, Me.ToolStripSeparator64, Me.mnuClimaticPrepareClimdex, Me.ToolStripSeparator51, Me.mnuClimaticPrepareEvapotranspiration, Me.mnuClimaticPrepareSummary, Me.mnuClimaticPrepareNewWorksheet, Me.mnuClimaticPrepareImportDailyData, Me.mnuClimaticPrepareMakeFactor, Me.mnuClimaticPrepareShiftDailyData, Me.mnuClimaticPrepareUnstackDailyData, Me.mnuClimaticPrepareStackDailyData})
         Me.mnuClimaticPrepare.Name = "mnuClimaticPrepare"
-        Me.mnuClimaticPrepare.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticPrepare.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticPrepare.Tag = "Prepare"
         Me.mnuClimaticPrepare.Text = "Prepare"
         '
         'mnuCimaticPrepareTransform
         '
         Me.mnuCimaticPrepareTransform.Name = "mnuCimaticPrepareTransform"
-        Me.mnuCimaticPrepareTransform.Size = New System.Drawing.Size(232, 26)
+        Me.mnuCimaticPrepareTransform.Size = New System.Drawing.Size(189, 22)
         Me.mnuCimaticPrepareTransform.Text = "Climatic Transform..."
         '
         'mnuClimaticPrepareConversions
         '
         Me.mnuClimaticPrepareConversions.Name = "mnuClimaticPrepareConversions"
-        Me.mnuClimaticPrepareConversions.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareConversions.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareConversions.Text = "Conversions..."
         '
         'ToolStripSeparator37
         '
         Me.ToolStripSeparator37.Name = "ToolStripSeparator37"
-        Me.ToolStripSeparator37.Size = New System.Drawing.Size(229, 6)
+        Me.ToolStripSeparator37.Size = New System.Drawing.Size(186, 6)
         '
         'mnuClimaticPrepareClimaticSummaries
         '
         Me.mnuClimaticPrepareClimaticSummaries.Name = "mnuClimaticPrepareClimaticSummaries"
-        Me.mnuClimaticPrepareClimaticSummaries.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareClimaticSummaries.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareClimaticSummaries.Text = "Climatic Summaries..."
         '
         'mnuClimaticPrepareStartoftheRains
         '
         Me.mnuClimaticPrepareStartoftheRains.Name = "mnuClimaticPrepareStartoftheRains"
-        Me.mnuClimaticPrepareStartoftheRains.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareStartoftheRains.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareStartoftheRains.Text = "Start of the Season..."
         '
         'mnuClimaticPrepareEndOfRains
         '
         Me.mnuClimaticPrepareEndOfRains.Name = "mnuClimaticPrepareEndOfRains"
-        Me.mnuClimaticPrepareEndOfRains.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareEndOfRains.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareEndOfRains.Text = "End of the Season..."
         '
         'mnuClimaticPrepareLengthOfSeason
         '
         Me.mnuClimaticPrepareLengthOfSeason.Name = "mnuClimaticPrepareLengthOfSeason"
-        Me.mnuClimaticPrepareLengthOfSeason.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareLengthOfSeason.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareLengthOfSeason.Text = "Length of Season..."
         '
         'mnuClimaticPrepareSpells
         '
         Me.mnuClimaticPrepareSpells.Name = "mnuClimaticPrepareSpells"
-        Me.mnuClimaticPrepareSpells.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareSpells.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareSpells.Text = "Spells..."
         '
         'mnuClimaticPrepareExtremes
         '
         Me.mnuClimaticPrepareExtremes.Name = "mnuClimaticPrepareExtremes"
-        Me.mnuClimaticPrepareExtremes.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareExtremes.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareExtremes.Text = "Extremes..."
         '
         'ToolStripSeparator64
         '
         Me.ToolStripSeparator64.Name = "ToolStripSeparator64"
-        Me.ToolStripSeparator64.Size = New System.Drawing.Size(229, 6)
+        Me.ToolStripSeparator64.Size = New System.Drawing.Size(186, 6)
         '
         'mnuClimaticPrepareClimdex
         '
         Me.mnuClimaticPrepareClimdex.Name = "mnuClimaticPrepareClimdex"
-        Me.mnuClimaticPrepareClimdex.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareClimdex.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareClimdex.Text = "Climdex..."
         '
         'ToolStripSeparator51
         '
         Me.ToolStripSeparator51.Name = "ToolStripSeparator51"
-        Me.ToolStripSeparator51.Size = New System.Drawing.Size(229, 6)
+        Me.ToolStripSeparator51.Size = New System.Drawing.Size(186, 6)
         '
         'mnuClimaticPrepareEvapotranspiration
         '
         Me.mnuClimaticPrepareEvapotranspiration.Name = "mnuClimaticPrepareEvapotranspiration"
-        Me.mnuClimaticPrepareEvapotranspiration.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareEvapotranspiration.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareEvapotranspiration.Text = "Evapotranspiration..."
         '
         'mnuClimaticPrepareSummary
         '
         Me.mnuClimaticPrepareSummary.Enabled = False
         Me.mnuClimaticPrepareSummary.Name = "mnuClimaticPrepareSummary"
-        Me.mnuClimaticPrepareSummary.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareSummary.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareSummary.Text = "Summary..."
         Me.mnuClimaticPrepareSummary.Visible = False
         '
@@ -2369,7 +2369,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticPrepareNewWorksheet.Enabled = False
         Me.mnuClimaticPrepareNewWorksheet.Name = "mnuClimaticPrepareNewWorksheet"
-        Me.mnuClimaticPrepareNewWorksheet.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareNewWorksheet.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareNewWorksheet.Tag = "New_Worksheet"
         Me.mnuClimaticPrepareNewWorksheet.Text = "New Worksheet..."
         Me.mnuClimaticPrepareNewWorksheet.Visible = False
@@ -2378,7 +2378,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticPrepareImportDailyData.Enabled = False
         Me.mnuClimaticPrepareImportDailyData.Name = "mnuClimaticPrepareImportDailyData"
-        Me.mnuClimaticPrepareImportDailyData.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareImportDailyData.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareImportDailyData.Tag = "Import_daily_data"
         Me.mnuClimaticPrepareImportDailyData.Text = "Import daily Data..."
         Me.mnuClimaticPrepareImportDailyData.Visible = False
@@ -2387,7 +2387,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticPrepareMakeFactor.Enabled = False
         Me.mnuClimaticPrepareMakeFactor.Name = "mnuClimaticPrepareMakeFactor"
-        Me.mnuClimaticPrepareMakeFactor.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareMakeFactor.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareMakeFactor.Tag = "Make_Factor"
         Me.mnuClimaticPrepareMakeFactor.Text = "Make Factor..."
         Me.mnuClimaticPrepareMakeFactor.Visible = False
@@ -2396,7 +2396,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticPrepareShiftDailyData.Enabled = False
         Me.mnuClimaticPrepareShiftDailyData.Name = "mnuClimaticPrepareShiftDailyData"
-        Me.mnuClimaticPrepareShiftDailyData.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareShiftDailyData.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareShiftDailyData.Tag = "Shift_Daily_data"
         Me.mnuClimaticPrepareShiftDailyData.Text = "Shift Daily Data..."
         Me.mnuClimaticPrepareShiftDailyData.Visible = False
@@ -2405,7 +2405,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticPrepareUnstackDailyData.Enabled = False
         Me.mnuClimaticPrepareUnstackDailyData.Name = "mnuClimaticPrepareUnstackDailyData"
-        Me.mnuClimaticPrepareUnstackDailyData.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareUnstackDailyData.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareUnstackDailyData.Tag = "Unstack_Daily_data"
         Me.mnuClimaticPrepareUnstackDailyData.Text = "Unstack Daily Data..."
         Me.mnuClimaticPrepareUnstackDailyData.Visible = False
@@ -2414,7 +2414,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticPrepareStackDailyData.Enabled = False
         Me.mnuClimaticPrepareStackDailyData.Name = "mnuClimaticPrepareStackDailyData"
-        Me.mnuClimaticPrepareStackDailyData.Size = New System.Drawing.Size(232, 26)
+        Me.mnuClimaticPrepareStackDailyData.Size = New System.Drawing.Size(189, 22)
         Me.mnuClimaticPrepareStackDailyData.Tag = "Stack_Daily_data"
         Me.mnuClimaticPrepareStackDailyData.Text = "Stack Daily data..."
         Me.mnuClimaticPrepareStackDailyData.Visible = False
@@ -2422,367 +2422,367 @@ Partial Class frmMain
         'ToolStripSeparator30
         '
         Me.ToolStripSeparator30.Name = "ToolStripSeparator30"
-        Me.ToolStripSeparator30.Size = New System.Drawing.Size(264, 6)
+        Me.ToolStripSeparator30.Size = New System.Drawing.Size(209, 6)
         '
         'mnuClimaticDescribe
         '
         Me.mnuClimaticDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticDescribeSummarise23Variables, Me.mnuClimaticDescribeGraph23Variables, Me.ToolStripSeparator31, Me.mnuClimaticDescribeSPISPEI, Me.mnuClimaticDescribeClimograph, Me.mnuClimaticDescribeTrendGraph, Me.mnuClimaticDescribeSeasonalGraph, Me.mnuClimaticDescribeIDF, Me.ToolStripSeparator17, Me.mnuClimaticDescribeWindRose, Me.mnuClimaticDescribeWindPollutionRose, Me.mnuClimaticDescribeOtherRosePlots, Me.CheckSummaryToolStripMenuItem})
         Me.mnuClimaticDescribe.Name = "mnuClimaticDescribe"
-        Me.mnuClimaticDescribe.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticDescribe.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticDescribe.Text = "Describe"
         '
         'mnuClimaticDescribeSummarise23Variables
         '
         Me.mnuClimaticDescribeSummarise23Variables.Name = "mnuClimaticDescribeSummarise23Variables"
-        Me.mnuClimaticDescribeSummarise23Variables.Size = New System.Drawing.Size(264, 26)
+        Me.mnuClimaticDescribeSummarise23Variables.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeSummarise23Variables.Text = "Summarise 2/3 Variables..."
         '
         'mnuClimaticDescribeGraph23Variables
         '
         Me.mnuClimaticDescribeGraph23Variables.Name = "mnuClimaticDescribeGraph23Variables"
-        Me.mnuClimaticDescribeGraph23Variables.Size = New System.Drawing.Size(264, 26)
+        Me.mnuClimaticDescribeGraph23Variables.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeGraph23Variables.Text = "Graph 2/3 Variables..."
         '
         'ToolStripSeparator31
         '
         Me.ToolStripSeparator31.Name = "ToolStripSeparator31"
-        Me.ToolStripSeparator31.Size = New System.Drawing.Size(261, 6)
+        Me.ToolStripSeparator31.Size = New System.Drawing.Size(208, 6)
         '
         'mnuClimaticDescribeSPISPEI
         '
         Me.mnuClimaticDescribeSPISPEI.Name = "mnuClimaticDescribeSPISPEI"
-        Me.mnuClimaticDescribeSPISPEI.Size = New System.Drawing.Size(264, 26)
+        Me.mnuClimaticDescribeSPISPEI.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeSPISPEI.Text = "SPI/SPEI..."
         '
         'mnuClimaticDescribeClimograph
         '
         Me.mnuClimaticDescribeClimograph.Name = "mnuClimaticDescribeClimograph"
-        Me.mnuClimaticDescribeClimograph.Size = New System.Drawing.Size(264, 26)
+        Me.mnuClimaticDescribeClimograph.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeClimograph.Text = "Climograph..."
         '
         'mnuClimaticDescribeTrendGraph
         '
         Me.mnuClimaticDescribeTrendGraph.Name = "mnuClimaticDescribeTrendGraph"
-        Me.mnuClimaticDescribeTrendGraph.Size = New System.Drawing.Size(264, 26)
+        Me.mnuClimaticDescribeTrendGraph.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeTrendGraph.Text = "Trend Graph..."
         '
         'mnuClimaticDescribeSeasonalGraph
         '
         Me.mnuClimaticDescribeSeasonalGraph.Name = "mnuClimaticDescribeSeasonalGraph"
-        Me.mnuClimaticDescribeSeasonalGraph.Size = New System.Drawing.Size(264, 26)
+        Me.mnuClimaticDescribeSeasonalGraph.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeSeasonalGraph.Text = "Seasonal Graph..."
         '
         'mnuClimaticDescribeIDF
         '
         Me.mnuClimaticDescribeIDF.Name = "mnuClimaticDescribeIDF"
-        Me.mnuClimaticDescribeIDF.Size = New System.Drawing.Size(264, 26)
+        Me.mnuClimaticDescribeIDF.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeIDF.Text = "IDF..."
         '
         'ToolStripSeparator17
         '
         Me.ToolStripSeparator17.Name = "ToolStripSeparator17"
-        Me.ToolStripSeparator17.Size = New System.Drawing.Size(261, 6)
+        Me.ToolStripSeparator17.Size = New System.Drawing.Size(208, 6)
         '
         'mnuClimaticDescribeWindRose
         '
         Me.mnuClimaticDescribeWindRose.Name = "mnuClimaticDescribeWindRose"
-        Me.mnuClimaticDescribeWindRose.Size = New System.Drawing.Size(264, 26)
+        Me.mnuClimaticDescribeWindRose.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeWindRose.Text = "Wind Rose..."
         '
         'mnuClimaticDescribeWindPollutionRose
         '
         Me.mnuClimaticDescribeWindPollutionRose.Name = "mnuClimaticDescribeWindPollutionRose"
-        Me.mnuClimaticDescribeWindPollutionRose.Size = New System.Drawing.Size(264, 26)
+        Me.mnuClimaticDescribeWindPollutionRose.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeWindPollutionRose.Text = "Wind/Pollution Rose..."
         '
         'mnuClimaticDescribeOtherRosePlots
         '
         Me.mnuClimaticDescribeOtherRosePlots.Name = "mnuClimaticDescribeOtherRosePlots"
-        Me.mnuClimaticDescribeOtherRosePlots.Size = New System.Drawing.Size(264, 26)
+        Me.mnuClimaticDescribeOtherRosePlots.Size = New System.Drawing.Size(211, 22)
         Me.mnuClimaticDescribeOtherRosePlots.Text = "Other Rose Plots..."
         '
         'CheckSummaryToolStripMenuItem
         '
         Me.CheckSummaryToolStripMenuItem.Name = "CheckSummaryToolStripMenuItem"
-        Me.CheckSummaryToolStripMenuItem.Size = New System.Drawing.Size(264, 26)
+        Me.CheckSummaryToolStripMenuItem.Size = New System.Drawing.Size(211, 22)
         Me.CheckSummaryToolStripMenuItem.Text = "Check Summary"
         '
         'mnuClimaticNCMP
         '
         Me.mnuClimaticNCMP.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticNCMPIndices, Me.mnuClimaticNCMPVariogram, Me.mnuClimaticNCMPRegionAverage, Me.mnuClimaticNCMPTrendGraphs, Me.mnuClimaticNCMPCountRecords, Me.mnuClimaticNCMPSummary})
         Me.mnuClimaticNCMP.Name = "mnuClimaticNCMP"
-        Me.mnuClimaticNCMP.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticNCMP.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticNCMP.Text = "NCMP"
         '
         'mnuClimaticNCMPIndices
         '
         Me.mnuClimaticNCMPIndices.Name = "mnuClimaticNCMPIndices"
-        Me.mnuClimaticNCMPIndices.Size = New System.Drawing.Size(207, 26)
+        Me.mnuClimaticNCMPIndices.Size = New System.Drawing.Size(166, 22)
         Me.mnuClimaticNCMPIndices.Text = "Indices..."
         '
         'mnuClimaticNCMPVariogram
         '
         Me.mnuClimaticNCMPVariogram.Name = "mnuClimaticNCMPVariogram"
-        Me.mnuClimaticNCMPVariogram.Size = New System.Drawing.Size(207, 26)
+        Me.mnuClimaticNCMPVariogram.Size = New System.Drawing.Size(166, 22)
         Me.mnuClimaticNCMPVariogram.Text = "Variogram..."
         '
         'mnuClimaticNCMPRegionAverage
         '
         Me.mnuClimaticNCMPRegionAverage.Name = "mnuClimaticNCMPRegionAverage"
-        Me.mnuClimaticNCMPRegionAverage.Size = New System.Drawing.Size(207, 26)
+        Me.mnuClimaticNCMPRegionAverage.Size = New System.Drawing.Size(166, 22)
         Me.mnuClimaticNCMPRegionAverage.Text = "Region Average..."
         '
         'mnuClimaticNCMPTrendGraphs
         '
         Me.mnuClimaticNCMPTrendGraphs.Name = "mnuClimaticNCMPTrendGraphs"
-        Me.mnuClimaticNCMPTrendGraphs.Size = New System.Drawing.Size(207, 26)
+        Me.mnuClimaticNCMPTrendGraphs.Size = New System.Drawing.Size(166, 22)
         Me.mnuClimaticNCMPTrendGraphs.Text = "Trend Graphs..."
         '
         'mnuClimaticNCMPCountRecords
         '
         Me.mnuClimaticNCMPCountRecords.Name = "mnuClimaticNCMPCountRecords"
-        Me.mnuClimaticNCMPCountRecords.Size = New System.Drawing.Size(207, 26)
+        Me.mnuClimaticNCMPCountRecords.Size = New System.Drawing.Size(166, 22)
         Me.mnuClimaticNCMPCountRecords.Text = "Count Records..."
         '
         'mnuClimaticNCMPSummary
         '
         Me.mnuClimaticNCMPSummary.Name = "mnuClimaticNCMPSummary"
-        Me.mnuClimaticNCMPSummary.Size = New System.Drawing.Size(207, 26)
+        Me.mnuClimaticNCMPSummary.Size = New System.Drawing.Size(166, 22)
         Me.mnuClimaticNCMPSummary.Text = "Summary..."
         '
         'mnuClimaticPICSA
         '
         Me.mnuClimaticPICSA.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticPICSARainfallGraph, Me.mnuClimaticPICSATemperatureGraph, Me.ToolStripSeparator73, Me.mnuClimaticPICSACumExeedenceGraph, Me.mnuClimaticPICSACrops})
         Me.mnuClimaticPICSA.Name = "mnuClimaticPICSA"
-        Me.mnuClimaticPICSA.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticPICSA.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticPICSA.Text = "PICSA"
         '
         'mnuClimaticPICSARainfallGraph
         '
         Me.mnuClimaticPICSARainfallGraph.Name = "mnuClimaticPICSARainfallGraph"
-        Me.mnuClimaticPICSARainfallGraph.Size = New System.Drawing.Size(303, 26)
+        Me.mnuClimaticPICSARainfallGraph.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticPICSARainfallGraph.Text = "Rainfall Graph..."
         '
         'mnuClimaticPICSATemperatureGraph
         '
         Me.mnuClimaticPICSATemperatureGraph.Name = "mnuClimaticPICSATemperatureGraph"
-        Me.mnuClimaticPICSATemperatureGraph.Size = New System.Drawing.Size(303, 26)
+        Me.mnuClimaticPICSATemperatureGraph.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticPICSATemperatureGraph.Text = "Temperature Graph..."
         '
         'ToolStripSeparator73
         '
         Me.ToolStripSeparator73.Name = "ToolStripSeparator73"
-        Me.ToolStripSeparator73.Size = New System.Drawing.Size(300, 6)
+        Me.ToolStripSeparator73.Size = New System.Drawing.Size(242, 6)
         '
         'mnuClimaticPICSACumExeedenceGraph
         '
         Me.mnuClimaticPICSACumExeedenceGraph.Name = "mnuClimaticPICSACumExeedenceGraph"
-        Me.mnuClimaticPICSACumExeedenceGraph.Size = New System.Drawing.Size(303, 26)
+        Me.mnuClimaticPICSACumExeedenceGraph.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticPICSACumExeedenceGraph.Text = "Cumulative/Exceedance Graph..."
         '
         'mnuClimaticPICSACrops
         '
         Me.mnuClimaticPICSACrops.Name = "mnuClimaticPICSACrops"
-        Me.mnuClimaticPICSACrops.Size = New System.Drawing.Size(303, 26)
+        Me.mnuClimaticPICSACrops.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticPICSACrops.Text = "Crops..."
         '
         'mnuCMSAF
         '
         Me.mnuCMSAF.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticCMSAFPlotRegion, Me.mnuClimaticCMSAFExporttoCMSAFRToolbox})
         Me.mnuCMSAF.Name = "mnuCMSAF"
-        Me.mnuCMSAF.Size = New System.Drawing.Size(267, 26)
+        Me.mnuCMSAF.Size = New System.Drawing.Size(212, 22)
         Me.mnuCMSAF.Text = "CM SAF"
         '
         'mnuClimaticCMSAFPlotRegion
         '
         Me.mnuClimaticCMSAFPlotRegion.Name = "mnuClimaticCMSAFPlotRegion"
-        Me.mnuClimaticCMSAFPlotRegion.Size = New System.Drawing.Size(288, 26)
+        Me.mnuClimaticCMSAFPlotRegion.Size = New System.Drawing.Size(230, 22)
         Me.mnuClimaticCMSAFPlotRegion.Text = "Plot Region..."
         '
         'mnuClimaticCMSAFExporttoCMSAFRToolbox
         '
         Me.mnuClimaticCMSAFExporttoCMSAFRToolbox.Name = "mnuClimaticCMSAFExporttoCMSAFRToolbox"
-        Me.mnuClimaticCMSAFExporttoCMSAFRToolbox.Size = New System.Drawing.Size(288, 26)
+        Me.mnuClimaticCMSAFExporttoCMSAFRToolbox.Size = New System.Drawing.Size(230, 22)
         Me.mnuClimaticCMSAFExporttoCMSAFRToolbox.Text = "Export to CM SAF R Toolbox..."
         '
         'mnuClimaticCompare
         '
         Me.mnuClimaticCompare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticCompareCalculation, Me.mnuClimaticCompareSummary, Me.ToolStripSeparator66, Me.mnuClimaticCompareCorrelations, Me.mnuClimaticCompareScatterplot, Me.mnuClimaticCompareTimeSeriesPlot, Me.mnuClimaticCompareSeasonalPlot, Me.mnuClimaticCompareDensityPlot, Me.mnuClimaticCompareConditionalQuantiles, Me.mnuClimaticCompareTaylorDiagram})
         Me.mnuClimaticCompare.Name = "mnuClimaticCompare"
-        Me.mnuClimaticCompare.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticCompare.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticCompare.Text = "Compare"
         '
         'mnuClimaticCompareCalculation
         '
         Me.mnuClimaticCompareCalculation.Name = "mnuClimaticCompareCalculation"
-        Me.mnuClimaticCompareCalculation.Size = New System.Drawing.Size(244, 26)
+        Me.mnuClimaticCompareCalculation.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareCalculation.Text = "Calculation..."
         '
         'mnuClimaticCompareSummary
         '
         Me.mnuClimaticCompareSummary.Name = "mnuClimaticCompareSummary"
-        Me.mnuClimaticCompareSummary.Size = New System.Drawing.Size(244, 26)
+        Me.mnuClimaticCompareSummary.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareSummary.Text = "Summary..."
         '
         'ToolStripSeparator66
         '
         Me.ToolStripSeparator66.Name = "ToolStripSeparator66"
-        Me.ToolStripSeparator66.Size = New System.Drawing.Size(241, 6)
+        Me.ToolStripSeparator66.Size = New System.Drawing.Size(195, 6)
         '
         'mnuClimaticCompareCorrelations
         '
         Me.mnuClimaticCompareCorrelations.Name = "mnuClimaticCompareCorrelations"
-        Me.mnuClimaticCompareCorrelations.Size = New System.Drawing.Size(244, 26)
+        Me.mnuClimaticCompareCorrelations.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareCorrelations.Text = "Correlations..."
         '
         'mnuClimaticCompareScatterplot
         '
         Me.mnuClimaticCompareScatterplot.Name = "mnuClimaticCompareScatterplot"
-        Me.mnuClimaticCompareScatterplot.Size = New System.Drawing.Size(244, 26)
+        Me.mnuClimaticCompareScatterplot.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareScatterplot.Text = "Scatterplot..."
         '
         'mnuClimaticCompareTimeSeriesPlot
         '
         Me.mnuClimaticCompareTimeSeriesPlot.Name = "mnuClimaticCompareTimeSeriesPlot"
-        Me.mnuClimaticCompareTimeSeriesPlot.Size = New System.Drawing.Size(244, 26)
+        Me.mnuClimaticCompareTimeSeriesPlot.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareTimeSeriesPlot.Text = "Time Series Plot..."
         '
         'mnuClimaticCompareSeasonalPlot
         '
         Me.mnuClimaticCompareSeasonalPlot.Name = "mnuClimaticCompareSeasonalPlot"
-        Me.mnuClimaticCompareSeasonalPlot.Size = New System.Drawing.Size(244, 26)
+        Me.mnuClimaticCompareSeasonalPlot.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareSeasonalPlot.Text = "Seasonal Plot..."
         '
         'mnuClimaticCompareDensityPlot
         '
         Me.mnuClimaticCompareDensityPlot.Name = "mnuClimaticCompareDensityPlot"
-        Me.mnuClimaticCompareDensityPlot.Size = New System.Drawing.Size(244, 26)
+        Me.mnuClimaticCompareDensityPlot.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareDensityPlot.Text = "Density Plot..."
         '
         'mnuClimaticCompareConditionalQuantiles
         '
         Me.mnuClimaticCompareConditionalQuantiles.Name = "mnuClimaticCompareConditionalQuantiles"
-        Me.mnuClimaticCompareConditionalQuantiles.Size = New System.Drawing.Size(244, 26)
+        Me.mnuClimaticCompareConditionalQuantiles.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareConditionalQuantiles.Text = "Conditional Quantiles..."
         '
         'mnuClimaticCompareTaylorDiagram
         '
         Me.mnuClimaticCompareTaylorDiagram.Name = "mnuClimaticCompareTaylorDiagram"
-        Me.mnuClimaticCompareTaylorDiagram.Size = New System.Drawing.Size(244, 26)
+        Me.mnuClimaticCompareTaylorDiagram.Size = New System.Drawing.Size(198, 22)
         Me.mnuClimaticCompareTaylorDiagram.Text = "Taylor Diagram..."
         '
         'mnuClimaticMapping
         '
         Me.mnuClimaticMapping.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticMappingMap, Me.mnuClimaticMappingCheckStationLocations})
         Me.mnuClimaticMapping.Name = "mnuClimaticMapping"
-        Me.mnuClimaticMapping.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticMapping.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticMapping.Text = "Mapping"
         '
         'mnuClimaticMappingMap
         '
         Me.mnuClimaticMappingMap.Name = "mnuClimaticMappingMap"
-        Me.mnuClimaticMappingMap.Size = New System.Drawing.Size(258, 26)
+        Me.mnuClimaticMappingMap.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticMappingMap.Text = "Map..."
         '
         'mnuClimaticMappingCheckStationLocations
         '
         Me.mnuClimaticMappingCheckStationLocations.Name = "mnuClimaticMappingCheckStationLocations"
-        Me.mnuClimaticMappingCheckStationLocations.Size = New System.Drawing.Size(258, 26)
+        Me.mnuClimaticMappingCheckStationLocations.Size = New System.Drawing.Size(210, 22)
         Me.mnuClimaticMappingCheckStationLocations.Text = "Check Station Locations..."
         '
         'mnuClimaticModel
         '
         Me.mnuClimaticModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticModelOutfilling, Me.mnuClimaticModelsExtremes, Me.mnuClimaticModelCircular, Me.mnuClimaticModelMarkovModelling})
         Me.mnuClimaticModel.Name = "mnuClimaticModel"
-        Me.mnuClimaticModel.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticModel.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticModel.Text = "Model"
         '
         'mnuClimaticModelOutfilling
         '
         Me.mnuClimaticModelOutfilling.Name = "mnuClimaticModelOutfilling"
-        Me.mnuClimaticModelOutfilling.Size = New System.Drawing.Size(222, 26)
+        Me.mnuClimaticModelOutfilling.Size = New System.Drawing.Size(180, 22)
         Me.mnuClimaticModelOutfilling.Text = "Outfilling..."
         '
         'mnuClimaticModelsExtremes
         '
         Me.mnuClimaticModelsExtremes.Name = "mnuClimaticModelsExtremes"
-        Me.mnuClimaticModelsExtremes.Size = New System.Drawing.Size(222, 26)
+        Me.mnuClimaticModelsExtremes.Size = New System.Drawing.Size(180, 22)
         Me.mnuClimaticModelsExtremes.Text = "Extremes..."
         '
         'mnuClimaticModelCircular
         '
         Me.mnuClimaticModelCircular.Enabled = False
         Me.mnuClimaticModelCircular.Name = "mnuClimaticModelCircular"
-        Me.mnuClimaticModelCircular.Size = New System.Drawing.Size(222, 26)
+        Me.mnuClimaticModelCircular.Size = New System.Drawing.Size(180, 22)
         Me.mnuClimaticModelCircular.Text = "Circular..."
         Me.mnuClimaticModelCircular.Visible = False
         '
         'mnuClimaticModelMarkovModelling
         '
         Me.mnuClimaticModelMarkovModelling.Name = "mnuClimaticModelMarkovModelling"
-        Me.mnuClimaticModelMarkovModelling.Size = New System.Drawing.Size(222, 26)
+        Me.mnuClimaticModelMarkovModelling.Size = New System.Drawing.Size(180, 22)
         Me.mnuClimaticModelMarkovModelling.Tag = "Markov_Modelling"
         Me.mnuClimaticModelMarkovModelling.Text = "Markov Modelling..."
         '
         'ToolStripSeparator23
         '
         Me.ToolStripSeparator23.Name = "ToolStripSeparator23"
-        Me.ToolStripSeparator23.Size = New System.Drawing.Size(264, 6)
+        Me.ToolStripSeparator23.Size = New System.Drawing.Size(209, 6)
         '
         'mnuClimaticSCF
         '
         Me.mnuClimaticSCF.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticSCFSupportOpenSST, Me.mnuClimaticSCFSupportExporttoCPT, Me.ToolStripSeparator32, Me.mnuClimaticSCFSupportCorrelations, Me.mnuClimaticSCFSupportPrincipalComponents, Me.mnuClimaticSCFSupportCanonicalCorrelations, Me.mnuClimaticSCFSupportCumulativeExceedanceGraph})
         Me.mnuClimaticSCF.Name = "mnuClimaticSCF"
-        Me.mnuClimaticSCF.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticSCF.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticSCF.Text = "Seasonal Forecast Support"
         '
         'mnuClimaticSCFSupportOpenSST
         '
         Me.mnuClimaticSCFSupportOpenSST.Name = "mnuClimaticSCFSupportOpenSST"
-        Me.mnuClimaticSCFSupportOpenSST.Size = New System.Drawing.Size(303, 26)
+        Me.mnuClimaticSCFSupportOpenSST.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticSCFSupportOpenSST.Text = "Open SST..."
         '
         'mnuClimaticSCFSupportExporttoCPT
         '
         Me.mnuClimaticSCFSupportExporttoCPT.Name = "mnuClimaticSCFSupportExporttoCPT"
-        Me.mnuClimaticSCFSupportExporttoCPT.Size = New System.Drawing.Size(303, 26)
+        Me.mnuClimaticSCFSupportExporttoCPT.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticSCFSupportExporttoCPT.Tag = "Export_to_CPT"
         Me.mnuClimaticSCFSupportExporttoCPT.Text = "Export to CPT..."
         '
         'ToolStripSeparator32
         '
         Me.ToolStripSeparator32.Name = "ToolStripSeparator32"
-        Me.ToolStripSeparator32.Size = New System.Drawing.Size(300, 6)
+        Me.ToolStripSeparator32.Size = New System.Drawing.Size(242, 6)
         '
         'mnuClimaticSCFSupportCorrelations
         '
         Me.mnuClimaticSCFSupportCorrelations.Name = "mnuClimaticSCFSupportCorrelations"
-        Me.mnuClimaticSCFSupportCorrelations.Size = New System.Drawing.Size(303, 26)
+        Me.mnuClimaticSCFSupportCorrelations.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticSCFSupportCorrelations.Text = "Correlations..."
         '
         'mnuClimaticSCFSupportPrincipalComponents
         '
         Me.mnuClimaticSCFSupportPrincipalComponents.Name = "mnuClimaticSCFSupportPrincipalComponents"
-        Me.mnuClimaticSCFSupportPrincipalComponents.Size = New System.Drawing.Size(303, 26)
+        Me.mnuClimaticSCFSupportPrincipalComponents.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticSCFSupportPrincipalComponents.Text = "Principal Components..."
         '
         'mnuClimaticSCFSupportCanonicalCorrelations
         '
         Me.mnuClimaticSCFSupportCanonicalCorrelations.Name = "mnuClimaticSCFSupportCanonicalCorrelations"
-        Me.mnuClimaticSCFSupportCanonicalCorrelations.Size = New System.Drawing.Size(303, 26)
+        Me.mnuClimaticSCFSupportCanonicalCorrelations.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticSCFSupportCanonicalCorrelations.Text = "Canonical Correlations..."
         '
         'mnuClimaticSCFSupportCumulativeExceedanceGraph
         '
         Me.mnuClimaticSCFSupportCumulativeExceedanceGraph.Name = "mnuClimaticSCFSupportCumulativeExceedanceGraph"
-        Me.mnuClimaticSCFSupportCumulativeExceedanceGraph.Size = New System.Drawing.Size(303, 26)
+        Me.mnuClimaticSCFSupportCumulativeExceedanceGraph.Size = New System.Drawing.Size(245, 22)
         Me.mnuClimaticSCFSupportCumulativeExceedanceGraph.Text = "Cumulative/Exceedance Graph..."
         '
         'mnuClimaticClimateMethods
         '
         Me.mnuClimaticClimateMethods.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticClimateMethodsDataManipulation, Me.mnuClimaticClimateMethodsGraphics, Me.mnuClimaticClimateMethodsModel, Me.mnuClimaticClimateMethodsAdditional, Me.mnuClimateMethodsCreateClimateObject})
         Me.mnuClimaticClimateMethods.Name = "mnuClimaticClimateMethods"
-        Me.mnuClimaticClimateMethods.Size = New System.Drawing.Size(267, 26)
+        Me.mnuClimaticClimateMethods.Size = New System.Drawing.Size(212, 22)
         Me.mnuClimaticClimateMethods.Tag = "Climatic_Methods"
         Me.mnuClimaticClimateMethods.Text = "Climate Methods"
         Me.mnuClimaticClimateMethods.Visible = False
@@ -2791,7 +2791,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulation.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticClimateMethodsDataManipulationStartOfRain, Me.mnuClimaticClimateMethodsDataManipulationEndOfRain, Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth, Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular, Me.mnuClimaticClimateMethodsDataManipulationDayMonth, Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily, Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear, Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal, Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength, Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA, Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents, Me.mnuClimaticClimateMethodsDataManipulationMissingData, Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable, Me.mnuClimateMethodsDataManipulationMonthlySummaries, Me.mnuClimateMethodsDataManipulationOutputForCD})
         Me.mnuClimaticClimateMethodsDataManipulation.Name = "mnuClimaticClimateMethodsDataManipulation"
-        Me.mnuClimaticClimateMethodsDataManipulation.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticClimateMethodsDataManipulation.Size = New System.Drawing.Size(199, 22)
         Me.mnuClimaticClimateMethodsDataManipulation.Tag = "Data_Manipulation"
         Me.mnuClimaticClimateMethodsDataManipulation.Text = "Data Manipulation"
         '
@@ -2799,7 +2799,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationStartOfRain.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationStartOfRain.Name = "mnuClimaticClimateMethodsDataManipulationStartOfRain"
-        Me.mnuClimaticClimateMethodsDataManipulationStartOfRain.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimaticClimateMethodsDataManipulationStartOfRain.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationStartOfRain.Tag = "Start_of_Rain"
         Me.mnuClimaticClimateMethodsDataManipulationStartOfRain.Text = "Start of Rain..."
         '
@@ -2807,7 +2807,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationEndOfRain.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationEndOfRain.Name = "mnuClimaticClimateMethodsDataManipulationEndOfRain"
-        Me.mnuClimaticClimateMethodsDataManipulationEndOfRain.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimaticClimateMethodsDataManipulationEndOfRain.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationEndOfRain.Tag = "End_of_Rain"
         Me.mnuClimaticClimateMethodsDataManipulationEndOfRain.Text = "End of Rain..."
         '
@@ -2815,7 +2815,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth.Name = "mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth"
-        Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth.Tag = "Change_Format_Month"
         Me.mnuClimaticClimateMethodsDataManipulationChangeFormatDayMonth.Text = "Change Format Day Month..."
         '
@@ -2823,7 +2823,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular.Name = "mnuClimaticClimateMethodsDataManipulationExportCPTToTabular"
-        Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular.Tag = "Expot_CPT_to_Tabular"
         Me.mnuClimaticClimateMethodsDataManipulationExportCPTToTabular.Text = "Export CPT to Tabular..."
         '
@@ -2831,7 +2831,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationDayMonth.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationDayMonth.Name = "mnuClimaticClimateMethodsDataManipulationDayMonth"
-        Me.mnuClimaticClimateMethodsDataManipulationDayMonth.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimaticClimateMethodsDataManipulationDayMonth.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationDayMonth.Tag = "Day_Month"
         Me.mnuClimaticClimateMethodsDataManipulationDayMonth.Text = "Day Month..."
         '
@@ -2839,7 +2839,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily.Name = "mnuClimaticClimateMethodsDataManipulationDisplayDaily"
-        Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily.Tag = "Display_Daily"
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDaily.Text = "Display Daily..."
         '
@@ -2847,7 +2847,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear.Name = "mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear"
-        Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear.Tag = "Display_DOY_of_Year"
         Me.mnuClimaticClimateMethodsDataManipulationDisplayDOYOfYear.Text = "Display DOY of Year..."
         '
@@ -2855,7 +2855,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal.Name = "mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal"
-        Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal.Tag = "Display_Rain_Running_Total"
         Me.mnuClimaticClimateMethodsDataManipulationDisplayRainRunningTotal.Text = "Display Rain Running Total..."
         '
@@ -2863,7 +2863,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength.Name = "mnuClimaticClimateMethodsDataManipulationDisplaySpellLength"
-        Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength.Tag = "Display_Spell_length"
         Me.mnuClimaticClimateMethodsDataManipulationDisplaySpellLength.Text = "Display Spell Length..."
         '
@@ -2871,7 +2871,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA.Name = "mnuClimaticClimateMethodsDataManipulationExportForPICSA"
-        Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA.Tag = "Export_for_PICSA"
         Me.mnuClimaticClimateMethodsDataManipulationExportForPICSA.Text = "Export for PICSA..."
         '
@@ -2879,7 +2879,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents.Name = "mnuClimaticClimateMethodsDataManipulationExtremeEvents"
-        Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents.Tag = "Extreme_Events"
         Me.mnuClimaticClimateMethodsDataManipulationExtremeEvents.Text = "Extreme Events..."
         '
@@ -2887,7 +2887,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationMissingData.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationMissingData.Name = "mnuClimaticClimateMethodsDataManipulationMissingData"
-        Me.mnuClimaticClimateMethodsDataManipulationMissingData.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimaticClimateMethodsDataManipulationMissingData.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationMissingData.Tag = "Missing_Data"
         Me.mnuClimaticClimateMethodsDataManipulationMissingData.Text = "Missing Data..."
         '
@@ -2895,7 +2895,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable.Enabled = False
         Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable.Name = "mnuClimaticClimateMethodsDataManipulationMissingDataTable"
-        Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable.Tag = "Missing_Data_Table"
         Me.mnuClimaticClimateMethodsDataManipulationMissingDataTable.Text = "Missing Data Table..."
         '
@@ -2903,7 +2903,7 @@ Partial Class frmMain
         '
         Me.mnuClimateMethodsDataManipulationMonthlySummaries.Enabled = False
         Me.mnuClimateMethodsDataManipulationMonthlySummaries.Name = "mnuClimateMethodsDataManipulationMonthlySummaries"
-        Me.mnuClimateMethodsDataManipulationMonthlySummaries.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimateMethodsDataManipulationMonthlySummaries.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimateMethodsDataManipulationMonthlySummaries.Tag = "Monthly_Summaries"
         Me.mnuClimateMethodsDataManipulationMonthlySummaries.Text = "Monthly Summaries..."
         '
@@ -2911,7 +2911,7 @@ Partial Class frmMain
         '
         Me.mnuClimateMethodsDataManipulationOutputForCD.Enabled = False
         Me.mnuClimateMethodsDataManipulationOutputForCD.Name = "mnuClimateMethodsDataManipulationOutputForCD"
-        Me.mnuClimateMethodsDataManipulationOutputForCD.Size = New System.Drawing.Size(279, 26)
+        Me.mnuClimateMethodsDataManipulationOutputForCD.Size = New System.Drawing.Size(227, 22)
         Me.mnuClimateMethodsDataManipulationOutputForCD.Tag = "Output_for_CDT"
         Me.mnuClimateMethodsDataManipulationOutputForCD.Text = "Output for CDT..."
         '
@@ -2919,7 +2919,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphics.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot, Me.mnuClimaticClimateMethodsGraphicsCliplot, Me.mnuClimaticClimateMethodsGraphicsMissingValues, Me.mnuClimaticClimateMethodsGraphicsHistogram, Me.mnuClimaticClimateMethodsGraphicsCumExceedance, Me.mnuClimaticClimateMethodsGraphicsBoxplot, Me.mnuClimaticClimateMethodsGraphicsInventory, Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall, Me.mnuClimaticClimateMethodsGraphicsRainCount, Me.mnuClimaticClimateMethodsGraphicsTimeseries, Me.mnuClimaticClimateMethodsGraphicsWindrose, Me.mnuClimateMethodsGraphicsMultipleLines, Me.mnuClmateMethodThreeSummaries})
         Me.mnuClimaticClimateMethodsGraphics.Name = "mnuClimaticClimateMethodsGraphics"
-        Me.mnuClimaticClimateMethodsGraphics.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticClimateMethodsGraphics.Size = New System.Drawing.Size(199, 22)
         Me.mnuClimaticClimateMethodsGraphics.Tag = "Graphics"
         Me.mnuClimaticClimateMethodsGraphics.Text = "Graphics"
         '
@@ -2927,7 +2927,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot.Name = "mnuClimaticClimateMethodsGraphicsClipBoxPlot"
-        Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot.Size = New System.Drawing.Size(270, 26)
+        Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot.Tag = "Cliboxplot"
         Me.mnuClimaticClimateMethodsGraphicsClipBoxPlot.Text = "Cliboxplot..."
         '
@@ -2935,7 +2935,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsCliplot.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsCliplot.Name = "mnuClimaticClimateMethodsGraphicsCliplot"
-        Me.mnuClimaticClimateMethodsGraphicsCliplot.Size = New System.Drawing.Size(270, 26)
+        Me.mnuClimaticClimateMethodsGraphicsCliplot.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsCliplot.Tag = "Cliplot"
         Me.mnuClimaticClimateMethodsGraphicsCliplot.Text = "Cliplot..."
         '
@@ -2943,7 +2943,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsMissingValues.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsMissingValues.Name = "mnuClimaticClimateMethodsGraphicsMissingValues"
-        Me.mnuClimaticClimateMethodsGraphicsMissingValues.Size = New System.Drawing.Size(270, 26)
+        Me.mnuClimaticClimateMethodsGraphicsMissingValues.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsMissingValues.Tag = "Missing_values"
         Me.mnuClimaticClimateMethodsGraphicsMissingValues.Text = "Missing Values..."
         '
@@ -2951,7 +2951,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsHistogram.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsHistogram.Name = "mnuClimaticClimateMethodsGraphicsHistogram"
-        Me.mnuClimaticClimateMethodsGraphicsHistogram.Size = New System.Drawing.Size(270, 26)
+        Me.mnuClimaticClimateMethodsGraphicsHistogram.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsHistogram.Tag = "Histogram"
         Me.mnuClimaticClimateMethodsGraphicsHistogram.Text = "Histogram..."
         '
@@ -2959,7 +2959,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsCumExceedance.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsCumExceedance.Name = "mnuClimaticClimateMethodsGraphicsCumExceedance"
-        Me.mnuClimaticClimateMethodsGraphicsCumExceedance.Size = New System.Drawing.Size(270, 26)
+        Me.mnuClimaticClimateMethodsGraphicsCumExceedance.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsCumExceedance.Tag = "Cumulative_Exceedence"
         Me.mnuClimaticClimateMethodsGraphicsCumExceedance.Text = "Cummulative Exceedance..."
         '
@@ -2967,7 +2967,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsBoxplot.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsBoxplot.Name = "mnuClimaticClimateMethodsGraphicsBoxplot"
-        Me.mnuClimaticClimateMethodsGraphicsBoxplot.Size = New System.Drawing.Size(270, 26)
+        Me.mnuClimaticClimateMethodsGraphicsBoxplot.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsBoxplot.Tag = "Boxplot"
         Me.mnuClimaticClimateMethodsGraphicsBoxplot.Text = "Boxplot..."
         '
@@ -2975,7 +2975,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsInventory.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsInventory.Name = "mnuClimaticClimateMethodsGraphicsInventory"
-        Me.mnuClimaticClimateMethodsGraphicsInventory.Size = New System.Drawing.Size(270, 26)
+        Me.mnuClimaticClimateMethodsGraphicsInventory.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsInventory.Tag = "Inventory"
         Me.mnuClimaticClimateMethodsGraphicsInventory.Text = "Inventory..."
         '
@@ -2983,7 +2983,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall.Name = "mnuClimaticClimateMethodsGraphicsAnnualRainfall"
-        Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall.Size = New System.Drawing.Size(270, 26)
+        Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall.Tag = "Annual_rainfall"
         Me.mnuClimaticClimateMethodsGraphicsAnnualRainfall.Text = "Annual Rainfall..."
         '
@@ -2991,7 +2991,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsRainCount.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsRainCount.Name = "mnuClimaticClimateMethodsGraphicsRainCount"
-        Me.mnuClimaticClimateMethodsGraphicsRainCount.Size = New System.Drawing.Size(270, 26)
+        Me.mnuClimaticClimateMethodsGraphicsRainCount.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsRainCount.Tag = "Rain_count"
         Me.mnuClimaticClimateMethodsGraphicsRainCount.Text = "Rain Count..."
         '
@@ -2999,7 +2999,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsTimeseries.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsTimeseries.Name = "mnuClimaticClimateMethodsGraphicsTimeseries"
-        Me.mnuClimaticClimateMethodsGraphicsTimeseries.Size = New System.Drawing.Size(270, 26)
+        Me.mnuClimaticClimateMethodsGraphicsTimeseries.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsTimeseries.Tag = "Timeseries"
         Me.mnuClimaticClimateMethodsGraphicsTimeseries.Text = "Timeseries..."
         '
@@ -3007,7 +3007,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsGraphicsWindrose.Enabled = False
         Me.mnuClimaticClimateMethodsGraphicsWindrose.Name = "mnuClimaticClimateMethodsGraphicsWindrose"
-        Me.mnuClimaticClimateMethodsGraphicsWindrose.Size = New System.Drawing.Size(270, 26)
+        Me.mnuClimaticClimateMethodsGraphicsWindrose.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimaticClimateMethodsGraphicsWindrose.Tag = "Windrose"
         Me.mnuClimaticClimateMethodsGraphicsWindrose.Text = "Windrose..."
         '
@@ -3015,7 +3015,7 @@ Partial Class frmMain
         '
         Me.mnuClimateMethodsGraphicsMultipleLines.Enabled = False
         Me.mnuClimateMethodsGraphicsMultipleLines.Name = "mnuClimateMethodsGraphicsMultipleLines"
-        Me.mnuClimateMethodsGraphicsMultipleLines.Size = New System.Drawing.Size(270, 26)
+        Me.mnuClimateMethodsGraphicsMultipleLines.Size = New System.Drawing.Size(219, 22)
         Me.mnuClimateMethodsGraphicsMultipleLines.Tag = "Multiple_lines"
         Me.mnuClimateMethodsGraphicsMultipleLines.Text = "Multple Lines..."
         '
@@ -3023,7 +3023,7 @@ Partial Class frmMain
         '
         Me.mnuClmateMethodThreeSummaries.Enabled = False
         Me.mnuClmateMethodThreeSummaries.Name = "mnuClmateMethodThreeSummaries"
-        Me.mnuClmateMethodThreeSummaries.Size = New System.Drawing.Size(270, 26)
+        Me.mnuClmateMethodThreeSummaries.Size = New System.Drawing.Size(219, 22)
         Me.mnuClmateMethodThreeSummaries.Tag = "Three_Summaries"
         Me.mnuClmateMethodThreeSummaries.Text = "Three Summaries..."
         '
@@ -3031,7 +3031,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsModel.Enabled = False
         Me.mnuClimaticClimateMethodsModel.Name = "mnuClimaticClimateMethodsModel"
-        Me.mnuClimaticClimateMethodsModel.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticClimateMethodsModel.Size = New System.Drawing.Size(199, 22)
         Me.mnuClimaticClimateMethodsModel.Tag = "Model"
         Me.mnuClimaticClimateMethodsModel.Text = "Model..."
         '
@@ -3039,7 +3039,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsAdditional.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuClimaticClimateMethodsAdditionalOutputForCPT, Me.mnuClimaticClimateMethodsAdditionalRainsStatistics, Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary, Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain, Me.mnuClimaticClimateMethodsAdditionalWaterBalance})
         Me.mnuClimaticClimateMethodsAdditional.Name = "mnuClimaticClimateMethodsAdditional"
-        Me.mnuClimaticClimateMethodsAdditional.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimaticClimateMethodsAdditional.Size = New System.Drawing.Size(199, 22)
         Me.mnuClimaticClimateMethodsAdditional.Tag = "Additional"
         Me.mnuClimaticClimateMethodsAdditional.Text = "Additional"
         '
@@ -3047,7 +3047,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsAdditionalOutputForCPT.Enabled = False
         Me.mnuClimaticClimateMethodsAdditionalOutputForCPT.Name = "mnuClimaticClimateMethodsAdditionalOutputForCPT"
-        Me.mnuClimaticClimateMethodsAdditionalOutputForCPT.Size = New System.Drawing.Size(259, 26)
+        Me.mnuClimaticClimateMethodsAdditionalOutputForCPT.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticClimateMethodsAdditionalOutputForCPT.Tag = "Output_for_CPT"
         Me.mnuClimaticClimateMethodsAdditionalOutputForCPT.Text = "Output for CPT..."
         '
@@ -3055,7 +3055,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsAdditionalRainsStatistics.Enabled = False
         Me.mnuClimaticClimateMethodsAdditionalRainsStatistics.Name = "mnuClimaticClimateMethodsAdditionalRainsStatistics"
-        Me.mnuClimaticClimateMethodsAdditionalRainsStatistics.Size = New System.Drawing.Size(259, 26)
+        Me.mnuClimaticClimateMethodsAdditionalRainsStatistics.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticClimateMethodsAdditionalRainsStatistics.Tag = "Rain_Statistics"
         Me.mnuClimaticClimateMethodsAdditionalRainsStatistics.Text = "Rains Statistics..."
         '
@@ -3063,7 +3063,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary.Enabled = False
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary.Name = "mnuClimaticClimateMethodsAdditionalSeasonalSummary"
-        Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary.Size = New System.Drawing.Size(259, 26)
+        Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary.Tag = "Seasonal_Summary"
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummary.Text = "Seasonal Summary..."
         '
@@ -3071,7 +3071,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain.Enabled = False
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain.Name = "mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain"
-        Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain.Size = New System.Drawing.Size(259, 26)
+        Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain.Tag = "Seasonal_Summary_Rain"
         Me.mnuClimaticClimateMethodsAdditionalSeasonalSummaryRain.Text = "Seasonal Summary Rain..."
         '
@@ -3079,7 +3079,7 @@ Partial Class frmMain
         '
         Me.mnuClimaticClimateMethodsAdditionalWaterBalance.Enabled = False
         Me.mnuClimaticClimateMethodsAdditionalWaterBalance.Name = "mnuClimaticClimateMethodsAdditionalWaterBalance"
-        Me.mnuClimaticClimateMethodsAdditionalWaterBalance.Size = New System.Drawing.Size(259, 26)
+        Me.mnuClimaticClimateMethodsAdditionalWaterBalance.Size = New System.Drawing.Size(209, 22)
         Me.mnuClimaticClimateMethodsAdditionalWaterBalance.Tag = "Water_Balance"
         Me.mnuClimaticClimateMethodsAdditionalWaterBalance.Text = "Water Balance..."
         '
@@ -3087,7 +3087,7 @@ Partial Class frmMain
         '
         Me.mnuClimateMethodsCreateClimateObject.Enabled = False
         Me.mnuClimateMethodsCreateClimateObject.Name = "mnuClimateMethodsCreateClimateObject"
-        Me.mnuClimateMethodsCreateClimateObject.Size = New System.Drawing.Size(247, 26)
+        Me.mnuClimateMethodsCreateClimateObject.Size = New System.Drawing.Size(199, 22)
         Me.mnuClimateMethodsCreateClimateObject.Tag = "Create_Climate_Object"
         Me.mnuClimateMethodsCreateClimateObject.Text = "Create Climate Object..."
         '
@@ -3095,7 +3095,7 @@ Partial Class frmMain
         '
         Me.mnuFileSave.Name = "mnuFileSave"
         Me.mnuFileSave.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.S), System.Windows.Forms.Keys)
-        Me.mnuFileSave.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileSave.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileSave.Tag = "Save"
         Me.mnuFileSave.Text = "Save..."
         '
@@ -3103,32 +3103,32 @@ Partial Class frmMain
         '
         Me.mnuFileSaveAs.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuFileSaveAsDataAs, Me.mnuFileSaveAsOutputAs, Me.mnuFileSaveAsLogAs, Me.mnuFileSaveAsScriptAs})
         Me.mnuFileSaveAs.Name = "mnuFileSaveAs"
-        Me.mnuFileSaveAs.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileSaveAs.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileSaveAs.Tag = "Save_As"
         Me.mnuFileSaveAs.Text = "Save As"
         '
         'mnuFileSaveAsDataAs
         '
         Me.mnuFileSaveAsDataAs.Name = "mnuFileSaveAsDataAs"
-        Me.mnuFileSaveAsDataAs.Size = New System.Drawing.Size(202, 26)
+        Me.mnuFileSaveAsDataAs.Size = New System.Drawing.Size(164, 22)
         Me.mnuFileSaveAsDataAs.Text = "Save Data As..."
         '
         'mnuFileSaveAsOutputAs
         '
         Me.mnuFileSaveAsOutputAs.Name = "mnuFileSaveAsOutputAs"
-        Me.mnuFileSaveAsOutputAs.Size = New System.Drawing.Size(202, 26)
+        Me.mnuFileSaveAsOutputAs.Size = New System.Drawing.Size(164, 22)
         Me.mnuFileSaveAsOutputAs.Text = "Save Output As..."
         '
         'mnuFileSaveAsLogAs
         '
         Me.mnuFileSaveAsLogAs.Name = "mnuFileSaveAsLogAs"
-        Me.mnuFileSaveAsLogAs.Size = New System.Drawing.Size(202, 26)
+        Me.mnuFileSaveAsLogAs.Size = New System.Drawing.Size(164, 22)
         Me.mnuFileSaveAsLogAs.Text = "Save Log As..."
         '
         'mnuFileSaveAsScriptAs
         '
         Me.mnuFileSaveAsScriptAs.Name = "mnuFileSaveAsScriptAs"
-        Me.mnuFileSaveAsScriptAs.Size = New System.Drawing.Size(202, 26)
+        Me.mnuFileSaveAsScriptAs.Size = New System.Drawing.Size(164, 22)
         Me.mnuFileSaveAsScriptAs.Text = "Save Script As..."
         '
         'mnuFilePrint
@@ -3136,7 +3136,7 @@ Partial Class frmMain
         Me.mnuFilePrint.Enabled = False
         Me.mnuFilePrint.Name = "mnuFilePrint"
         Me.mnuFilePrint.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.P), System.Windows.Forms.Keys)
-        Me.mnuFilePrint.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFilePrint.Size = New System.Drawing.Size(241, 22)
         Me.mnuFilePrint.Tag = "Print"
         Me.mnuFilePrint.Text = "Print..."
         Me.mnuFilePrint.Visible = False
@@ -3145,7 +3145,7 @@ Partial Class frmMain
         '
         Me.mnuFilePrintPreview.Enabled = False
         Me.mnuFilePrintPreview.Name = "mnuFilePrintPreview"
-        Me.mnuFilePrintPreview.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFilePrintPreview.Size = New System.Drawing.Size(241, 22)
         Me.mnuFilePrintPreview.Tag = "Print_Preview"
         Me.mnuFilePrintPreview.Text = "Print Preview..."
         Me.mnuFilePrintPreview.Visible = False
@@ -3153,12 +3153,12 @@ Partial Class frmMain
         'tlSeparatorFile3
         '
         Me.tlSeparatorFile3.Name = "tlSeparatorFile3"
-        Me.tlSeparatorFile3.Size = New System.Drawing.Size(296, 6)
+        Me.tlSeparatorFile3.Size = New System.Drawing.Size(238, 6)
         '
         'mnuFIleExit
         '
         Me.mnuFIleExit.Name = "mnuFIleExit"
-        Me.mnuFIleExit.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFIleExit.Size = New System.Drawing.Size(241, 22)
         Me.mnuFIleExit.Tag = "Exit"
         Me.mnuFIleExit.Text = "Exit"
         '
@@ -3166,7 +3166,7 @@ Partial Class frmMain
         '
         Me.mnuEdit.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuUndo, Me.mnuEditFind, Me.mnuEditCopy, Me.mnuEditPaste, Me.mnuEditPasteNew, Me.mnuEditWordwrap, Me.mnuEditSelectAll})
         Me.mnuEdit.Name = "mnuEdit"
-        Me.mnuEdit.Size = New System.Drawing.Size(49, 24)
+        Me.mnuEdit.Size = New System.Drawing.Size(39, 20)
         Me.mnuEdit.Tag = "Edit"
         Me.mnuEdit.Text = "Edit"
         '
@@ -3174,14 +3174,14 @@ Partial Class frmMain
         '
         Me.mnuUndo.Name = "mnuUndo"
         Me.mnuUndo.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.Z), System.Windows.Forms.Keys)
-        Me.mnuUndo.Size = New System.Drawing.Size(210, 26)
+        Me.mnuUndo.Size = New System.Drawing.Size(167, 22)
         Me.mnuUndo.Text = "Undo"
         '
         'mnuEditFind
         '
         Me.mnuEditFind.Name = "mnuEditFind"
         Me.mnuEditFind.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.F), System.Windows.Forms.Keys)
-        Me.mnuEditFind.Size = New System.Drawing.Size(210, 26)
+        Me.mnuEditFind.Size = New System.Drawing.Size(167, 22)
         Me.mnuEditFind.Tag = "Find"
         Me.mnuEditFind.Text = "Find"
         '
@@ -3189,7 +3189,7 @@ Partial Class frmMain
         '
         Me.mnuEditCopy.Name = "mnuEditCopy"
         Me.mnuEditCopy.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.C), System.Windows.Forms.Keys)
-        Me.mnuEditCopy.Size = New System.Drawing.Size(210, 26)
+        Me.mnuEditCopy.Size = New System.Drawing.Size(167, 22)
         Me.mnuEditCopy.Tag = "Copy"
         Me.mnuEditCopy.Text = "Copy"
         '
@@ -3197,27 +3197,27 @@ Partial Class frmMain
         '
         Me.mnuEditPaste.Name = "mnuEditPaste"
         Me.mnuEditPaste.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.V), System.Windows.Forms.Keys)
-        Me.mnuEditPaste.Size = New System.Drawing.Size(210, 26)
+        Me.mnuEditPaste.Size = New System.Drawing.Size(167, 22)
         Me.mnuEditPaste.Tag = "Paste"
         Me.mnuEditPaste.Text = "Paste"
         '
         'mnuEditPasteNew
         '
         Me.mnuEditPasteNew.Name = "mnuEditPasteNew"
-        Me.mnuEditPasteNew.Size = New System.Drawing.Size(210, 26)
+        Me.mnuEditPasteNew.Size = New System.Drawing.Size(167, 22)
         Me.mnuEditPasteNew.Text = "Paste New..."
         '
         'mnuEditWordwrap
         '
         Me.mnuEditWordwrap.Name = "mnuEditWordwrap"
-        Me.mnuEditWordwrap.Size = New System.Drawing.Size(210, 26)
+        Me.mnuEditWordwrap.Size = New System.Drawing.Size(167, 22)
         Me.mnuEditWordwrap.Text = "Wordwrap..."
         '
         'mnuEditSelectAll
         '
         Me.mnuEditSelectAll.Name = "mnuEditSelectAll"
         Me.mnuEditSelectAll.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.A), System.Windows.Forms.Keys)
-        Me.mnuEditSelectAll.Size = New System.Drawing.Size(210, 26)
+        Me.mnuEditSelectAll.Size = New System.Drawing.Size(167, 22)
         Me.mnuEditSelectAll.Tag = "Select_All"
         Me.mnuEditSelectAll.Text = "Select All "
         '
@@ -3225,18 +3225,18 @@ Partial Class frmMain
         '
         Me.stsStrip.ImageScalingSize = New System.Drawing.Size(24, 24)
         Me.stsStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.tstatus})
-        Me.stsStrip.Location = New System.Drawing.Point(0, 551)
+        Me.stsStrip.Location = New System.Drawing.Point(0, 440)
         Me.stsStrip.Name = "stsStrip"
-        Me.stsStrip.Padding = New System.Windows.Forms.Padding(2, 0, 22, 0)
+        Me.stsStrip.Padding = New System.Windows.Forms.Padding(2, 0, 18, 0)
         Me.stsStrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional
-        Me.stsStrip.Size = New System.Drawing.Size(1000, 26)
+        Me.stsStrip.Size = New System.Drawing.Size(800, 22)
         Me.stsStrip.TabIndex = 8
         Me.stsStrip.Text = "Status"
         '
         'tstatus
         '
         Me.tstatus.Name = "tstatus"
-        Me.tstatus.Size = New System.Drawing.Size(151, 20)
+        Me.tstatus.Size = New System.Drawing.Size(119, 17)
         Me.tstatus.Text = "No worksheet loaded"
         '
         'Tool_strip
@@ -3245,12 +3245,12 @@ Partial Class frmMain
         Me.Tool_strip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden
         Me.Tool_strip.ImageScalingSize = New System.Drawing.Size(30, 30)
         Me.Tool_strip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTbOpen, Me.mnuTbOpenFromLibrary, Me.mnuTbSave, Me.toolStripSeparator, Me.mnuTbLast10Dialogs, Me.separator2, Me.mnuTbDataView, Me.mnuTbOutput, Me.ToolStripSeparator74, Me.mnuLastGraph, Me.ToolStripSeparator75, Me.mnuTbLogScript, Me.mnuMetadata, Me.ToolStripSeparator76, Me.mnuTbResetLayout, Me.separator3, Me.mnuTbHelp, Me.ToolStripSeparator77, Me.mnuTbLan, Me.separator1})
-        Me.Tool_strip.Location = New System.Drawing.Point(0, 28)
+        Me.Tool_strip.Location = New System.Drawing.Point(0, 24)
         Me.Tool_strip.Name = "Tool_strip"
         Me.Tool_strip.Padding = New System.Windows.Forms.Padding(0, 0, 2, 0)
         Me.Tool_strip.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional
         Me.Tool_strip.RightToLeft = System.Windows.Forms.RightToLeft.No
-        Me.Tool_strip.Size = New System.Drawing.Size(1000, 37)
+        Me.Tool_strip.Size = New System.Drawing.Size(800, 37)
         Me.Tool_strip.TabIndex = 7
         Me.Tool_strip.Text = "Tool"
         '
@@ -3292,27 +3292,27 @@ Partial Class frmMain
         '
         Me.mnuSaveData.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuSaveData.Name = "mnuSaveData"
-        Me.mnuSaveData.Size = New System.Drawing.Size(173, 26)
+        Me.mnuSaveData.Size = New System.Drawing.Size(139, 22)
         Me.mnuSaveData.Text = "Save Data"
         '
         'mnuSaveOutput
         '
         Me.mnuSaveOutput.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuSaveOutput.Name = "mnuSaveOutput"
-        Me.mnuSaveOutput.Size = New System.Drawing.Size(173, 26)
+        Me.mnuSaveOutput.Size = New System.Drawing.Size(139, 22)
         Me.mnuSaveOutput.Text = "Save Output"
         '
         'mnuSaveScript
         '
         Me.mnuSaveScript.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuSaveScript.Name = "mnuSaveScript"
-        Me.mnuSaveScript.Size = New System.Drawing.Size(173, 26)
+        Me.mnuSaveScript.Size = New System.Drawing.Size(139, 22)
         Me.mnuSaveScript.Text = "Save Script"
         '
         'mnuSaveLog
         '
         Me.mnuSaveLog.Name = "mnuSaveLog"
-        Me.mnuSaveLog.Size = New System.Drawing.Size(173, 26)
+        Me.mnuSaveLog.Size = New System.Drawing.Size(139, 22)
         Me.mnuSaveLog.Text = "Save Log"
         '
         'toolStripSeparator
@@ -3352,28 +3352,28 @@ Partial Class frmMain
         '
         Me.mnuDataViewWindow.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuDataViewWindow.Name = "mnuDataViewWindow"
-        Me.mnuDataViewWindow.Size = New System.Drawing.Size(342, 26)
+        Me.mnuDataViewWindow.Size = New System.Drawing.Size(268, 22)
         Me.mnuDataViewWindow.Text = "Data View"
         '
         'mnuSwapDataMetadata
         '
         Me.mnuSwapDataMetadata.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuSwapDataMetadata.Name = "mnuSwapDataMetadata"
-        Me.mnuSwapDataMetadata.Size = New System.Drawing.Size(342, 26)
+        Me.mnuSwapDataMetadata.Size = New System.Drawing.Size(268, 22)
         Me.mnuSwapDataMetadata.Text = "Swap Data With Column Metadata"
         '
         'mnuSwapDataDataframeMetadata
         '
         Me.mnuSwapDataDataframeMetadata.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuSwapDataDataframeMetadata.Name = "mnuSwapDataDataframeMetadata"
-        Me.mnuSwapDataDataframeMetadata.Size = New System.Drawing.Size(342, 26)
+        Me.mnuSwapDataDataframeMetadata.Size = New System.Drawing.Size(268, 22)
         Me.mnuSwapDataDataframeMetadata.Text = "Swap Data With Dataframe Metadata"
         '
         'mnuRDataViewerWindow
         '
         Me.mnuRDataViewerWindow.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuRDataViewerWindow.Name = "mnuRDataViewerWindow"
-        Me.mnuRDataViewerWindow.Size = New System.Drawing.Size(342, 26)
+        Me.mnuRDataViewerWindow.Size = New System.Drawing.Size(268, 22)
         Me.mnuRDataViewerWindow.Text = "R-Data Viewer"
         '
         'mnuTbOutput
@@ -3392,21 +3392,21 @@ Partial Class frmMain
         '
         Me.mnuOutputWindow.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuOutputWindow.Name = "mnuOutputWindow"
-        Me.mnuOutputWindow.Size = New System.Drawing.Size(220, 26)
+        Me.mnuOutputWindow.Size = New System.Drawing.Size(178, 22)
         Me.mnuOutputWindow.Text = "Show Output"
         '
         'mnuShowRCommand
         '
         Me.mnuShowRCommand.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuShowRCommand.Name = "mnuShowRCommand"
-        Me.mnuShowRCommand.Size = New System.Drawing.Size(220, 26)
+        Me.mnuShowRCommand.Size = New System.Drawing.Size(178, 22)
         Me.mnuShowRCommand.Text = "Show R Commands"
         '
         'mnuIncludeComments
         '
         Me.mnuIncludeComments.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuIncludeComments.Name = "mnuIncludeComments"
-        Me.mnuIncludeComments.Size = New System.Drawing.Size(220, 26)
+        Me.mnuIncludeComments.Size = New System.Drawing.Size(178, 22)
         Me.mnuIncludeComments.Text = "Show Comments"
         '
         'ToolStripSeparator74
@@ -3429,19 +3429,19 @@ Partial Class frmMain
         'mnuNormalViewer
         '
         Me.mnuNormalViewer.Name = "mnuNormalViewer"
-        Me.mnuNormalViewer.Size = New System.Drawing.Size(159, 26)
+        Me.mnuNormalViewer.Size = New System.Drawing.Size(128, 22)
         Me.mnuNormalViewer.Text = "Viewer..."
         '
         'mnuploty
         '
         Me.mnuploty.Name = "mnuploty"
-        Me.mnuploty.Size = New System.Drawing.Size(159, 26)
+        Me.mnuploty.Size = New System.Drawing.Size(128, 22)
         Me.mnuploty.Text = "Plotly..."
         '
         'mnuRViewer
         '
         Me.mnuRViewer.Name = "mnuRViewer"
-        Me.mnuRViewer.Size = New System.Drawing.Size(159, 26)
+        Me.mnuRViewer.Size = New System.Drawing.Size(128, 22)
         Me.mnuRViewer.Text = "R Viewer..."
         '
         'ToolStripSeparator75
@@ -3465,14 +3465,14 @@ Partial Class frmMain
         '
         Me.mnuLogScript.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuLogScript.Name = "mnuLogScript"
-        Me.mnuLogScript.Size = New System.Drawing.Size(266, 26)
+        Me.mnuLogScript.Size = New System.Drawing.Size(210, 22)
         Me.mnuLogScript.Text = "Log/Script"
         '
         'mnuSwapDataLogScript
         '
         Me.mnuSwapDataLogScript.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuSwapDataLogScript.Name = "mnuSwapDataLogScript"
-        Me.mnuSwapDataLogScript.Size = New System.Drawing.Size(266, 26)
+        Me.mnuSwapDataLogScript.Size = New System.Drawing.Size(210, 22)
         Me.mnuSwapDataLogScript.Text = "Swap Data and Log/Script"
         '
         'mnuMetadata
@@ -3491,14 +3491,14 @@ Partial Class frmMain
         '
         Me.mnuColumnMetadat.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuColumnMetadat.Name = "mnuColumnMetadat"
-        Me.mnuColumnMetadat.Size = New System.Drawing.Size(254, 26)
+        Me.mnuColumnMetadat.Size = New System.Drawing.Size(202, 22)
         Me.mnuColumnMetadat.Text = "  Column Metadata..."
         '
         'mnuDataFrameMetadat
         '
         Me.mnuDataFrameMetadat.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuDataFrameMetadat.Name = "mnuDataFrameMetadat"
-        Me.mnuDataFrameMetadat.Size = New System.Drawing.Size(254, 26)
+        Me.mnuDataFrameMetadat.Size = New System.Drawing.Size(202, 22)
         Me.mnuDataFrameMetadat.Text = "  Data Frame Metadata..."
         '
         'ToolStripSeparator76
@@ -3537,26 +3537,26 @@ Partial Class frmMain
         '
         Me.mnuToolBarHelp.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuToolBarHelp.Name = "mnuToolBarHelp"
-        Me.mnuToolBarHelp.Size = New System.Drawing.Size(219, 26)
+        Me.mnuToolBarHelp.Size = New System.Drawing.Size(173, 22)
         Me.mnuToolBarHelp.Text = "Toolbar Help"
         '
         'mnuDataWindowHelp
         '
         Me.mnuDataWindowHelp.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.mnuDataWindowHelp.Name = "mnuDataWindowHelp"
-        Me.mnuDataWindowHelp.Size = New System.Drawing.Size(219, 26)
+        Me.mnuDataWindowHelp.Size = New System.Drawing.Size(173, 22)
         Me.mnuDataWindowHelp.Text = "Data Window Help"
         '
         'mnuOutputHelp
         '
         Me.mnuOutputHelp.Name = "mnuOutputHelp"
-        Me.mnuOutputHelp.Size = New System.Drawing.Size(219, 26)
+        Me.mnuOutputHelp.Size = New System.Drawing.Size(173, 22)
         Me.mnuOutputHelp.Text = "Output Help"
         '
         'mnuLogScriptHelp
         '
         Me.mnuLogScriptHelp.Name = "mnuLogScriptHelp"
-        Me.mnuLogScriptHelp.Size = New System.Drawing.Size(219, 26)
+        Me.mnuLogScriptHelp.Size = New System.Drawing.Size(173, 22)
         Me.mnuLogScriptHelp.Text = "Log Script Help"
         '
         'ToolStripSeparator77
@@ -3589,10 +3589,10 @@ Partial Class frmMain
         Me.mnuBar.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow
         Me.mnuBar.Location = New System.Drawing.Point(0, 0)
         Me.mnuBar.Name = "mnuBar"
-        Me.mnuBar.Padding = New System.Windows.Forms.Padding(5, 2, 0, 2)
+        Me.mnuBar.Padding = New System.Windows.Forms.Padding(4, 2, 0, 2)
         Me.mnuBar.RenderMode = System.Windows.Forms.ToolStripRenderMode.System
         Me.mnuBar.ShowItemToolTips = True
-        Me.mnuBar.Size = New System.Drawing.Size(1000, 28)
+        Me.mnuBar.Size = New System.Drawing.Size(800, 24)
         Me.mnuBar.TabIndex = 6
         Me.mnuBar.Text = "Menu_strip"
         '
@@ -3600,7 +3600,7 @@ Partial Class frmMain
         '
         Me.mnuFile.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuFileNewDataFrame, Me.mnuFileImportFromFile, Me.mnuFileImportFromLibrary, Me.ToolStripSeparator35, Me.mnuFileImportFromODK, Me.mnuFileImportFromCSPRO, Me.mnuFileImportFromDatabases, Me.mnuFileImportFromPostgres, Me.mnuFileImportFromRapidPro, Me.mnuFileImportandTidyNetCDFFile, Me.mnuImportFromOpenAppBuilder, Me.mnuFileConvert, Me.tlSeparatorFile, Me.mnuFileSave, Me.mnuFileSaveAs, Me.mnuFileExport, Me.mnuFilePrint, Me.mnuFilePrintPreview, Me.tlSeparatorFile3, Me.mnuFileCloseData, Me.ToolStripSeparator8, Me.mnuFIleExit})
         Me.mnuFile.Name = "mnuFile"
-        Me.mnuFile.Size = New System.Drawing.Size(46, 24)
+        Me.mnuFile.Size = New System.Drawing.Size(37, 20)
         Me.mnuFile.Tag = "File"
         Me.mnuFile.Text = "File"
         '
@@ -3608,7 +3608,7 @@ Partial Class frmMain
         '
         Me.mnuFileNewDataFrame.Name = "mnuFileNewDataFrame"
         Me.mnuFileNewDataFrame.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.N), System.Windows.Forms.Keys)
-        Me.mnuFileNewDataFrame.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileNewDataFrame.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileNewDataFrame.Tag = "New_Data_Frame"
         Me.mnuFileNewDataFrame.Text = "New Data Frame..."
         '
@@ -3616,33 +3616,33 @@ Partial Class frmMain
         '
         Me.mnuFileImportFromFile.Name = "mnuFileImportFromFile"
         Me.mnuFileImportFromFile.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.O), System.Windows.Forms.Keys)
-        Me.mnuFileImportFromFile.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileImportFromFile.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromFile.Tag = "Import_From_File"
         Me.mnuFileImportFromFile.Text = "Import From File..."
         '
         'mnuFileImportFromLibrary
         '
         Me.mnuFileImportFromLibrary.Name = "mnuFileImportFromLibrary"
-        Me.mnuFileImportFromLibrary.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileImportFromLibrary.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromLibrary.Tag = "Open_From_Library"
         Me.mnuFileImportFromLibrary.Text = "Import From Library..."
         '
         'ToolStripSeparator35
         '
         Me.ToolStripSeparator35.Name = "ToolStripSeparator35"
-        Me.ToolStripSeparator35.Size = New System.Drawing.Size(296, 6)
+        Me.ToolStripSeparator35.Size = New System.Drawing.Size(238, 6)
         '
         'mnuFileImportFromODK
         '
         Me.mnuFileImportFromODK.Name = "mnuFileImportFromODK"
-        Me.mnuFileImportFromODK.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileImportFromODK.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromODK.Text = "Import From ODK..."
         '
         'mnuFileImportFromCSPRO
         '
         Me.mnuFileImportFromCSPRO.Enabled = False
         Me.mnuFileImportFromCSPRO.Name = "mnuFileImportFromCSPRO"
-        Me.mnuFileImportFromCSPRO.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileImportFromCSPRO.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromCSPRO.Text = "Import From CSPRO..."
         Me.mnuFileImportFromCSPRO.Visible = False
         '
@@ -3650,7 +3650,7 @@ Partial Class frmMain
         '
         Me.mnuFileImportFromDatabases.Enabled = False
         Me.mnuFileImportFromDatabases.Name = "mnuFileImportFromDatabases"
-        Me.mnuFileImportFromDatabases.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileImportFromDatabases.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromDatabases.Text = "Import From Databases..."
         Me.mnuFileImportFromDatabases.Visible = False
         '
@@ -3658,88 +3658,88 @@ Partial Class frmMain
         '
         Me.mnuFileImportFromPostgres.Enabled = False
         Me.mnuFileImportFromPostgres.Name = "mnuFileImportFromPostgres"
-        Me.mnuFileImportFromPostgres.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileImportFromPostgres.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromPostgres.Text = "Import From Postgres..."
         Me.mnuFileImportFromPostgres.Visible = False
         '
         'mnuFileImportFromRapidPro
         '
         Me.mnuFileImportFromRapidPro.Name = "mnuFileImportFromRapidPro"
-        Me.mnuFileImportFromRapidPro.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileImportFromRapidPro.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportFromRapidPro.Text = "Import From RapidPro..."
         '
         'mnuFileImportandTidyNetCDFFile
         '
         Me.mnuFileImportandTidyNetCDFFile.Name = "mnuFileImportandTidyNetCDFFile"
-        Me.mnuFileImportandTidyNetCDFFile.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileImportandTidyNetCDFFile.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileImportandTidyNetCDFFile.Text = "Import and Tidy NetCDF File..."
         '
         'mnuImportFromOpenAppBuilder
         '
         Me.mnuImportFromOpenAppBuilder.Name = "mnuImportFromOpenAppBuilder"
-        Me.mnuImportFromOpenAppBuilder.Size = New System.Drawing.Size(299, 26)
+        Me.mnuImportFromOpenAppBuilder.Size = New System.Drawing.Size(241, 22)
         Me.mnuImportFromOpenAppBuilder.Text = "Import From OpenAppBuilder..."
         '
         'mnuFileConvert
         '
         Me.mnuFileConvert.Enabled = False
         Me.mnuFileConvert.Name = "mnuFileConvert"
-        Me.mnuFileConvert.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileConvert.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileConvert.Text = "Convert..."
         Me.mnuFileConvert.Visible = False
         '
         'tlSeparatorFile
         '
         Me.tlSeparatorFile.Name = "tlSeparatorFile"
-        Me.tlSeparatorFile.Size = New System.Drawing.Size(296, 6)
+        Me.tlSeparatorFile.Size = New System.Drawing.Size(238, 6)
         '
         'mnuFileExport
         '
         Me.mnuFileExport.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuFileExportExportDataSet, Me.mnuFileExportExportRObjectsToolStripMenuItem, Me.mnuFileExportExportRWorkspace, Me.mnuFileExportExportGraphAsImage})
         Me.mnuFileExport.Name = "mnuFileExport"
-        Me.mnuFileExport.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileExport.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileExport.Text = "Export"
         '
         'mnuFileExportExportDataSet
         '
         Me.mnuFileExportExportDataSet.Name = "mnuFileExportExportDataSet"
-        Me.mnuFileExportExportDataSet.Size = New System.Drawing.Size(254, 26)
+        Me.mnuFileExportExportDataSet.Size = New System.Drawing.Size(203, 22)
         Me.mnuFileExportExportDataSet.Text = "Export Dataset..."
         '
         'mnuFileExportExportRObjectsToolStripMenuItem
         '
         Me.mnuFileExportExportRObjectsToolStripMenuItem.Name = "mnuFileExportExportRObjectsToolStripMenuItem"
-        Me.mnuFileExportExportRObjectsToolStripMenuItem.Size = New System.Drawing.Size(254, 26)
+        Me.mnuFileExportExportRObjectsToolStripMenuItem.Size = New System.Drawing.Size(203, 22)
         Me.mnuFileExportExportRObjectsToolStripMenuItem.Text = "Export R Objects..."
         '
         'mnuFileExportExportRWorkspace
         '
         Me.mnuFileExportExportRWorkspace.Name = "mnuFileExportExportRWorkspace"
-        Me.mnuFileExportExportRWorkspace.Size = New System.Drawing.Size(254, 26)
+        Me.mnuFileExportExportRWorkspace.Size = New System.Drawing.Size(203, 22)
         Me.mnuFileExportExportRWorkspace.Text = "Export R Workspace..."
         '
         'mnuFileExportExportGraphAsImage
         '
         Me.mnuFileExportExportGraphAsImage.Name = "mnuFileExportExportGraphAsImage"
-        Me.mnuFileExportExportGraphAsImage.Size = New System.Drawing.Size(254, 26)
+        Me.mnuFileExportExportGraphAsImage.Size = New System.Drawing.Size(203, 22)
         Me.mnuFileExportExportGraphAsImage.Text = "Export Graph As Image..."
         '
         'mnuFileCloseData
         '
         Me.mnuFileCloseData.Name = "mnuFileCloseData"
-        Me.mnuFileCloseData.Size = New System.Drawing.Size(299, 26)
+        Me.mnuFileCloseData.Size = New System.Drawing.Size(241, 22)
         Me.mnuFileCloseData.Text = "Close Data Book"
         '
         'ToolStripSeparator8
         '
         Me.ToolStripSeparator8.Name = "ToolStripSeparator8"
-        Me.ToolStripSeparator8.Size = New System.Drawing.Size(296, 6)
+        Me.ToolStripSeparator8.Size = New System.Drawing.Size(238, 6)
         '
         'mnuPrepare
         '
         Me.mnuPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataFrame, Me.mnuPrepareCheckData, Me.ToolStripSeparator6, Me.mnuPrepareCalculator, Me.ToolStripSeparator79, Me.mnuPrepareColumnCalculate, Me.mnuPrepareColumnFactor, Me.mnuPrepareColumnText, Me.mnuPrepareColumnDate, Me.mnuPrepareColumnDefine, Me.ToolStripSeparator4, Me.mnuPrepareDataReshape, Me.ToolStripSeparator7, Me.mnuPrepareKeysAndLinks, Me.mnuPrepareDataBook, Me.mnuPrepareRObjects})
         Me.mnuPrepare.Name = "mnuPrepare"
-        Me.mnuPrepare.Size = New System.Drawing.Size(74, 24)
+        Me.mnuPrepare.Size = New System.Drawing.Size(59, 20)
         Me.mnuPrepare.Tag = "Prepare"
         Me.mnuPrepare.Text = "Prepare"
         '
@@ -3747,105 +3747,105 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataFrame.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataFrameViewData, Me.mnuPrepareDataFrameRenameColumn, Me.mnuPrepareDataFrameDuplicateColumn, Me.mnuPrepareDataFrameRowNumbersNames, Me.ToolStripSeparator1, Me.mnuPrepareDataFrameSort, Me.mnuPrepareDataFrameFilterRows, Me.mnuPrepareDataFrameSelectColumns, Me.mnuPrepareDataFrameReplaceValues, Me.mnuPrepareDataFrameConvertColumns, Me.ToolStripSeparator2, Me.mnuPrepareDataFrameReorderColumns, Me.mnuPrepareDataFrameAddMergeColumns, Me.mnuPrepareDataFrameInsertColumnsRows, Me.mnuPrepareDataFrameDeleteColumnsRows, Me.mnuPrepareDataFrameProtectColumn, Me.mnuPrepareDataFrameFreezeColumns, Me.mnuPrepareDataframeColourByProperty})
         Me.mnuPrepareDataFrame.Name = "mnuPrepareDataFrame"
-        Me.mnuPrepareDataFrame.Size = New System.Drawing.Size(224, 26)
+        Me.mnuPrepareDataFrame.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareDataFrame.Tag = "Data_Frame"
         Me.mnuPrepareDataFrame.Text = "Data Frame"
         '
         'mnuPrepareDataFrameViewData
         '
         Me.mnuPrepareDataFrameViewData.Name = "mnuPrepareDataFrameViewData"
-        Me.mnuPrepareDataFrameViewData.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameViewData.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameViewData.Tag = "View_Data..."
         Me.mnuPrepareDataFrameViewData.Text = "View Data..."
         '
         'mnuPrepareDataFrameRenameColumn
         '
         Me.mnuPrepareDataFrameRenameColumn.Name = "mnuPrepareDataFrameRenameColumn"
-        Me.mnuPrepareDataFrameRenameColumn.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameRenameColumn.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameRenameColumn.Tag = "Rename_Column..."
         Me.mnuPrepareDataFrameRenameColumn.Text = "Rename Columns..."
         '
         'mnuPrepareDataFrameDuplicateColumn
         '
         Me.mnuPrepareDataFrameDuplicateColumn.Name = "mnuPrepareDataFrameDuplicateColumn"
-        Me.mnuPrepareDataFrameDuplicateColumn.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameDuplicateColumn.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameDuplicateColumn.Text = "Duplicate Column..."
         '
         'mnuPrepareDataFrameRowNumbersNames
         '
         Me.mnuPrepareDataFrameRowNumbersNames.Name = "mnuPrepareDataFrameRowNumbersNames"
-        Me.mnuPrepareDataFrameRowNumbersNames.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameRowNumbersNames.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameRowNumbersNames.Tag = "Row_Numbers/Names..."
         Me.mnuPrepareDataFrameRowNumbersNames.Text = "Row Numbers/Names..."
         '
         'ToolStripSeparator1
         '
         Me.ToolStripSeparator1.Name = "ToolStripSeparator1"
-        Me.ToolStripSeparator1.Size = New System.Drawing.Size(244, 6)
+        Me.ToolStripSeparator1.Size = New System.Drawing.Size(198, 6)
         '
         'mnuPrepareDataFrameSort
         '
         Me.mnuPrepareDataFrameSort.Name = "mnuPrepareDataFrameSort"
-        Me.mnuPrepareDataFrameSort.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameSort.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameSort.Tag = "Sort..."
         Me.mnuPrepareDataFrameSort.Text = "Sort..."
         '
         'mnuPrepareDataFrameFilterRows
         '
         Me.mnuPrepareDataFrameFilterRows.Name = "mnuPrepareDataFrameFilterRows"
-        Me.mnuPrepareDataFrameFilterRows.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameFilterRows.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameFilterRows.Tag = "Filter..."
         Me.mnuPrepareDataFrameFilterRows.Text = "Filter Rows..."
         '
         'mnuPrepareDataFrameSelectColumns
         '
         Me.mnuPrepareDataFrameSelectColumns.Name = "mnuPrepareDataFrameSelectColumns"
-        Me.mnuPrepareDataFrameSelectColumns.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameSelectColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameSelectColumns.Text = "Select Columns..."
         '
         'mnuPrepareDataFrameReplaceValues
         '
         Me.mnuPrepareDataFrameReplaceValues.Name = "mnuPrepareDataFrameReplaceValues"
-        Me.mnuPrepareDataFrameReplaceValues.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameReplaceValues.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameReplaceValues.Tag = "Replace_Values..."
         Me.mnuPrepareDataFrameReplaceValues.Text = "Replace Values..."
         '
         'mnuPrepareDataFrameConvertColumns
         '
         Me.mnuPrepareDataFrameConvertColumns.Name = "mnuPrepareDataFrameConvertColumns"
-        Me.mnuPrepareDataFrameConvertColumns.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameConvertColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameConvertColumns.Tag = "Convert_Columns..."
         Me.mnuPrepareDataFrameConvertColumns.Text = "Convert Columns..."
         '
         'ToolStripSeparator2
         '
         Me.ToolStripSeparator2.Name = "ToolStripSeparator2"
-        Me.ToolStripSeparator2.Size = New System.Drawing.Size(244, 6)
+        Me.ToolStripSeparator2.Size = New System.Drawing.Size(198, 6)
         '
         'mnuPrepareDataFrameReorderColumns
         '
         Me.mnuPrepareDataFrameReorderColumns.Name = "mnuPrepareDataFrameReorderColumns"
-        Me.mnuPrepareDataFrameReorderColumns.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameReorderColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameReorderColumns.Tag = "Reorder_Columns..."
         Me.mnuPrepareDataFrameReorderColumns.Text = "Reorder Columns..."
         '
         'mnuPrepareDataFrameAddMergeColumns
         '
         Me.mnuPrepareDataFrameAddMergeColumns.Name = "mnuPrepareDataFrameAddMergeColumns"
-        Me.mnuPrepareDataFrameAddMergeColumns.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameAddMergeColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameAddMergeColumns.Text = "Add (Merge) Columns..."
         '
         'mnuPrepareDataFrameInsertColumnsRows
         '
         Me.mnuPrepareDataFrameInsertColumnsRows.Name = "mnuPrepareDataFrameInsertColumnsRows"
-        Me.mnuPrepareDataFrameInsertColumnsRows.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameInsertColumnsRows.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameInsertColumnsRows.Tag = "Insert_Columns/Rows..."
         Me.mnuPrepareDataFrameInsertColumnsRows.Text = "Insert Columns/Rows..."
         '
         'mnuPrepareDataFrameDeleteColumnsRows
         '
         Me.mnuPrepareDataFrameDeleteColumnsRows.Name = "mnuPrepareDataFrameDeleteColumnsRows"
-        Me.mnuPrepareDataFrameDeleteColumnsRows.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameDeleteColumnsRows.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameDeleteColumnsRows.Tag = "Delete_Columns/Rows..."
         Me.mnuPrepareDataFrameDeleteColumnsRows.Text = "Delete Columns/Rows..."
         '
@@ -3853,7 +3853,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataFrameProtectColumn.Enabled = False
         Me.mnuPrepareDataFrameProtectColumn.Name = "mnuPrepareDataFrameProtectColumn"
-        Me.mnuPrepareDataFrameProtectColumn.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameProtectColumn.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameProtectColumn.Tag = "..."
         Me.mnuPrepareDataFrameProtectColumn.Text = "Protect Column..."
         Me.mnuPrepareDataFrameProtectColumn.Visible = False
@@ -3862,7 +3862,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataFrameFreezeColumns.Enabled = False
         Me.mnuPrepareDataFrameFreezeColumns.Name = "mnuPrepareDataFrameFreezeColumns"
-        Me.mnuPrepareDataFrameFreezeColumns.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataFrameFreezeColumns.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataFrameFreezeColumns.Tag = "Freeze_Columns..."
         Me.mnuPrepareDataFrameFreezeColumns.Text = "Freeze Columns..."
         Me.mnuPrepareDataFrameFreezeColumns.Visible = False
@@ -3870,7 +3870,7 @@ Partial Class frmMain
         'mnuPrepareDataframeColourByProperty
         '
         Me.mnuPrepareDataframeColourByProperty.Name = "mnuPrepareDataframeColourByProperty"
-        Me.mnuPrepareDataframeColourByProperty.Size = New System.Drawing.Size(247, 26)
+        Me.mnuPrepareDataframeColourByProperty.Size = New System.Drawing.Size(201, 22)
         Me.mnuPrepareDataframeColourByProperty.Text = "Colour by Property..."
         '
         'mnuPrepareCheckData
@@ -3878,109 +3878,109 @@ Partial Class frmMain
         Me.mnuPrepareCheckData.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right
         Me.mnuPrepareCheckData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareCheckDataVisualiseData, Me.mnuPrepareCheckDataPivotTable, Me.ToolStripSeparator50, Me.mnuPrepareCheckDataDuplicates, Me.mnuPrepareCheckDataCompareColumns, Me.mnuPrepareCheckDataNonNumericCases, Me.ToolStripSeparator49, Me.mnuPrepareCheckDataBoxplot, Me.mnuPrepareCheckDataOneVariableSummarise, Me.mnuPrepareCheckDataOneVariableGraph, Me.mnuPrepareCheckDataOneWayFrequencies, Me.mnuPrepareCheckDataViewDeleteLabels, Me.ToolStripSeparator41, Me.mnuPrepareCheckDataExportOpenRefine, Me.mnuPrepareCheckDataImportOpenRefine, Me.ToolStripSeparator40, Me.mnuPreparePrepareToShareJitter, Me.mnuPrepareCheckDataPrePareToShareSdcPackage, Me.mnuPrepareCheckDataAnonymiseIDColumn})
         Me.mnuPrepareCheckData.Name = "mnuPrepareCheckData"
-        Me.mnuPrepareCheckData.Size = New System.Drawing.Size(224, 26)
+        Me.mnuPrepareCheckData.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareCheckData.Text = "Check Data"
         '
         'mnuPrepareCheckDataVisualiseData
         '
         Me.mnuPrepareCheckDataVisualiseData.Name = "mnuPrepareCheckDataVisualiseData"
-        Me.mnuPrepareCheckDataVisualiseData.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataVisualiseData.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataVisualiseData.Text = "Visualise Data..."
         '
         'mnuPrepareCheckDataPivotTable
         '
         Me.mnuPrepareCheckDataPivotTable.Name = "mnuPrepareCheckDataPivotTable"
-        Me.mnuPrepareCheckDataPivotTable.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataPivotTable.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataPivotTable.Text = "Pivot Table..."
         '
         'ToolStripSeparator50
         '
         Me.ToolStripSeparator50.Name = "ToolStripSeparator50"
-        Me.ToolStripSeparator50.Size = New System.Drawing.Size(304, 6)
+        Me.ToolStripSeparator50.Size = New System.Drawing.Size(242, 6)
         '
         'mnuPrepareCheckDataDuplicates
         '
         Me.mnuPrepareCheckDataDuplicates.Name = "mnuPrepareCheckDataDuplicates"
-        Me.mnuPrepareCheckDataDuplicates.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataDuplicates.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataDuplicates.Text = "Duplicate Rows..."
         '
         'mnuPrepareCheckDataCompareColumns
         '
         Me.mnuPrepareCheckDataCompareColumns.Name = "mnuPrepareCheckDataCompareColumns"
-        Me.mnuPrepareCheckDataCompareColumns.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataCompareColumns.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataCompareColumns.Text = "Compare Columns..."
         '
         'mnuPrepareCheckDataNonNumericCases
         '
         Me.mnuPrepareCheckDataNonNumericCases.Name = "mnuPrepareCheckDataNonNumericCases"
-        Me.mnuPrepareCheckDataNonNumericCases.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataNonNumericCases.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataNonNumericCases.Text = "Non-Numeric Values..."
         '
         'ToolStripSeparator49
         '
         Me.ToolStripSeparator49.Name = "ToolStripSeparator49"
-        Me.ToolStripSeparator49.Size = New System.Drawing.Size(304, 6)
+        Me.ToolStripSeparator49.Size = New System.Drawing.Size(242, 6)
         '
         'mnuPrepareCheckDataBoxplot
         '
         Me.mnuPrepareCheckDataBoxplot.Name = "mnuPrepareCheckDataBoxplot"
-        Me.mnuPrepareCheckDataBoxplot.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataBoxplot.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataBoxplot.Text = "Boxplot..."
         '
         'mnuPrepareCheckDataOneVariableSummarise
         '
         Me.mnuPrepareCheckDataOneVariableSummarise.Name = "mnuPrepareCheckDataOneVariableSummarise"
-        Me.mnuPrepareCheckDataOneVariableSummarise.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataOneVariableSummarise.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataOneVariableSummarise.Text = "One Variable Summarise..."
         '
         'mnuPrepareCheckDataOneVariableGraph
         '
         Me.mnuPrepareCheckDataOneVariableGraph.Name = "mnuPrepareCheckDataOneVariableGraph"
-        Me.mnuPrepareCheckDataOneVariableGraph.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataOneVariableGraph.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataOneVariableGraph.Text = "One Variable Graph..."
         '
         'mnuPrepareCheckDataOneWayFrequencies
         '
         Me.mnuPrepareCheckDataOneWayFrequencies.Name = "mnuPrepareCheckDataOneWayFrequencies"
-        Me.mnuPrepareCheckDataOneWayFrequencies.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataOneWayFrequencies.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataOneWayFrequencies.Text = "One Variable Frequencies..."
         '
         'mnuPrepareCheckDataViewDeleteLabels
         '
         Me.mnuPrepareCheckDataViewDeleteLabels.Name = "mnuPrepareCheckDataViewDeleteLabels"
-        Me.mnuPrepareCheckDataViewDeleteLabels.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataViewDeleteLabels.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataViewDeleteLabels.Text = "View/Delete Labels..."
         '
         'ToolStripSeparator41
         '
         Me.ToolStripSeparator41.Name = "ToolStripSeparator41"
-        Me.ToolStripSeparator41.Size = New System.Drawing.Size(304, 6)
+        Me.ToolStripSeparator41.Size = New System.Drawing.Size(242, 6)
         Me.ToolStripSeparator41.Visible = False
         '
         'mnuPrepareCheckDataExportOpenRefine
         '
         Me.mnuPrepareCheckDataExportOpenRefine.Name = "mnuPrepareCheckDataExportOpenRefine"
-        Me.mnuPrepareCheckDataExportOpenRefine.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataExportOpenRefine.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataExportOpenRefine.Text = "Export To OpenRefine..."
         Me.mnuPrepareCheckDataExportOpenRefine.Visible = False
         '
         'mnuPrepareCheckDataImportOpenRefine
         '
         Me.mnuPrepareCheckDataImportOpenRefine.Name = "mnuPrepareCheckDataImportOpenRefine"
-        Me.mnuPrepareCheckDataImportOpenRefine.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataImportOpenRefine.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataImportOpenRefine.Text = "Import From OpenRefine..."
         Me.mnuPrepareCheckDataImportOpenRefine.Visible = False
         '
         'ToolStripSeparator40
         '
         Me.ToolStripSeparator40.Name = "ToolStripSeparator40"
-        Me.ToolStripSeparator40.Size = New System.Drawing.Size(304, 6)
+        Me.ToolStripSeparator40.Size = New System.Drawing.Size(242, 6)
         '
         'mnuPreparePrepareToShareJitter
         '
         Me.mnuPreparePrepareToShareJitter.Enabled = False
         Me.mnuPreparePrepareToShareJitter.Name = "mnuPreparePrepareToShareJitter"
-        Me.mnuPreparePrepareToShareJitter.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPreparePrepareToShareJitter.Size = New System.Drawing.Size(245, 22)
         Me.mnuPreparePrepareToShareJitter.Text = "Jitter..."
         Me.mnuPreparePrepareToShareJitter.Visible = False
         '
@@ -3988,95 +3988,95 @@ Partial Class frmMain
         '
         Me.mnuPrepareCheckDataPrePareToShareSdcPackage.Enabled = False
         Me.mnuPrepareCheckDataPrePareToShareSdcPackage.Name = "mnuPrepareCheckDataPrePareToShareSdcPackage"
-        Me.mnuPrepareCheckDataPrePareToShareSdcPackage.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataPrePareToShareSdcPackage.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataPrePareToShareSdcPackage.Text = "Prepare to Share (sdc package)..."
         Me.mnuPrepareCheckDataPrePareToShareSdcPackage.Visible = False
         '
         'mnuPrepareCheckDataAnonymiseIDColumn
         '
         Me.mnuPrepareCheckDataAnonymiseIDColumn.Name = "mnuPrepareCheckDataAnonymiseIDColumn"
-        Me.mnuPrepareCheckDataAnonymiseIDColumn.Size = New System.Drawing.Size(307, 26)
+        Me.mnuPrepareCheckDataAnonymiseIDColumn.Size = New System.Drawing.Size(245, 22)
         Me.mnuPrepareCheckDataAnonymiseIDColumn.Text = "Anonymise ID Column..."
         '
         'ToolStripSeparator6
         '
         Me.ToolStripSeparator6.Name = "ToolStripSeparator6"
-        Me.ToolStripSeparator6.Size = New System.Drawing.Size(221, 6)
+        Me.ToolStripSeparator6.Size = New System.Drawing.Size(166, 6)
         '
         'mnuPrepareCalculator
         '
         Me.mnuPrepareCalculator.Name = "mnuPrepareCalculator"
-        Me.mnuPrepareCalculator.Size = New System.Drawing.Size(224, 26)
+        Me.mnuPrepareCalculator.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareCalculator.Tag = "Calculator..."
         Me.mnuPrepareCalculator.Text = "Calculator..."
         '
         'ToolStripSeparator79
         '
         Me.ToolStripSeparator79.Name = "ToolStripSeparator79"
-        Me.ToolStripSeparator79.Size = New System.Drawing.Size(221, 6)
+        Me.ToolStripSeparator79.Size = New System.Drawing.Size(166, 6)
         '
         'mnuPrepareColumnCalculate
         '
         Me.mnuPrepareColumnCalculate.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnNumericRegularSequence, Me.mnuPrepareColumnNumericEnter, Me.ToolStripSeparator25, Me.mnuPrepareColumnNumericRowSummaries, Me.mnuPrepareColumnNumericTransform, Me.mnuPrepareColumnNumericPolynomials, Me.ToolStripSeparator56, Me.mnuPrepareColumnNumericRandomSamples, Me.mnuPrepareColumnNumericPermuteRows})
         Me.mnuPrepareColumnCalculate.Name = "mnuPrepareColumnCalculate"
-        Me.mnuPrepareColumnCalculate.Size = New System.Drawing.Size(224, 26)
+        Me.mnuPrepareColumnCalculate.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareColumnCalculate.Tag = "Column:_Calculate"
         Me.mnuPrepareColumnCalculate.Text = "Column: Numeric"
         '
         'mnuPrepareColumnNumericRegularSequence
         '
         Me.mnuPrepareColumnNumericRegularSequence.Name = "mnuPrepareColumnNumericRegularSequence"
-        Me.mnuPrepareColumnNumericRegularSequence.Size = New System.Drawing.Size(250, 26)
+        Me.mnuPrepareColumnNumericRegularSequence.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericRegularSequence.Tag = "Regular_Sequence..."
         Me.mnuPrepareColumnNumericRegularSequence.Text = "Regular Sequence..."
         '
         'mnuPrepareColumnNumericEnter
         '
         Me.mnuPrepareColumnNumericEnter.Name = "mnuPrepareColumnNumericEnter"
-        Me.mnuPrepareColumnNumericEnter.Size = New System.Drawing.Size(250, 26)
+        Me.mnuPrepareColumnNumericEnter.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericEnter.Text = "Enter..."
         '
         'ToolStripSeparator25
         '
         Me.ToolStripSeparator25.Name = "ToolStripSeparator25"
-        Me.ToolStripSeparator25.Size = New System.Drawing.Size(247, 6)
+        Me.ToolStripSeparator25.Size = New System.Drawing.Size(200, 6)
         '
         'mnuPrepareColumnNumericRowSummaries
         '
         Me.mnuPrepareColumnNumericRowSummaries.Name = "mnuPrepareColumnNumericRowSummaries"
-        Me.mnuPrepareColumnNumericRowSummaries.Size = New System.Drawing.Size(250, 26)
+        Me.mnuPrepareColumnNumericRowSummaries.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericRowSummaries.Text = "Row Summaries..."
         '
         'mnuPrepareColumnNumericTransform
         '
         Me.mnuPrepareColumnNumericTransform.Name = "mnuPrepareColumnNumericTransform"
-        Me.mnuPrepareColumnNumericTransform.Size = New System.Drawing.Size(250, 26)
+        Me.mnuPrepareColumnNumericTransform.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericTransform.Tag = "Rank..."
         Me.mnuPrepareColumnNumericTransform.Text = "Transform..."
         '
         'mnuPrepareColumnNumericPolynomials
         '
         Me.mnuPrepareColumnNumericPolynomials.Name = "mnuPrepareColumnNumericPolynomials"
-        Me.mnuPrepareColumnNumericPolynomials.Size = New System.Drawing.Size(250, 26)
+        Me.mnuPrepareColumnNumericPolynomials.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericPolynomials.Tag = "Polynomials..."
         Me.mnuPrepareColumnNumericPolynomials.Text = "Polynomials..."
         '
         'ToolStripSeparator56
         '
         Me.ToolStripSeparator56.Name = "ToolStripSeparator56"
-        Me.ToolStripSeparator56.Size = New System.Drawing.Size(247, 6)
+        Me.ToolStripSeparator56.Size = New System.Drawing.Size(200, 6)
         '
         'mnuPrepareColumnNumericRandomSamples
         '
         Me.mnuPrepareColumnNumericRandomSamples.Name = "mnuPrepareColumnNumericRandomSamples"
-        Me.mnuPrepareColumnNumericRandomSamples.Size = New System.Drawing.Size(250, 26)
+        Me.mnuPrepareColumnNumericRandomSamples.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericRandomSamples.Tag = "Random_Samples..."
         Me.mnuPrepareColumnNumericRandomSamples.Text = "Random Samples..."
         '
         'mnuPrepareColumnNumericPermuteRows
         '
         Me.mnuPrepareColumnNumericPermuteRows.Name = "mnuPrepareColumnNumericPermuteRows"
-        Me.mnuPrepareColumnNumericPermuteRows.Size = New System.Drawing.Size(250, 26)
+        Me.mnuPrepareColumnNumericPermuteRows.Size = New System.Drawing.Size(203, 22)
         Me.mnuPrepareColumnNumericPermuteRows.Tag = "Permute_Rows..."
         Me.mnuPrepareColumnNumericPermuteRows.Text = "Permute/Sample Rows..."
         '
@@ -4084,105 +4084,105 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnFactor.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnFactorConvertToFactor, Me.mnuPrepareColumnFactorRecodeNumeric, Me.mnuPrepareColumnFactorCountInFactor, Me.ToolStripSeparator12, Me.mnuPrepareColumnFactorRecodeFactor, Me.mnuPrepareColumnFactorCombineFactors, Me.mnuPrepareColumnFactorDummyVariables, Me.ToolStripSeparator14, Me.mnuPrepareColumnFactorLevelsLabels, Me.mnuPrepareColumnFactorReorderLevels, Me.mnuPrepareColumnFactorReferenceLevel, Me.mnuPrepareColumnFactorUnusedLevels, Me.mnuPrepareColumnFactorContrasts, Me.ToolStripSeparator19, Me.mnuPrepareColumnFactorFactorDataFrame})
         Me.mnuPrepareColumnFactor.Name = "mnuPrepareColumnFactor"
-        Me.mnuPrepareColumnFactor.Size = New System.Drawing.Size(224, 26)
+        Me.mnuPrepareColumnFactor.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareColumnFactor.Tag = "Column:_Factor"
         Me.mnuPrepareColumnFactor.Text = "Column: Factor"
         '
         'mnuPrepareColumnFactorConvertToFactor
         '
         Me.mnuPrepareColumnFactorConvertToFactor.Name = "mnuPrepareColumnFactorConvertToFactor"
-        Me.mnuPrepareColumnFactorConvertToFactor.Size = New System.Drawing.Size(222, 26)
+        Me.mnuPrepareColumnFactorConvertToFactor.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorConvertToFactor.Tag = "Convert_To_Factor"
         Me.mnuPrepareColumnFactorConvertToFactor.Text = "Convert To Factor..."
         '
         'mnuPrepareColumnFactorRecodeNumeric
         '
         Me.mnuPrepareColumnFactorRecodeNumeric.Name = "mnuPrepareColumnFactorRecodeNumeric"
-        Me.mnuPrepareColumnFactorRecodeNumeric.Size = New System.Drawing.Size(222, 26)
+        Me.mnuPrepareColumnFactorRecodeNumeric.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorRecodeNumeric.Tag = "Recode_Numeric..."
         Me.mnuPrepareColumnFactorRecodeNumeric.Text = "Recode Numeric..."
         '
         'mnuPrepareColumnFactorCountInFactor
         '
         Me.mnuPrepareColumnFactorCountInFactor.Name = "mnuPrepareColumnFactorCountInFactor"
-        Me.mnuPrepareColumnFactorCountInFactor.Size = New System.Drawing.Size(222, 26)
+        Me.mnuPrepareColumnFactorCountInFactor.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorCountInFactor.Text = "Count in Factor..."
         '
         'ToolStripSeparator12
         '
         Me.ToolStripSeparator12.Name = "ToolStripSeparator12"
-        Me.ToolStripSeparator12.Size = New System.Drawing.Size(219, 6)
+        Me.ToolStripSeparator12.Size = New System.Drawing.Size(176, 6)
         '
         'mnuPrepareColumnFactorRecodeFactor
         '
         Me.mnuPrepareColumnFactorRecodeFactor.Name = "mnuPrepareColumnFactorRecodeFactor"
-        Me.mnuPrepareColumnFactorRecodeFactor.Size = New System.Drawing.Size(222, 26)
+        Me.mnuPrepareColumnFactorRecodeFactor.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorRecodeFactor.Tag = "Recode_Factor..."
         Me.mnuPrepareColumnFactorRecodeFactor.Text = "Recode Factor..."
         '
         'mnuPrepareColumnFactorCombineFactors
         '
         Me.mnuPrepareColumnFactorCombineFactors.Name = "mnuPrepareColumnFactorCombineFactors"
-        Me.mnuPrepareColumnFactorCombineFactors.Size = New System.Drawing.Size(222, 26)
+        Me.mnuPrepareColumnFactorCombineFactors.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorCombineFactors.Tag = "Combine_Factors..."
         Me.mnuPrepareColumnFactorCombineFactors.Text = "Combine Factors..."
         '
         'mnuPrepareColumnFactorDummyVariables
         '
         Me.mnuPrepareColumnFactorDummyVariables.Name = "mnuPrepareColumnFactorDummyVariables"
-        Me.mnuPrepareColumnFactorDummyVariables.Size = New System.Drawing.Size(222, 26)
+        Me.mnuPrepareColumnFactorDummyVariables.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorDummyVariables.Tag = "Dummy_Variables..."
         Me.mnuPrepareColumnFactorDummyVariables.Text = "Dummy Variables..."
         '
         'ToolStripSeparator14
         '
         Me.ToolStripSeparator14.Name = "ToolStripSeparator14"
-        Me.ToolStripSeparator14.Size = New System.Drawing.Size(219, 6)
+        Me.ToolStripSeparator14.Size = New System.Drawing.Size(176, 6)
         '
         'mnuPrepareColumnFactorLevelsLabels
         '
         Me.mnuPrepareColumnFactorLevelsLabels.Name = "mnuPrepareColumnFactorLevelsLabels"
-        Me.mnuPrepareColumnFactorLevelsLabels.Size = New System.Drawing.Size(222, 26)
+        Me.mnuPrepareColumnFactorLevelsLabels.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorLevelsLabels.Tag = "Levels/Labels..."
         Me.mnuPrepareColumnFactorLevelsLabels.Text = "Levels/Labels..."
         '
         'mnuPrepareColumnFactorReorderLevels
         '
         Me.mnuPrepareColumnFactorReorderLevels.Name = "mnuPrepareColumnFactorReorderLevels"
-        Me.mnuPrepareColumnFactorReorderLevels.Size = New System.Drawing.Size(222, 26)
+        Me.mnuPrepareColumnFactorReorderLevels.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorReorderLevels.Tag = "Reorder_Levels..."
         Me.mnuPrepareColumnFactorReorderLevels.Text = "Reorder Levels..."
         '
         'mnuPrepareColumnFactorReferenceLevel
         '
         Me.mnuPrepareColumnFactorReferenceLevel.Name = "mnuPrepareColumnFactorReferenceLevel"
-        Me.mnuPrepareColumnFactorReferenceLevel.Size = New System.Drawing.Size(222, 26)
+        Me.mnuPrepareColumnFactorReferenceLevel.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorReferenceLevel.Tag = "Reference_Level..."
         Me.mnuPrepareColumnFactorReferenceLevel.Text = "Reference Level..."
         '
         'mnuPrepareColumnFactorUnusedLevels
         '
         Me.mnuPrepareColumnFactorUnusedLevels.Name = "mnuPrepareColumnFactorUnusedLevels"
-        Me.mnuPrepareColumnFactorUnusedLevels.Size = New System.Drawing.Size(222, 26)
+        Me.mnuPrepareColumnFactorUnusedLevels.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorUnusedLevels.Tag = "Unused_Levels..."
         Me.mnuPrepareColumnFactorUnusedLevels.Text = "Unused Levels..."
         '
         'mnuPrepareColumnFactorContrasts
         '
         Me.mnuPrepareColumnFactorContrasts.Name = "mnuPrepareColumnFactorContrasts"
-        Me.mnuPrepareColumnFactorContrasts.Size = New System.Drawing.Size(222, 26)
+        Me.mnuPrepareColumnFactorContrasts.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorContrasts.Tag = "Contrasts..."
         Me.mnuPrepareColumnFactorContrasts.Text = "Contrasts..."
         '
         'ToolStripSeparator19
         '
         Me.ToolStripSeparator19.Name = "ToolStripSeparator19"
-        Me.ToolStripSeparator19.Size = New System.Drawing.Size(219, 6)
+        Me.ToolStripSeparator19.Size = New System.Drawing.Size(176, 6)
         '
         'mnuPrepareColumnFactorFactorDataFrame
         '
         Me.mnuPrepareColumnFactorFactorDataFrame.Name = "mnuPrepareColumnFactorFactorDataFrame"
-        Me.mnuPrepareColumnFactorFactorDataFrame.Size = New System.Drawing.Size(222, 26)
+        Me.mnuPrepareColumnFactorFactorDataFrame.Size = New System.Drawing.Size(179, 22)
         Me.mnuPrepareColumnFactorFactorDataFrame.Tag = "Factor_Data_Frame"
         Me.mnuPrepareColumnFactorFactorDataFrame.Text = "Factor Data Frame..."
         '
@@ -4190,42 +4190,42 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnText.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnTextFindReplace, Me.mnuPrepareColumnTextSearch, Me.mnuPrepareColumnTextTransform, Me.mnuPrepareColumnTextSplit, Me.mnuPrepareColumnTextCombine, Me.mnuPrepareColumnTextMatch, Me.mnuPrepareColumnTextDistance})
         Me.mnuPrepareColumnText.Name = "mnuPrepareColumnText"
-        Me.mnuPrepareColumnText.Size = New System.Drawing.Size(224, 26)
+        Me.mnuPrepareColumnText.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareColumnText.Tag = "Column:_Text"
         Me.mnuPrepareColumnText.Text = "Column: Text"
         '
         'mnuPrepareColumnTextFindReplace
         '
         Me.mnuPrepareColumnTextFindReplace.Name = "mnuPrepareColumnTextFindReplace"
-        Me.mnuPrepareColumnTextFindReplace.Size = New System.Drawing.Size(188, 26)
+        Me.mnuPrepareColumnTextFindReplace.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextFindReplace.Tag = "Find/Replace..."
         Me.mnuPrepareColumnTextFindReplace.Text = "Find/Replace..."
         '
         'mnuPrepareColumnTextSearch
         '
         Me.mnuPrepareColumnTextSearch.Name = "mnuPrepareColumnTextSearch"
-        Me.mnuPrepareColumnTextSearch.Size = New System.Drawing.Size(188, 26)
+        Me.mnuPrepareColumnTextSearch.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextSearch.Text = "Search..."
         Me.mnuPrepareColumnTextSearch.Visible = False
         '
         'mnuPrepareColumnTextTransform
         '
         Me.mnuPrepareColumnTextTransform.Name = "mnuPrepareColumnTextTransform"
-        Me.mnuPrepareColumnTextTransform.Size = New System.Drawing.Size(188, 26)
+        Me.mnuPrepareColumnTextTransform.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextTransform.Tag = "Transform..."
         Me.mnuPrepareColumnTextTransform.Text = "Transform..."
         '
         'mnuPrepareColumnTextSplit
         '
         Me.mnuPrepareColumnTextSplit.Name = "mnuPrepareColumnTextSplit"
-        Me.mnuPrepareColumnTextSplit.Size = New System.Drawing.Size(188, 26)
+        Me.mnuPrepareColumnTextSplit.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextSplit.Tag = "Split..."
         Me.mnuPrepareColumnTextSplit.Text = "Split..."
         '
         'mnuPrepareColumnTextCombine
         '
         Me.mnuPrepareColumnTextCombine.Name = "mnuPrepareColumnTextCombine"
-        Me.mnuPrepareColumnTextCombine.Size = New System.Drawing.Size(188, 26)
+        Me.mnuPrepareColumnTextCombine.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextCombine.Tag = "Combine..."
         Me.mnuPrepareColumnTextCombine.Text = "Combine..."
         '
@@ -4233,7 +4233,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnTextMatch.Enabled = False
         Me.mnuPrepareColumnTextMatch.Name = "mnuPrepareColumnTextMatch"
-        Me.mnuPrepareColumnTextMatch.Size = New System.Drawing.Size(188, 26)
+        Me.mnuPrepareColumnTextMatch.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextMatch.Tag = "Match..."
         Me.mnuPrepareColumnTextMatch.Text = "Match..."
         Me.mnuPrepareColumnTextMatch.Visible = False
@@ -4241,7 +4241,7 @@ Partial Class frmMain
         'mnuPrepareColumnTextDistance
         '
         Me.mnuPrepareColumnTextDistance.Name = "mnuPrepareColumnTextDistance"
-        Me.mnuPrepareColumnTextDistance.Size = New System.Drawing.Size(188, 26)
+        Me.mnuPrepareColumnTextDistance.Size = New System.Drawing.Size(152, 22)
         Me.mnuPrepareColumnTextDistance.Tag = "Distance..."
         Me.mnuPrepareColumnTextDistance.Text = "Distance..."
         '
@@ -4249,38 +4249,38 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnDate.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnDateGenerateDate, Me.mnuPrepareColumnDateMakeDate, Me.mnuPrepareColumnDateInfillMissingDates, Me.mnuPrepareColumnDateUseDate, Me.mnuPrepareColumnDateMakeTime, Me.mnuPrepareColumnDateUseTime})
         Me.mnuPrepareColumnDate.Name = "mnuPrepareColumnDate"
-        Me.mnuPrepareColumnDate.Size = New System.Drawing.Size(224, 26)
+        Me.mnuPrepareColumnDate.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareColumnDate.Text = "Column: Date"
         '
         'mnuPrepareColumnDateGenerateDate
         '
         Me.mnuPrepareColumnDateGenerateDate.Name = "mnuPrepareColumnDateGenerateDate"
-        Me.mnuPrepareColumnDateGenerateDate.Size = New System.Drawing.Size(203, 26)
+        Me.mnuPrepareColumnDateGenerateDate.Size = New System.Drawing.Size(162, 22)
         Me.mnuPrepareColumnDateGenerateDate.Text = "Generate Dates..."
         '
         'mnuPrepareColumnDateMakeDate
         '
         Me.mnuPrepareColumnDateMakeDate.Name = "mnuPrepareColumnDateMakeDate"
-        Me.mnuPrepareColumnDateMakeDate.Size = New System.Drawing.Size(203, 26)
+        Me.mnuPrepareColumnDateMakeDate.Size = New System.Drawing.Size(162, 22)
         Me.mnuPrepareColumnDateMakeDate.Text = "Make Date..."
         '
         'mnuPrepareColumnDateInfillMissingDates
         '
         Me.mnuPrepareColumnDateInfillMissingDates.Name = "mnuPrepareColumnDateInfillMissingDates"
-        Me.mnuPrepareColumnDateInfillMissingDates.Size = New System.Drawing.Size(203, 26)
+        Me.mnuPrepareColumnDateInfillMissingDates.Size = New System.Drawing.Size(162, 22)
         Me.mnuPrepareColumnDateInfillMissingDates.Text = "Fill Date Gaps..."
         '
         'mnuPrepareColumnDateUseDate
         '
         Me.mnuPrepareColumnDateUseDate.Name = "mnuPrepareColumnDateUseDate"
-        Me.mnuPrepareColumnDateUseDate.Size = New System.Drawing.Size(203, 26)
+        Me.mnuPrepareColumnDateUseDate.Size = New System.Drawing.Size(162, 22)
         Me.mnuPrepareColumnDateUseDate.Text = "Use Date..."
         '
         'mnuPrepareColumnDateMakeTime
         '
         Me.mnuPrepareColumnDateMakeTime.Enabled = False
         Me.mnuPrepareColumnDateMakeTime.Name = "mnuPrepareColumnDateMakeTime"
-        Me.mnuPrepareColumnDateMakeTime.Size = New System.Drawing.Size(203, 26)
+        Me.mnuPrepareColumnDateMakeTime.Size = New System.Drawing.Size(162, 22)
         Me.mnuPrepareColumnDateMakeTime.Text = "Make Time..."
         Me.mnuPrepareColumnDateMakeTime.Visible = False
         '
@@ -4288,7 +4288,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnDateUseTime.Enabled = False
         Me.mnuPrepareColumnDateUseTime.Name = "mnuPrepareColumnDateUseTime"
-        Me.mnuPrepareColumnDateUseTime.Size = New System.Drawing.Size(203, 26)
+        Me.mnuPrepareColumnDateUseTime.Size = New System.Drawing.Size(162, 22)
         Me.mnuPrepareColumnDateUseTime.Text = "Use Time..."
         Me.mnuPrepareColumnDateUseTime.Visible = False
         '
@@ -4296,75 +4296,75 @@ Partial Class frmMain
         '
         Me.mnuPrepareColumnDefine.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnDefineConvertColumns, Me.ToolStripSeparator55, Me.mnuPrepareColumnDefineCircular})
         Me.mnuPrepareColumnDefine.Name = "mnuPrepareColumnDefine"
-        Me.mnuPrepareColumnDefine.Size = New System.Drawing.Size(224, 26)
+        Me.mnuPrepareColumnDefine.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareColumnDefine.Text = "Column: Define"
         '
         'mnuPrepareColumnDefineConvertColumns
         '
         Me.mnuPrepareColumnDefineConvertColumns.Name = "mnuPrepareColumnDefineConvertColumns"
-        Me.mnuPrepareColumnDefineConvertColumns.Size = New System.Drawing.Size(213, 26)
+        Me.mnuPrepareColumnDefineConvertColumns.Size = New System.Drawing.Size(176, 22)
         Me.mnuPrepareColumnDefineConvertColumns.Text = "Convert Columns..."
         '
         'ToolStripSeparator55
         '
         Me.ToolStripSeparator55.Name = "ToolStripSeparator55"
-        Me.ToolStripSeparator55.Size = New System.Drawing.Size(210, 6)
+        Me.ToolStripSeparator55.Size = New System.Drawing.Size(173, 6)
         '
         'mnuPrepareColumnDefineCircular
         '
         Me.mnuPrepareColumnDefineCircular.Name = "mnuPrepareColumnDefineCircular"
-        Me.mnuPrepareColumnDefineCircular.Size = New System.Drawing.Size(213, 26)
+        Me.mnuPrepareColumnDefineCircular.Size = New System.Drawing.Size(176, 22)
         Me.mnuPrepareColumnDefineCircular.Text = "Circular..."
         '
         'ToolStripSeparator4
         '
         Me.ToolStripSeparator4.Name = "ToolStripSeparator4"
-        Me.ToolStripSeparator4.Size = New System.Drawing.Size(221, 6)
+        Me.ToolStripSeparator4.Size = New System.Drawing.Size(166, 6)
         '
         'mnuPrepareDataReshape
         '
         Me.mnuPrepareDataReshape.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareColumnReshapeColumnSummaries, Me.mnuPrepareColumnReshapeGeneralSummaries, Me.ToolStripSeparator10, Me.mnuPrepareColumnReshapeStack, Me.mnuPrepareColumnReshapeUnstack, Me.mnuPrepareColumnReshapeMerge, Me.mnuUnnest, Me.ToolStripSeparator11, Me.mnuPrepareAppendDataFrame, Me.mnuPrepareColumnReshapeSubset, Me.mnuPrepareColumnReshapeRandomSubset, Me.mnuPrepareColumnReshapeTranspose, Me.mnuPrepareDataReshapeScaleOrDistance, Me.mnuPrepareDataReshapeRandomSplit})
         Me.mnuPrepareDataReshape.Name = "mnuPrepareDataReshape"
-        Me.mnuPrepareDataReshape.Size = New System.Drawing.Size(224, 26)
+        Me.mnuPrepareDataReshape.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareDataReshape.Tag = ""
         Me.mnuPrepareDataReshape.Text = "Data Reshape"
         '
         'mnuPrepareColumnReshapeColumnSummaries
         '
         Me.mnuPrepareColumnReshapeColumnSummaries.Name = "mnuPrepareColumnReshapeColumnSummaries"
-        Me.mnuPrepareColumnReshapeColumnSummaries.Size = New System.Drawing.Size(243, 26)
+        Me.mnuPrepareColumnReshapeColumnSummaries.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeColumnSummaries.Tag = "Column_Summaries..."
         Me.mnuPrepareColumnReshapeColumnSummaries.Text = "Column Summaries..."
         '
         'mnuPrepareColumnReshapeGeneralSummaries
         '
         Me.mnuPrepareColumnReshapeGeneralSummaries.Name = "mnuPrepareColumnReshapeGeneralSummaries"
-        Me.mnuPrepareColumnReshapeGeneralSummaries.Size = New System.Drawing.Size(243, 26)
+        Me.mnuPrepareColumnReshapeGeneralSummaries.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeGeneralSummaries.Text = "General Summaries..."
         '
         'ToolStripSeparator10
         '
         Me.ToolStripSeparator10.Name = "ToolStripSeparator10"
-        Me.ToolStripSeparator10.Size = New System.Drawing.Size(240, 6)
+        Me.ToolStripSeparator10.Size = New System.Drawing.Size(194, 6)
         '
         'mnuPrepareColumnReshapeStack
         '
         Me.mnuPrepareColumnReshapeStack.Name = "mnuPrepareColumnReshapeStack"
-        Me.mnuPrepareColumnReshapeStack.Size = New System.Drawing.Size(243, 26)
+        Me.mnuPrepareColumnReshapeStack.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeStack.Tag = "Stack..."
         Me.mnuPrepareColumnReshapeStack.Text = "Stack (Pivot Longer)..."
         '
         'mnuPrepareColumnReshapeUnstack
         '
         Me.mnuPrepareColumnReshapeUnstack.Name = "mnuPrepareColumnReshapeUnstack"
-        Me.mnuPrepareColumnReshapeUnstack.Size = New System.Drawing.Size(243, 26)
+        Me.mnuPrepareColumnReshapeUnstack.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeUnstack.Tag = "Unstack..."
         Me.mnuPrepareColumnReshapeUnstack.Text = "Unstack (Pivot Wider)..."
         '
         'mnuPrepareColumnReshapeMerge
         '
         Me.mnuPrepareColumnReshapeMerge.Name = "mnuPrepareColumnReshapeMerge"
-        Me.mnuPrepareColumnReshapeMerge.Size = New System.Drawing.Size(243, 26)
+        Me.mnuPrepareColumnReshapeMerge.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeMerge.Tag = "Merge (Join)..."
         Me.mnuPrepareColumnReshapeMerge.Text = "Merge (Join)..."
         '
@@ -4372,100 +4372,100 @@ Partial Class frmMain
         '
         Me.mnuUnnest.Enabled = False
         Me.mnuUnnest.Name = "mnuUnnest"
-        Me.mnuUnnest.Size = New System.Drawing.Size(243, 26)
+        Me.mnuUnnest.Size = New System.Drawing.Size(197, 22)
         Me.mnuUnnest.Text = "Unnest..."
         '
         'ToolStripSeparator11
         '
         Me.ToolStripSeparator11.Name = "ToolStripSeparator11"
-        Me.ToolStripSeparator11.Size = New System.Drawing.Size(240, 6)
+        Me.ToolStripSeparator11.Size = New System.Drawing.Size(194, 6)
         '
         'mnuPrepareAppendDataFrame
         '
         Me.mnuPrepareAppendDataFrame.Name = "mnuPrepareAppendDataFrame"
-        Me.mnuPrepareAppendDataFrame.Size = New System.Drawing.Size(243, 26)
+        Me.mnuPrepareAppendDataFrame.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareAppendDataFrame.Text = "Append (Bind Rows)..."
         '
         'mnuPrepareColumnReshapeSubset
         '
         Me.mnuPrepareColumnReshapeSubset.Name = "mnuPrepareColumnReshapeSubset"
-        Me.mnuPrepareColumnReshapeSubset.Size = New System.Drawing.Size(243, 26)
+        Me.mnuPrepareColumnReshapeSubset.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeSubset.Tag = "Subset..."
         Me.mnuPrepareColumnReshapeSubset.Text = "Subset..."
         '
         'mnuPrepareColumnReshapeRandomSubset
         '
         Me.mnuPrepareColumnReshapeRandomSubset.Name = "mnuPrepareColumnReshapeRandomSubset"
-        Me.mnuPrepareColumnReshapeRandomSubset.Size = New System.Drawing.Size(243, 26)
+        Me.mnuPrepareColumnReshapeRandomSubset.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeRandomSubset.Tag = "Random_Subset..."
         Me.mnuPrepareColumnReshapeRandomSubset.Text = "Random Subset..."
         '
         'mnuPrepareColumnReshapeTranspose
         '
         Me.mnuPrepareColumnReshapeTranspose.Name = "mnuPrepareColumnReshapeTranspose"
-        Me.mnuPrepareColumnReshapeTranspose.Size = New System.Drawing.Size(243, 26)
+        Me.mnuPrepareColumnReshapeTranspose.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareColumnReshapeTranspose.Tag = "Transpose..."
         Me.mnuPrepareColumnReshapeTranspose.Text = "Transpose..."
         '
         'mnuPrepareDataReshapeScaleOrDistance
         '
         Me.mnuPrepareDataReshapeScaleOrDistance.Name = "mnuPrepareDataReshapeScaleOrDistance"
-        Me.mnuPrepareDataReshapeScaleOrDistance.Size = New System.Drawing.Size(243, 26)
+        Me.mnuPrepareDataReshapeScaleOrDistance.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareDataReshapeScaleOrDistance.Text = "Scale/Distance..."
         '
         'mnuPrepareDataReshapeRandomSplit
         '
         Me.mnuPrepareDataReshapeRandomSplit.Name = "mnuPrepareDataReshapeRandomSplit"
-        Me.mnuPrepareDataReshapeRandomSplit.Size = New System.Drawing.Size(243, 26)
+        Me.mnuPrepareDataReshapeRandomSplit.Size = New System.Drawing.Size(197, 22)
         Me.mnuPrepareDataReshapeRandomSplit.Text = "Random Split..."
         '
         'ToolStripSeparator7
         '
         Me.ToolStripSeparator7.Name = "ToolStripSeparator7"
-        Me.ToolStripSeparator7.Size = New System.Drawing.Size(221, 6)
+        Me.ToolStripSeparator7.Size = New System.Drawing.Size(166, 6)
         '
         'mnuPrepareKeysAndLinks
         '
         Me.mnuPrepareKeysAndLinks.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareKeysAndLinksAddKey, Me.mnuPrepareKeysAndLinksViewAndRemoveKey, Me.mnuPrepareKeysAndLinksAddLink, Me.mnuPrepareKeysAndLinksViewAndRemoveKeys, Me.mnuPrepareKeysAndLinksAddComment})
         Me.mnuPrepareKeysAndLinks.Name = "mnuPrepareKeysAndLinks"
-        Me.mnuPrepareKeysAndLinks.Size = New System.Drawing.Size(224, 26)
+        Me.mnuPrepareKeysAndLinks.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareKeysAndLinks.Text = "Keys and Links"
         '
         'mnuPrepareKeysAndLinksAddKey
         '
         Me.mnuPrepareKeysAndLinksAddKey.Name = "mnuPrepareKeysAndLinksAddKey"
-        Me.mnuPrepareKeysAndLinksAddKey.Size = New System.Drawing.Size(256, 26)
+        Me.mnuPrepareKeysAndLinksAddKey.Size = New System.Drawing.Size(207, 22)
         Me.mnuPrepareKeysAndLinksAddKey.Text = "Add Key..."
         '
         'mnuPrepareKeysAndLinksViewAndRemoveKey
         '
         Me.mnuPrepareKeysAndLinksViewAndRemoveKey.Name = "mnuPrepareKeysAndLinksViewAndRemoveKey"
-        Me.mnuPrepareKeysAndLinksViewAndRemoveKey.Size = New System.Drawing.Size(256, 26)
+        Me.mnuPrepareKeysAndLinksViewAndRemoveKey.Size = New System.Drawing.Size(207, 22)
         Me.mnuPrepareKeysAndLinksViewAndRemoveKey.Text = "View and Remove Keys..."
         '
         'mnuPrepareKeysAndLinksAddLink
         '
         Me.mnuPrepareKeysAndLinksAddLink.Name = "mnuPrepareKeysAndLinksAddLink"
-        Me.mnuPrepareKeysAndLinksAddLink.Size = New System.Drawing.Size(256, 26)
+        Me.mnuPrepareKeysAndLinksAddLink.Size = New System.Drawing.Size(207, 22)
         Me.mnuPrepareKeysAndLinksAddLink.Text = "Add Link..."
         '
         'mnuPrepareKeysAndLinksViewAndRemoveKeys
         '
         Me.mnuPrepareKeysAndLinksViewAndRemoveKeys.Name = "mnuPrepareKeysAndLinksViewAndRemoveKeys"
-        Me.mnuPrepareKeysAndLinksViewAndRemoveKeys.Size = New System.Drawing.Size(256, 26)
+        Me.mnuPrepareKeysAndLinksViewAndRemoveKeys.Size = New System.Drawing.Size(207, 22)
         Me.mnuPrepareKeysAndLinksViewAndRemoveKeys.Text = "View and Remove Links..."
         '
         'mnuPrepareKeysAndLinksAddComment
         '
         Me.mnuPrepareKeysAndLinksAddComment.Name = "mnuPrepareKeysAndLinksAddComment"
-        Me.mnuPrepareKeysAndLinksAddComment.Size = New System.Drawing.Size(256, 26)
+        Me.mnuPrepareKeysAndLinksAddComment.Size = New System.Drawing.Size(207, 22)
         Me.mnuPrepareKeysAndLinksAddComment.Text = "Add Comment..."
         '
         'mnuPrepareDataBook
         '
         Me.mnuPrepareDataBook.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareDataObjectDataFrameMetadata, Me.mnuPrepareDataObjectRenameDataFrame, Me.mnuPrepareDataObjectReorderDataFrames, Me.mnuPrepareDataObjectCopyDataFrame, Me.mnuPrepareDataObjectDeleteDataFrame, Me.ToolStripSeparator21, Me.mnuPrepareDataObjectHideDataframes, Me.mnuPrepareDataObjectMetadata, Me.mnuPrepareDataObjectRenameMetadata, Me.mnuPrepareDataObjectReorderMetadata, Me.mnuPrepareDataObjectDeleteMetadata})
         Me.mnuPrepareDataBook.Name = "mnuPrepareDataBook"
-        Me.mnuPrepareDataBook.Size = New System.Drawing.Size(224, 26)
+        Me.mnuPrepareDataBook.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareDataBook.Tag = "Data_Object"
         Me.mnuPrepareDataBook.Text = "Data Book"
         '
@@ -4473,7 +4473,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataObjectDataFrameMetadata.Enabled = False
         Me.mnuPrepareDataObjectDataFrameMetadata.Name = "mnuPrepareDataObjectDataFrameMetadata"
-        Me.mnuPrepareDataObjectDataFrameMetadata.Size = New System.Drawing.Size(262, 26)
+        Me.mnuPrepareDataObjectDataFrameMetadata.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectDataFrameMetadata.Tag = "Data_Frame_Metadata..."
         Me.mnuPrepareDataObjectDataFrameMetadata.Text = "Data Frame Metadata..."
         Me.mnuPrepareDataObjectDataFrameMetadata.Visible = False
@@ -4481,46 +4481,46 @@ Partial Class frmMain
         'mnuPrepareDataObjectRenameDataFrame
         '
         Me.mnuPrepareDataObjectRenameDataFrame.Name = "mnuPrepareDataObjectRenameDataFrame"
-        Me.mnuPrepareDataObjectRenameDataFrame.Size = New System.Drawing.Size(262, 26)
+        Me.mnuPrepareDataObjectRenameDataFrame.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectRenameDataFrame.Tag = "ReName_Data_Frame..."
         Me.mnuPrepareDataObjectRenameDataFrame.Text = "Rename Data Frame..."
         '
         'mnuPrepareDataObjectReorderDataFrames
         '
         Me.mnuPrepareDataObjectReorderDataFrames.Name = "mnuPrepareDataObjectReorderDataFrames"
-        Me.mnuPrepareDataObjectReorderDataFrames.Size = New System.Drawing.Size(262, 26)
+        Me.mnuPrepareDataObjectReorderDataFrames.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectReorderDataFrames.Tag = "Reorder_Data_Frames..."
         Me.mnuPrepareDataObjectReorderDataFrames.Text = "Reorder Data Frames..."
         '
         'mnuPrepareDataObjectCopyDataFrame
         '
         Me.mnuPrepareDataObjectCopyDataFrame.Name = "mnuPrepareDataObjectCopyDataFrame"
-        Me.mnuPrepareDataObjectCopyDataFrame.Size = New System.Drawing.Size(262, 26)
+        Me.mnuPrepareDataObjectCopyDataFrame.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectCopyDataFrame.Tag = "Copy_Data_Frame..."
         Me.mnuPrepareDataObjectCopyDataFrame.Text = "Copy Data Frame..."
         '
         'mnuPrepareDataObjectDeleteDataFrame
         '
         Me.mnuPrepareDataObjectDeleteDataFrame.Name = "mnuPrepareDataObjectDeleteDataFrame"
-        Me.mnuPrepareDataObjectDeleteDataFrame.Size = New System.Drawing.Size(262, 26)
+        Me.mnuPrepareDataObjectDeleteDataFrame.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectDeleteDataFrame.Tag = "Delete_Data_Frame..."
         Me.mnuPrepareDataObjectDeleteDataFrame.Text = "Delete Data Frames..."
         '
         'ToolStripSeparator21
         '
         Me.ToolStripSeparator21.Name = "ToolStripSeparator21"
-        Me.ToolStripSeparator21.Size = New System.Drawing.Size(259, 6)
+        Me.ToolStripSeparator21.Size = New System.Drawing.Size(207, 6)
         '
         'mnuPrepareDataObjectHideDataframes
         '
         Me.mnuPrepareDataObjectHideDataframes.Name = "mnuPrepareDataObjectHideDataframes"
-        Me.mnuPrepareDataObjectHideDataframes.Size = New System.Drawing.Size(262, 26)
+        Me.mnuPrepareDataObjectHideDataframes.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectHideDataframes.Text = "Hide/Show Data Frames..."
         '
         'mnuPrepareDataObjectMetadata
         '
         Me.mnuPrepareDataObjectMetadata.Name = "mnuPrepareDataObjectMetadata"
-        Me.mnuPrepareDataObjectMetadata.Size = New System.Drawing.Size(262, 26)
+        Me.mnuPrepareDataObjectMetadata.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectMetadata.Tag = "Metadata..."
         Me.mnuPrepareDataObjectMetadata.Text = "Metadata..."
         '
@@ -4528,7 +4528,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataObjectRenameMetadata.Enabled = False
         Me.mnuPrepareDataObjectRenameMetadata.Name = "mnuPrepareDataObjectRenameMetadata"
-        Me.mnuPrepareDataObjectRenameMetadata.Size = New System.Drawing.Size(262, 26)
+        Me.mnuPrepareDataObjectRenameMetadata.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectRenameMetadata.Tag = "Rename_Metadata..."
         Me.mnuPrepareDataObjectRenameMetadata.Text = "Rename Metadata..."
         Me.mnuPrepareDataObjectRenameMetadata.Visible = False
@@ -4537,7 +4537,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataObjectReorderMetadata.Enabled = False
         Me.mnuPrepareDataObjectReorderMetadata.Name = "mnuPrepareDataObjectReorderMetadata"
-        Me.mnuPrepareDataObjectReorderMetadata.Size = New System.Drawing.Size(262, 26)
+        Me.mnuPrepareDataObjectReorderMetadata.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectReorderMetadata.Tag = "Reorder_Metadata..."
         Me.mnuPrepareDataObjectReorderMetadata.Text = "Reorder Metadata..."
         Me.mnuPrepareDataObjectReorderMetadata.Visible = False
@@ -4546,7 +4546,7 @@ Partial Class frmMain
         '
         Me.mnuPrepareDataObjectDeleteMetadata.Enabled = False
         Me.mnuPrepareDataObjectDeleteMetadata.Name = "mnuPrepareDataObjectDeleteMetadata"
-        Me.mnuPrepareDataObjectDeleteMetadata.Size = New System.Drawing.Size(262, 26)
+        Me.mnuPrepareDataObjectDeleteMetadata.Size = New System.Drawing.Size(210, 22)
         Me.mnuPrepareDataObjectDeleteMetadata.Tag = "Delete_Metadata..."
         Me.mnuPrepareDataObjectDeleteMetadata.Text = "Delete Metadata..."
         Me.mnuPrepareDataObjectDeleteMetadata.Visible = False
@@ -4555,35 +4555,35 @@ Partial Class frmMain
         '
         Me.mnuPrepareRObjects.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuPrepareRObjectsView, Me.mnuPrepareRObjectsRename, Me.mnuPrepareRObjectsReorder, Me.mnuPrepareRObjectsDelete})
         Me.mnuPrepareRObjects.Name = "mnuPrepareRObjects"
-        Me.mnuPrepareRObjects.Size = New System.Drawing.Size(224, 26)
+        Me.mnuPrepareRObjects.Size = New System.Drawing.Size(169, 22)
         Me.mnuPrepareRObjects.Tag = "R_Objects"
         Me.mnuPrepareRObjects.Text = "R Objects"
         '
         'mnuPrepareRObjectsView
         '
         Me.mnuPrepareRObjectsView.Name = "mnuPrepareRObjectsView"
-        Me.mnuPrepareRObjectsView.Size = New System.Drawing.Size(155, 26)
+        Me.mnuPrepareRObjectsView.Size = New System.Drawing.Size(126, 22)
         Me.mnuPrepareRObjectsView.Tag = "View..."
         Me.mnuPrepareRObjectsView.Text = "View..."
         '
         'mnuPrepareRObjectsRename
         '
         Me.mnuPrepareRObjectsRename.Name = "mnuPrepareRObjectsRename"
-        Me.mnuPrepareRObjectsRename.Size = New System.Drawing.Size(155, 26)
+        Me.mnuPrepareRObjectsRename.Size = New System.Drawing.Size(126, 22)
         Me.mnuPrepareRObjectsRename.Tag = "Rename..."
         Me.mnuPrepareRObjectsRename.Text = "Rename..."
         '
         'mnuPrepareRObjectsReorder
         '
         Me.mnuPrepareRObjectsReorder.Name = "mnuPrepareRObjectsReorder"
-        Me.mnuPrepareRObjectsReorder.Size = New System.Drawing.Size(155, 26)
+        Me.mnuPrepareRObjectsReorder.Size = New System.Drawing.Size(126, 22)
         Me.mnuPrepareRObjectsReorder.Tag = "Reorder"
         Me.mnuPrepareRObjectsReorder.Text = "Reorder..."
         '
         'mnuPrepareRObjectsDelete
         '
         Me.mnuPrepareRObjectsDelete.Name = "mnuPrepareRObjectsDelete"
-        Me.mnuPrepareRObjectsDelete.Size = New System.Drawing.Size(155, 26)
+        Me.mnuPrepareRObjectsDelete.Size = New System.Drawing.Size(126, 22)
         Me.mnuPrepareRObjectsDelete.Tag = "Delete..."
         Me.mnuPrepareRObjectsDelete.Text = "Delete..."
         '
@@ -4591,78 +4591,78 @@ Partial Class frmMain
         '
         Me.mnuStructured.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredCircular, Me.mnuStructuredLow_Flow, Me.mnuStructuredSurvival, Me.mnuStructuredTimeSeries, Me.ToolStripSeparator63, Me.mnuStructuredClimatic, Me.mnuStructuredProcurement, Me.mnuStructuredOptionByContext, Me.mnuStructuredSurvey})
         Me.mnuStructured.Name = "mnuStructured"
-        Me.mnuStructured.Size = New System.Drawing.Size(91, 24)
+        Me.mnuStructured.Size = New System.Drawing.Size(74, 20)
         Me.mnuStructured.Text = "Structured"
         '
         'mnuStructuredCircular
         '
         Me.mnuStructuredCircular.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredCircularDefine, Me.mnuStructuredCircularCalculator, Me.mnuStructuredCircularSummaries, Me.ToolStripSeparator46, Me.mnuStructuredCircularDensityPlot, Me.ToolStripSeparator67, Me.mnuStructuredCircularWindRose, Me.mnuStructuredCircularWindPollutionRose, Me.mnuStructuredCircularOtherRosePlots, Me.ToolStripSeparator68, Me.mnuStructuredCircularCirclize})
         Me.mnuStructuredCircular.Name = "mnuStructuredCircular"
-        Me.mnuStructuredCircular.Size = New System.Drawing.Size(228, 26)
+        Me.mnuStructuredCircular.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredCircular.Text = "Circular"
         '
         'mnuStructuredCircularDefine
         '
         Me.mnuStructuredCircularDefine.Name = "mnuStructuredCircularDefine"
-        Me.mnuStructuredCircularDefine.Size = New System.Drawing.Size(236, 26)
+        Me.mnuStructuredCircularDefine.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularDefine.Text = "Define..."
         '
         'mnuStructuredCircularCalculator
         '
         Me.mnuStructuredCircularCalculator.Name = "mnuStructuredCircularCalculator"
-        Me.mnuStructuredCircularCalculator.Size = New System.Drawing.Size(236, 26)
+        Me.mnuStructuredCircularCalculator.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularCalculator.Text = "Calculator..."
         '
         'mnuStructuredCircularSummaries
         '
         Me.mnuStructuredCircularSummaries.Name = "mnuStructuredCircularSummaries"
-        Me.mnuStructuredCircularSummaries.Size = New System.Drawing.Size(236, 26)
+        Me.mnuStructuredCircularSummaries.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularSummaries.Text = "Summaries..."
         '
         'ToolStripSeparator46
         '
         Me.ToolStripSeparator46.Name = "ToolStripSeparator46"
-        Me.ToolStripSeparator46.Size = New System.Drawing.Size(233, 6)
+        Me.ToolStripSeparator46.Size = New System.Drawing.Size(189, 6)
         '
         'mnuStructuredCircularDensityPlot
         '
         Me.mnuStructuredCircularDensityPlot.Name = "mnuStructuredCircularDensityPlot"
-        Me.mnuStructuredCircularDensityPlot.Size = New System.Drawing.Size(236, 26)
+        Me.mnuStructuredCircularDensityPlot.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularDensityPlot.Text = "Circular Plots..."
         '
         'ToolStripSeparator67
         '
         Me.ToolStripSeparator67.Name = "ToolStripSeparator67"
-        Me.ToolStripSeparator67.Size = New System.Drawing.Size(233, 6)
+        Me.ToolStripSeparator67.Size = New System.Drawing.Size(189, 6)
         '
         'mnuStructuredCircularWindRose
         '
         Me.mnuStructuredCircularWindRose.Name = "mnuStructuredCircularWindRose"
-        Me.mnuStructuredCircularWindRose.Size = New System.Drawing.Size(236, 26)
+        Me.mnuStructuredCircularWindRose.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularWindRose.Text = "Wind Rose..."
         '
         'mnuStructuredCircularWindPollutionRose
         '
         Me.mnuStructuredCircularWindPollutionRose.Name = "mnuStructuredCircularWindPollutionRose"
-        Me.mnuStructuredCircularWindPollutionRose.Size = New System.Drawing.Size(236, 26)
+        Me.mnuStructuredCircularWindPollutionRose.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularWindPollutionRose.Text = "Wind/Pollution Rose..."
         '
         'mnuStructuredCircularOtherRosePlots
         '
         Me.mnuStructuredCircularOtherRosePlots.Name = "mnuStructuredCircularOtherRosePlots"
-        Me.mnuStructuredCircularOtherRosePlots.Size = New System.Drawing.Size(236, 26)
+        Me.mnuStructuredCircularOtherRosePlots.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularOtherRosePlots.Text = "Other Rose Plots..."
         '
         'ToolStripSeparator68
         '
         Me.ToolStripSeparator68.Name = "ToolStripSeparator68"
-        Me.ToolStripSeparator68.Size = New System.Drawing.Size(233, 6)
+        Me.ToolStripSeparator68.Size = New System.Drawing.Size(189, 6)
         '
         'mnuStructuredCircularCirclize
         '
         Me.mnuStructuredCircularCirclize.Enabled = False
         Me.mnuStructuredCircularCirclize.Name = "mnuStructuredCircularCirclize"
-        Me.mnuStructuredCircularCirclize.Size = New System.Drawing.Size(236, 26)
+        Me.mnuStructuredCircularCirclize.Size = New System.Drawing.Size(192, 22)
         Me.mnuStructuredCircularCirclize.Text = "Circlize..."
         Me.mnuStructuredCircularCirclize.Visible = False
         '
@@ -4670,126 +4670,126 @@ Partial Class frmMain
         '
         Me.mnuStructuredLow_Flow.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredLow_FlowDefine})
         Me.mnuStructuredLow_Flow.Name = "mnuStructuredLow_Flow"
-        Me.mnuStructuredLow_Flow.Size = New System.Drawing.Size(228, 26)
+        Me.mnuStructuredLow_Flow.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredLow_Flow.Text = "Low_Flow"
         Me.mnuStructuredLow_Flow.Visible = False
         '
         'mnuStructuredLow_FlowDefine
         '
         Me.mnuStructuredLow_FlowDefine.Name = "mnuStructuredLow_FlowDefine"
-        Me.mnuStructuredLow_FlowDefine.Size = New System.Drawing.Size(145, 26)
+        Me.mnuStructuredLow_FlowDefine.Size = New System.Drawing.Size(117, 22)
         Me.mnuStructuredLow_FlowDefine.Text = "Define..."
         '
         'mnuStructuredSurvival
         '
         Me.mnuStructuredSurvival.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredSurvivalDefine})
         Me.mnuStructuredSurvival.Name = "mnuStructuredSurvival"
-        Me.mnuStructuredSurvival.Size = New System.Drawing.Size(228, 26)
+        Me.mnuStructuredSurvival.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredSurvival.Text = "Survival"
         '
         'mnuStructuredSurvivalDefine
         '
         Me.mnuStructuredSurvivalDefine.Name = "mnuStructuredSurvivalDefine"
-        Me.mnuStructuredSurvivalDefine.Size = New System.Drawing.Size(145, 26)
+        Me.mnuStructuredSurvivalDefine.Size = New System.Drawing.Size(117, 22)
         Me.mnuStructuredSurvivalDefine.Text = "Define..."
         '
         'mnuStructuredTimeSeries
         '
         Me.mnuStructuredTimeSeries.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredTimeSeriesDefine, Me.ToolStripSeparator60, Me.mnuStructuredTimeSeriesDescribe, Me.ToolStripSeparator61, Me.mnuStructuredTimeSeriesModel, Me.ToolStripSeparator62})
         Me.mnuStructuredTimeSeries.Name = "mnuStructuredTimeSeries"
-        Me.mnuStructuredTimeSeries.Size = New System.Drawing.Size(228, 26)
+        Me.mnuStructuredTimeSeries.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredTimeSeries.Text = "Time Series"
         Me.mnuStructuredTimeSeries.Visible = False
         '
         'mnuStructuredTimeSeriesDefine
         '
         Me.mnuStructuredTimeSeriesDefine.Name = "mnuStructuredTimeSeriesDefine"
-        Me.mnuStructuredTimeSeriesDefine.Size = New System.Drawing.Size(150, 26)
+        Me.mnuStructuredTimeSeriesDefine.Size = New System.Drawing.Size(119, 22)
         Me.mnuStructuredTimeSeriesDefine.Text = "Define..."
         '
         'ToolStripSeparator60
         '
         Me.ToolStripSeparator60.Name = "ToolStripSeparator60"
-        Me.ToolStripSeparator60.Size = New System.Drawing.Size(147, 6)
+        Me.ToolStripSeparator60.Size = New System.Drawing.Size(116, 6)
         '
         'mnuStructuredTimeSeriesDescribe
         '
         Me.mnuStructuredTimeSeriesDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredTimeSeriesDescribeOneVariable, Me.mnuStructuredTimeSeriesDescribeGeneral})
         Me.mnuStructuredTimeSeriesDescribe.Name = "mnuStructuredTimeSeriesDescribe"
-        Me.mnuStructuredTimeSeriesDescribe.Size = New System.Drawing.Size(150, 26)
+        Me.mnuStructuredTimeSeriesDescribe.Size = New System.Drawing.Size(119, 22)
         Me.mnuStructuredTimeSeriesDescribe.Text = "Describe"
         '
         'mnuStructuredTimeSeriesDescribeOneVariable
         '
         Me.mnuStructuredTimeSeriesDescribeOneVariable.Name = "mnuStructuredTimeSeriesDescribeOneVariable"
-        Me.mnuStructuredTimeSeriesDescribeOneVariable.Size = New System.Drawing.Size(186, 26)
+        Me.mnuStructuredTimeSeriesDescribeOneVariable.Size = New System.Drawing.Size(149, 22)
         Me.mnuStructuredTimeSeriesDescribeOneVariable.Text = "One Variable..."
         '
         'mnuStructuredTimeSeriesDescribeGeneral
         '
         Me.mnuStructuredTimeSeriesDescribeGeneral.Name = "mnuStructuredTimeSeriesDescribeGeneral"
-        Me.mnuStructuredTimeSeriesDescribeGeneral.Size = New System.Drawing.Size(186, 26)
+        Me.mnuStructuredTimeSeriesDescribeGeneral.Size = New System.Drawing.Size(149, 22)
         Me.mnuStructuredTimeSeriesDescribeGeneral.Text = "General..."
         '
         'ToolStripSeparator61
         '
         Me.ToolStripSeparator61.Name = "ToolStripSeparator61"
-        Me.ToolStripSeparator61.Size = New System.Drawing.Size(147, 6)
+        Me.ToolStripSeparator61.Size = New System.Drawing.Size(116, 6)
         '
         'mnuStructuredTimeSeriesModel
         '
         Me.mnuStructuredTimeSeriesModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuStructuredTimeSeriesModelOneVariable, Me.mnuStructuredTimeSeriesModelGeneral})
         Me.mnuStructuredTimeSeriesModel.Name = "mnuStructuredTimeSeriesModel"
-        Me.mnuStructuredTimeSeriesModel.Size = New System.Drawing.Size(150, 26)
+        Me.mnuStructuredTimeSeriesModel.Size = New System.Drawing.Size(119, 22)
         Me.mnuStructuredTimeSeriesModel.Text = "Model"
         '
         'mnuStructuredTimeSeriesModelOneVariable
         '
         Me.mnuStructuredTimeSeriesModelOneVariable.Name = "mnuStructuredTimeSeriesModelOneVariable"
-        Me.mnuStructuredTimeSeriesModelOneVariable.Size = New System.Drawing.Size(186, 26)
+        Me.mnuStructuredTimeSeriesModelOneVariable.Size = New System.Drawing.Size(149, 22)
         Me.mnuStructuredTimeSeriesModelOneVariable.Text = "One Variable..."
         '
         'mnuStructuredTimeSeriesModelGeneral
         '
         Me.mnuStructuredTimeSeriesModelGeneral.Name = "mnuStructuredTimeSeriesModelGeneral"
-        Me.mnuStructuredTimeSeriesModelGeneral.Size = New System.Drawing.Size(186, 26)
+        Me.mnuStructuredTimeSeriesModelGeneral.Size = New System.Drawing.Size(149, 22)
         Me.mnuStructuredTimeSeriesModelGeneral.Text = "General..."
         '
         'ToolStripSeparator62
         '
         Me.ToolStripSeparator62.Name = "ToolStripSeparator62"
-        Me.ToolStripSeparator62.Size = New System.Drawing.Size(147, 6)
+        Me.ToolStripSeparator62.Size = New System.Drawing.Size(116, 6)
         '
         'ToolStripSeparator63
         '
         Me.ToolStripSeparator63.Name = "ToolStripSeparator63"
-        Me.ToolStripSeparator63.Size = New System.Drawing.Size(225, 6)
+        Me.ToolStripSeparator63.Size = New System.Drawing.Size(182, 6)
         '
         'mnuStructuredClimatic
         '
         Me.mnuStructuredClimatic.Name = "mnuStructuredClimatic"
-        Me.mnuStructuredClimatic.Size = New System.Drawing.Size(228, 26)
+        Me.mnuStructuredClimatic.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredClimatic.Text = "Climatic..."
         Me.mnuStructuredClimatic.Visible = False
         '
         'mnuStructuredProcurement
         '
         Me.mnuStructuredProcurement.Name = "mnuStructuredProcurement"
-        Me.mnuStructuredProcurement.Size = New System.Drawing.Size(228, 26)
+        Me.mnuStructuredProcurement.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredProcurement.Text = "Procurement..."
         Me.mnuStructuredProcurement.Visible = False
         '
         'mnuStructuredOptionByContext
         '
         Me.mnuStructuredOptionByContext.Name = "mnuStructuredOptionByContext"
-        Me.mnuStructuredOptionByContext.Size = New System.Drawing.Size(228, 26)
+        Me.mnuStructuredOptionByContext.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredOptionByContext.Text = "Options by Context..."
         Me.mnuStructuredOptionByContext.Visible = False
         '
         'mnuStructuredSurvey
         '
         Me.mnuStructuredSurvey.Name = "mnuStructuredSurvey"
-        Me.mnuStructuredSurvey.Size = New System.Drawing.Size(228, 26)
+        Me.mnuStructuredSurvey.Size = New System.Drawing.Size(185, 22)
         Me.mnuStructuredSurvey.Text = "Survey"
         Me.mnuStructuredSurvey.Visible = False
         '
@@ -4797,247 +4797,247 @@ Partial Class frmMain
         '
         Me.mnuTricot.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotImportFromClimMob, Me.ToolStripSeparator87, Me.mnuTricotExamineData, Me.TidyToolStripMenuItem, Me.mnuTransformAndDefineAsTricot, Me.mnuTricotDefineTricotData, Me.ToolStripSeparator20, Me.mnuTricotDescribe, Me.mnuTricotModelPlackettLuce})
         Me.mnuTricot.Name = "mnuTricot"
-        Me.mnuTricot.Size = New System.Drawing.Size(60, 24)
+        Me.mnuTricot.Size = New System.Drawing.Size(49, 20)
         Me.mnuTricot.Text = "Tricot"
         '
         'mnuTricotImportFromClimMob
         '
         Me.mnuTricotImportFromClimMob.Name = "mnuTricotImportFromClimMob"
-        Me.mnuTricotImportFromClimMob.Size = New System.Drawing.Size(303, 26)
+        Me.mnuTricotImportFromClimMob.Size = New System.Drawing.Size(244, 22)
         Me.mnuTricotImportFromClimMob.Text = "Import from ClimMob..."
         '
         'ToolStripSeparator87
         '
         Me.ToolStripSeparator87.Name = "ToolStripSeparator87"
-        Me.ToolStripSeparator87.Size = New System.Drawing.Size(300, 6)
+        Me.ToolStripSeparator87.Size = New System.Drawing.Size(241, 6)
         '
         'mnuTricotExamineData
         '
         Me.mnuTricotExamineData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotexamineeditdataVisualiseData, Me.mnuTricotexamineeditdataPivotTable, Me.ToolStripSeparator88, Me.mnuTricotexamineeditdataOneVariableSummarise, Me.mnuTricotexamineeditdataOneVariableGraph, Me.mnuTricotexamineeditdataOneVariableFrequencies})
         Me.mnuTricotExamineData.Name = "mnuTricotExamineData"
-        Me.mnuTricotExamineData.Size = New System.Drawing.Size(303, 26)
+        Me.mnuTricotExamineData.Size = New System.Drawing.Size(244, 22)
         Me.mnuTricotExamineData.Text = "Examine Data"
         '
         'mnuTricotexamineeditdataVisualiseData
         '
         Me.mnuTricotexamineeditdataVisualiseData.Name = "mnuTricotexamineeditdataVisualiseData"
-        Me.mnuTricotexamineeditdataVisualiseData.Size = New System.Drawing.Size(268, 26)
+        Me.mnuTricotexamineeditdataVisualiseData.Size = New System.Drawing.Size(215, 22)
         Me.mnuTricotexamineeditdataVisualiseData.Text = "Visualise Data..."
         '
         'mnuTricotexamineeditdataPivotTable
         '
         Me.mnuTricotexamineeditdataPivotTable.Name = "mnuTricotexamineeditdataPivotTable"
-        Me.mnuTricotexamineeditdataPivotTable.Size = New System.Drawing.Size(268, 26)
+        Me.mnuTricotexamineeditdataPivotTable.Size = New System.Drawing.Size(215, 22)
         Me.mnuTricotexamineeditdataPivotTable.Text = "Pivot Table..."
         '
         'ToolStripSeparator88
         '
         Me.ToolStripSeparator88.Name = "ToolStripSeparator88"
-        Me.ToolStripSeparator88.Size = New System.Drawing.Size(265, 6)
+        Me.ToolStripSeparator88.Size = New System.Drawing.Size(212, 6)
         '
         'mnuTricotexamineeditdataOneVariableSummarise
         '
         Me.mnuTricotexamineeditdataOneVariableSummarise.Name = "mnuTricotexamineeditdataOneVariableSummarise"
-        Me.mnuTricotexamineeditdataOneVariableSummarise.Size = New System.Drawing.Size(268, 26)
+        Me.mnuTricotexamineeditdataOneVariableSummarise.Size = New System.Drawing.Size(215, 22)
         Me.mnuTricotexamineeditdataOneVariableSummarise.Text = "One Variable Summarise..."
         '
         'mnuTricotexamineeditdataOneVariableGraph
         '
         Me.mnuTricotexamineeditdataOneVariableGraph.Name = "mnuTricotexamineeditdataOneVariableGraph"
-        Me.mnuTricotexamineeditdataOneVariableGraph.Size = New System.Drawing.Size(268, 26)
+        Me.mnuTricotexamineeditdataOneVariableGraph.Size = New System.Drawing.Size(215, 22)
         Me.mnuTricotexamineeditdataOneVariableGraph.Text = "One Variable Graph..."
         '
         'mnuTricotexamineeditdataOneVariableFrequencies
         '
         Me.mnuTricotexamineeditdataOneVariableFrequencies.Name = "mnuTricotexamineeditdataOneVariableFrequencies"
-        Me.mnuTricotexamineeditdataOneVariableFrequencies.Size = New System.Drawing.Size(268, 26)
+        Me.mnuTricotexamineeditdataOneVariableFrequencies.Size = New System.Drawing.Size(215, 22)
         Me.mnuTricotexamineeditdataOneVariableFrequencies.Text = "One Variable Frequencies..."
         '
         'TidyToolStripMenuItem
         '
         Me.TidyToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTidyDuplicateRows, Me.RowNumbersNamesToolStripMenuItem, Me.RecodeFactorToolStripMenuItem, Me.CombineFactorsToolStripMenuItem, Me.mnuReorderLevels, Me.mnuTransformText, Me.ToolStripSeparator85, Me.mnuStackPivotLonger, Me.mnuUnstackPivotWider, Me.mnuTidyAddMergeColumns, Me.ToolStripSeparator86, Me.AddKeyToolStripMenuItem})
         Me.TidyToolStripMenuItem.Name = "TidyToolStripMenuItem"
-        Me.TidyToolStripMenuItem.Size = New System.Drawing.Size(303, 26)
+        Me.TidyToolStripMenuItem.Size = New System.Drawing.Size(244, 22)
         Me.TidyToolStripMenuItem.Text = "Tidy Data"
         '
         'mnuTidyDuplicateRows
         '
         Me.mnuTidyDuplicateRows.Name = "mnuTidyDuplicateRows"
-        Me.mnuTidyDuplicateRows.Size = New System.Drawing.Size(250, 26)
+        Me.mnuTidyDuplicateRows.Size = New System.Drawing.Size(203, 22)
         Me.mnuTidyDuplicateRows.Text = "Duplicate Rows..."
         '
         'RowNumbersNamesToolStripMenuItem
         '
         Me.RowNumbersNamesToolStripMenuItem.Name = "RowNumbersNamesToolStripMenuItem"
-        Me.RowNumbersNamesToolStripMenuItem.Size = New System.Drawing.Size(250, 26)
+        Me.RowNumbersNamesToolStripMenuItem.Size = New System.Drawing.Size(203, 22)
         Me.RowNumbersNamesToolStripMenuItem.Text = "Row Numbers/ Names..."
         '
         'RecodeFactorToolStripMenuItem
         '
         Me.RecodeFactorToolStripMenuItem.Name = "RecodeFactorToolStripMenuItem"
-        Me.RecodeFactorToolStripMenuItem.Size = New System.Drawing.Size(250, 26)
+        Me.RecodeFactorToolStripMenuItem.Size = New System.Drawing.Size(203, 22)
         Me.RecodeFactorToolStripMenuItem.Text = "Recode Factor..."
         '
         'CombineFactorsToolStripMenuItem
         '
         Me.CombineFactorsToolStripMenuItem.Name = "CombineFactorsToolStripMenuItem"
-        Me.CombineFactorsToolStripMenuItem.Size = New System.Drawing.Size(250, 26)
+        Me.CombineFactorsToolStripMenuItem.Size = New System.Drawing.Size(203, 22)
         Me.CombineFactorsToolStripMenuItem.Text = "Combine Factors..."
         '
         'mnuReorderLevels
         '
         Me.mnuReorderLevels.Name = "mnuReorderLevels"
-        Me.mnuReorderLevels.Size = New System.Drawing.Size(250, 26)
+        Me.mnuReorderLevels.Size = New System.Drawing.Size(203, 22)
         Me.mnuReorderLevels.Text = "Reorder Factor Levels..."
         '
         'mnuTransformText
         '
         Me.mnuTransformText.Name = "mnuTransformText"
-        Me.mnuTransformText.Size = New System.Drawing.Size(250, 26)
+        Me.mnuTransformText.Size = New System.Drawing.Size(203, 22)
         Me.mnuTransformText.Text = "Transform Text..."
         '
         'ToolStripSeparator85
         '
         Me.ToolStripSeparator85.Name = "ToolStripSeparator85"
-        Me.ToolStripSeparator85.Size = New System.Drawing.Size(247, 6)
+        Me.ToolStripSeparator85.Size = New System.Drawing.Size(200, 6)
         '
         'mnuStackPivotLonger
         '
         Me.mnuStackPivotLonger.Name = "mnuStackPivotLonger"
-        Me.mnuStackPivotLonger.Size = New System.Drawing.Size(250, 26)
+        Me.mnuStackPivotLonger.Size = New System.Drawing.Size(203, 22)
         Me.mnuStackPivotLonger.Text = "Stack (Pivot Longer)..."
         '
         'mnuUnstackPivotWider
         '
         Me.mnuUnstackPivotWider.Name = "mnuUnstackPivotWider"
-        Me.mnuUnstackPivotWider.Size = New System.Drawing.Size(250, 26)
+        Me.mnuUnstackPivotWider.Size = New System.Drawing.Size(203, 22)
         Me.mnuUnstackPivotWider.Text = "Unstack (Pivot Wider)..."
         '
         'mnuTidyAddMergeColumns
         '
         Me.mnuTidyAddMergeColumns.Name = "mnuTidyAddMergeColumns"
-        Me.mnuTidyAddMergeColumns.Size = New System.Drawing.Size(250, 26)
+        Me.mnuTidyAddMergeColumns.Size = New System.Drawing.Size(203, 22)
         Me.mnuTidyAddMergeColumns.Text = "Add (Merge) Columns..."
         '
         'ToolStripSeparator86
         '
         Me.ToolStripSeparator86.Name = "ToolStripSeparator86"
-        Me.ToolStripSeparator86.Size = New System.Drawing.Size(247, 6)
+        Me.ToolStripSeparator86.Size = New System.Drawing.Size(200, 6)
         '
         'AddKeyToolStripMenuItem
         '
         Me.AddKeyToolStripMenuItem.Name = "AddKeyToolStripMenuItem"
-        Me.AddKeyToolStripMenuItem.Size = New System.Drawing.Size(250, 26)
+        Me.AddKeyToolStripMenuItem.Size = New System.Drawing.Size(203, 22)
         Me.AddKeyToolStripMenuItem.Text = "Add Key..."
         '
         'mnuTransformAndDefineAsTricot
         '
         Me.mnuTransformAndDefineAsTricot.Name = "mnuTransformAndDefineAsTricot"
-        Me.mnuTransformAndDefineAsTricot.Size = New System.Drawing.Size(303, 26)
+        Me.mnuTransformAndDefineAsTricot.Size = New System.Drawing.Size(244, 22)
         Me.mnuTransformAndDefineAsTricot.Text = "Transform and Define as Tricot..."
         '
         'mnuTricotDefineTricotData
         '
         Me.mnuTricotDefineTricotData.Name = "mnuTricotDefineTricotData"
-        Me.mnuTricotDefineTricotData.Size = New System.Drawing.Size(303, 26)
+        Me.mnuTricotDefineTricotData.Size = New System.Drawing.Size(244, 22)
         Me.mnuTricotDefineTricotData.Text = "Define as Tricot..."
         '
         'ToolStripSeparator20
         '
         Me.ToolStripSeparator20.Name = "ToolStripSeparator20"
-        Me.ToolStripSeparator20.Size = New System.Drawing.Size(300, 6)
+        Me.ToolStripSeparator20.Size = New System.Drawing.Size(241, 6)
         '
         'mnuTricotDescribe
         '
         Me.mnuTricotDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuSummariseTricot, Me.mnuDescribeGraphTricots, Me.ToolStripSeparator83, Me.mnuTricotDescribeTraits, Me.mnuTricotDescribeCorrelations})
         Me.mnuTricotDescribe.Name = "mnuTricotDescribe"
-        Me.mnuTricotDescribe.Size = New System.Drawing.Size(303, 26)
+        Me.mnuTricotDescribe.Size = New System.Drawing.Size(244, 22)
         Me.mnuTricotDescribe.Text = "Describe"
         '
         'mnuSummariseTricot
         '
         Me.mnuSummariseTricot.Name = "mnuSummariseTricot"
-        Me.mnuSummariseTricot.Size = New System.Drawing.Size(264, 26)
+        Me.mnuSummariseTricot.Size = New System.Drawing.Size(211, 22)
         Me.mnuSummariseTricot.Text = "Summarise 2/3 Variables..."
         '
         'mnuDescribeGraphTricots
         '
         Me.mnuDescribeGraphTricots.Name = "mnuDescribeGraphTricots"
-        Me.mnuDescribeGraphTricots.Size = New System.Drawing.Size(264, 26)
+        Me.mnuDescribeGraphTricots.Size = New System.Drawing.Size(211, 22)
         Me.mnuDescribeGraphTricots.Text = "Graph 2/3 Variables..."
         '
         'ToolStripSeparator83
         '
         Me.ToolStripSeparator83.Name = "ToolStripSeparator83"
-        Me.ToolStripSeparator83.Size = New System.Drawing.Size(261, 6)
+        Me.ToolStripSeparator83.Size = New System.Drawing.Size(208, 6)
         '
         'mnuTricotDescribeTraits
         '
         Me.mnuTricotDescribeTraits.Name = "mnuTricotDescribeTraits"
-        Me.mnuTricotDescribeTraits.Size = New System.Drawing.Size(264, 26)
+        Me.mnuTricotDescribeTraits.Size = New System.Drawing.Size(211, 22)
         Me.mnuTricotDescribeTraits.Text = "Traits..."
         '
         'mnuTricotDescribeCorrelations
         '
         Me.mnuTricotDescribeCorrelations.Name = "mnuTricotDescribeCorrelations"
-        Me.mnuTricotDescribeCorrelations.Size = New System.Drawing.Size(264, 26)
+        Me.mnuTricotDescribeCorrelations.Size = New System.Drawing.Size(211, 22)
         Me.mnuTricotDescribeCorrelations.Text = "Correlations..."
         '
         'mnuTricotModelPlackettLuce
         '
         Me.mnuTricotModelPlackettLuce.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuTricotModelWithoutCovariates, Me.mnuTricotModelTree, Me.mnuTricotModelOverall, Me.mnuTricotModelCharacterisation})
         Me.mnuTricotModelPlackettLuce.Name = "mnuTricotModelPlackettLuce"
-        Me.mnuTricotModelPlackettLuce.Size = New System.Drawing.Size(303, 26)
+        Me.mnuTricotModelPlackettLuce.Size = New System.Drawing.Size(244, 22)
         Me.mnuTricotModelPlackettLuce.Text = "Model (Plackett-Luce)"
         '
         'mnuTricotModelWithoutCovariates
         '
         Me.mnuTricotModelWithoutCovariates.Name = "mnuTricotModelWithoutCovariates"
-        Me.mnuTricotModelWithoutCovariates.Size = New System.Drawing.Size(252, 26)
+        Me.mnuTricotModelWithoutCovariates.Size = New System.Drawing.Size(203, 22)
         Me.mnuTricotModelWithoutCovariates.Text = "No Covariates..."
         '
         'mnuTricotModelTree
         '
         Me.mnuTricotModelTree.Name = "mnuTricotModelTree"
-        Me.mnuTricotModelTree.Size = New System.Drawing.Size(252, 26)
+        Me.mnuTricotModelTree.Size = New System.Drawing.Size(203, 22)
         Me.mnuTricotModelTree.Text = "Tree..."
         '
         'mnuTricotModelOverall
         '
         Me.mnuTricotModelOverall.Name = "mnuTricotModelOverall"
-        Me.mnuTricotModelOverall.Size = New System.Drawing.Size(252, 26)
+        Me.mnuTricotModelOverall.Size = New System.Drawing.Size(203, 22)
         Me.mnuTricotModelOverall.Text = "Model (One Covariate)..."
         '
         'mnuTricotModelCharacterisation
         '
         Me.mnuTricotModelCharacterisation.Name = "mnuTricotModelCharacterisation"
-        Me.mnuTricotModelCharacterisation.Size = New System.Drawing.Size(252, 26)
+        Me.mnuTricotModelCharacterisation.Size = New System.Drawing.Size(203, 22)
         Me.mnuTricotModelCharacterisation.Text = "Model (General)..."
         '
         'mnuTricotXp
         '
         Me.mnuTricotXp.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuItem3, Me.ToolStripSeparator89, Me.ToolStripMenuItem4, Me.ToolStripMenuItem2, Me.ToolStripMenuItem5, Me.ToolStripMenuItem6, Me.ToolStripSeparator84, Me.ToolStripMenuItem7, Me.ToolStripMenuItem10})
         Me.mnuTricotXp.Name = "mnuTricotXp"
-        Me.mnuTricotXp.Size = New System.Drawing.Size(77, 24)
+        Me.mnuTricotXp.Size = New System.Drawing.Size(63, 20)
         Me.mnuTricotXp.Text = "TricotXP"
         '
         'ToolStripMenuItem3
         '
         Me.ToolStripMenuItem3.Enabled = False
         Me.ToolStripMenuItem3.Name = "ToolStripMenuItem3"
-        Me.ToolStripMenuItem3.Size = New System.Drawing.Size(305, 26)
+        Me.ToolStripMenuItem3.Size = New System.Drawing.Size(246, 22)
         Me.ToolStripMenuItem3.Text = "Import from ClimMob..."
         '
         'ToolStripSeparator89
         '
         Me.ToolStripSeparator89.Name = "ToolStripSeparator89"
-        Me.ToolStripSeparator89.Size = New System.Drawing.Size(302, 6)
+        Me.ToolStripSeparator89.Size = New System.Drawing.Size(243, 6)
         '
         'ToolStripMenuItem4
         '
         Me.ToolStripMenuItem4.Enabled = False
         Me.ToolStripMenuItem4.Name = "ToolStripMenuItem4"
-        Me.ToolStripMenuItem4.Size = New System.Drawing.Size(305, 26)
+        Me.ToolStripMenuItem4.Size = New System.Drawing.Size(246, 22)
         Me.ToolStripMenuItem4.Text = "Examine Data"
         Me.ToolStripMenuItem4.TextAlign = System.Drawing.ContentAlignment.MiddleRight
         '
@@ -5045,14 +5045,14 @@ Partial Class frmMain
         '
         Me.ToolStripMenuItem2.Enabled = False
         Me.ToolStripMenuItem2.Name = "ToolStripMenuItem2"
-        Me.ToolStripMenuItem2.Size = New System.Drawing.Size(305, 26)
+        Me.ToolStripMenuItem2.Size = New System.Drawing.Size(246, 22)
         Me.ToolStripMenuItem2.Text = "Tidy Data"
         '
         'ToolStripMenuItem5
         '
         Me.ToolStripMenuItem5.Enabled = False
         Me.ToolStripMenuItem5.Name = "ToolStripMenuItem5"
-        Me.ToolStripMenuItem5.Size = New System.Drawing.Size(305, 26)
+        Me.ToolStripMenuItem5.Size = New System.Drawing.Size(246, 22)
         Me.ToolStripMenuItem5.Text = "Transform and Define As Tricot..."
         Me.ToolStripMenuItem5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
         '
@@ -5060,50 +5060,50 @@ Partial Class frmMain
         '
         Me.ToolStripMenuItem6.Enabled = False
         Me.ToolStripMenuItem6.Name = "ToolStripMenuItem6"
-        Me.ToolStripMenuItem6.Size = New System.Drawing.Size(305, 26)
+        Me.ToolStripMenuItem6.Size = New System.Drawing.Size(246, 22)
         Me.ToolStripMenuItem6.Text = "Define as Tricot..."
         '
         'ToolStripSeparator84
         '
         Me.ToolStripSeparator84.Name = "ToolStripSeparator84"
-        Me.ToolStripSeparator84.Size = New System.Drawing.Size(302, 6)
+        Me.ToolStripSeparator84.Size = New System.Drawing.Size(243, 6)
         '
         'ToolStripMenuItem7
         '
         Me.ToolStripMenuItem7.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuItem8, Me.ToolStripMenuItem15, Me.ToolStripSeparator90, Me.mnuTricotXpDescribeTraits, Me.mnuTricotXpDescribeTraitCorrelations})
         Me.ToolStripMenuItem7.Name = "ToolStripMenuItem7"
-        Me.ToolStripMenuItem7.Size = New System.Drawing.Size(305, 26)
+        Me.ToolStripMenuItem7.Size = New System.Drawing.Size(246, 22)
         Me.ToolStripMenuItem7.Text = "Describe"
         '
         'ToolStripMenuItem8
         '
         Me.ToolStripMenuItem8.Enabled = False
         Me.ToolStripMenuItem8.Name = "ToolStripMenuItem8"
-        Me.ToolStripMenuItem8.Size = New System.Drawing.Size(265, 26)
+        Me.ToolStripMenuItem8.Size = New System.Drawing.Size(211, 22)
         Me.ToolStripMenuItem8.Text = "Summarize 2/3 Variables..."
         '
         'ToolStripMenuItem15
         '
         Me.ToolStripMenuItem15.Enabled = False
         Me.ToolStripMenuItem15.Name = "ToolStripMenuItem15"
-        Me.ToolStripMenuItem15.Size = New System.Drawing.Size(265, 26)
+        Me.ToolStripMenuItem15.Size = New System.Drawing.Size(211, 22)
         Me.ToolStripMenuItem15.Text = "Graph 2/3 Variables..."
         '
         'ToolStripSeparator90
         '
         Me.ToolStripSeparator90.Name = "ToolStripSeparator90"
-        Me.ToolStripSeparator90.Size = New System.Drawing.Size(262, 6)
+        Me.ToolStripSeparator90.Size = New System.Drawing.Size(208, 6)
         '
         'mnuTricotXpDescribeTraits
         '
         Me.mnuTricotXpDescribeTraits.Name = "mnuTricotXpDescribeTraits"
-        Me.mnuTricotXpDescribeTraits.Size = New System.Drawing.Size(265, 26)
+        Me.mnuTricotXpDescribeTraits.Size = New System.Drawing.Size(211, 22)
         Me.mnuTricotXpDescribeTraits.Text = "Traits..."
         '
         'mnuTricotXpDescribeTraitCorrelations
         '
         Me.mnuTricotXpDescribeTraitCorrelations.Name = "mnuTricotXpDescribeTraitCorrelations"
-        Me.mnuTricotXpDescribeTraitCorrelations.Size = New System.Drawing.Size(265, 26)
+        Me.mnuTricotXpDescribeTraitCorrelations.Size = New System.Drawing.Size(211, 22)
         Me.mnuTricotXpDescribeTraitCorrelations.Text = "Correlations..."
         '
         'ToolStripMenuItem10
@@ -5111,515 +5111,514 @@ Partial Class frmMain
         Me.ToolStripMenuItem10.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuItem11, Me.ToolStripMenuItem12, Me.ToolStripMenuItem13, Me.ToolStripMenuItem14})
         Me.ToolStripMenuItem10.Enabled = False
         Me.ToolStripMenuItem10.Name = "ToolStripMenuItem10"
-        Me.ToolStripMenuItem10.Size = New System.Drawing.Size(305, 26)
+        Me.ToolStripMenuItem10.Size = New System.Drawing.Size(246, 22)
         Me.ToolStripMenuItem10.Text = "Model (Plackett-Luce)"
         '
         'ToolStripMenuItem11
         '
         Me.ToolStripMenuItem11.Name = "ToolStripMenuItem11"
-        Me.ToolStripMenuItem11.Size = New System.Drawing.Size(227, 26)
+        Me.ToolStripMenuItem11.Size = New System.Drawing.Size(184, 22)
         Me.ToolStripMenuItem11.Text = "Without Covariates..."
         '
         'ToolStripMenuItem12
         '
         Me.ToolStripMenuItem12.Name = "ToolStripMenuItem12"
-        Me.ToolStripMenuItem12.Size = New System.Drawing.Size(227, 26)
+        Me.ToolStripMenuItem12.Size = New System.Drawing.Size(184, 22)
         Me.ToolStripMenuItem12.Text = "Tree..."
         '
         'ToolStripMenuItem13
         '
         Me.ToolStripMenuItem13.Name = "ToolStripMenuItem13"
-        Me.ToolStripMenuItem13.Size = New System.Drawing.Size(227, 26)
+        Me.ToolStripMenuItem13.Size = New System.Drawing.Size(184, 22)
         Me.ToolStripMenuItem13.Text = "Overall..."
         '
         'ToolStripMenuItem14
         '
         Me.ToolStripMenuItem14.Name = "ToolStripMenuItem14"
-        Me.ToolStripMenuItem14.Size = New System.Drawing.Size(227, 26)
+        Me.ToolStripMenuItem14.Size = New System.Drawing.Size(184, 22)
         Me.ToolStripMenuItem14.Text = "Characterisation..."
         '
         'mnuOptionsByContext
         '
         Me.mnuOptionsByContext.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCheckData, Me.mnuOptionsByContextDefine, Me.mnuOptionsByContextPrepare, Me.mnuOptionsByContextDescribe, Me.mnuExperimentsDesign, Me.mnuOptionsByContextModel, Me.mnuOptionsByContextCropModel})
         Me.mnuOptionsByContext.Name = "mnuOptionsByContext"
-        Me.mnuOptionsByContext.Size = New System.Drawing.Size(104, 24)
+        Me.mnuOptionsByContext.Size = New System.Drawing.Size(83, 20)
         Me.mnuOptionsByContext.Text = "Experiments"
         '
         'mnuOptionsByContextCheckData
         '
         Me.mnuOptionsByContextCheckData.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCheckDataDuplicateRows, Me.mnuOptionsByContextCheckDataCompareColumns, Me.ToolStripSeparator47, Me.mnuOptionsByContextCheckDataOneVariableSummarise, Me.mnuOptionsByContextCheckDataOneVariableGraph, Me.mnuOptionsByContextCheckDataOneVariableFrequencies})
         Me.mnuOptionsByContextCheckData.Name = "mnuOptionsByContextCheckData"
-        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(224, 26)
+        Me.mnuOptionsByContextCheckData.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextCheckData.Text = "Check Data"
         '
         'mnuOptionsByContextCheckDataDuplicateRows
         '
         Me.mnuOptionsByContextCheckDataDuplicateRows.Name = "mnuOptionsByContextCheckDataDuplicateRows"
-        Me.mnuOptionsByContextCheckDataDuplicateRows.Size = New System.Drawing.Size(268, 26)
+        Me.mnuOptionsByContextCheckDataDuplicateRows.Size = New System.Drawing.Size(215, 22)
         Me.mnuOptionsByContextCheckDataDuplicateRows.Text = "Duplicate Rows..."
         '
         'mnuOptionsByContextCheckDataCompareColumns
         '
         Me.mnuOptionsByContextCheckDataCompareColumns.Name = "mnuOptionsByContextCheckDataCompareColumns"
-        Me.mnuOptionsByContextCheckDataCompareColumns.Size = New System.Drawing.Size(268, 26)
+        Me.mnuOptionsByContextCheckDataCompareColumns.Size = New System.Drawing.Size(215, 22)
         Me.mnuOptionsByContextCheckDataCompareColumns.Text = "Compare Columns..."
         '
         'ToolStripSeparator47
         '
         Me.ToolStripSeparator47.Name = "ToolStripSeparator47"
-        Me.ToolStripSeparator47.Size = New System.Drawing.Size(265, 6)
+        Me.ToolStripSeparator47.Size = New System.Drawing.Size(212, 6)
         '
         'mnuOptionsByContextCheckDataOneVariableSummarise
         '
         Me.mnuOptionsByContextCheckDataOneVariableSummarise.Name = "mnuOptionsByContextCheckDataOneVariableSummarise"
-        Me.mnuOptionsByContextCheckDataOneVariableSummarise.Size = New System.Drawing.Size(268, 26)
+        Me.mnuOptionsByContextCheckDataOneVariableSummarise.Size = New System.Drawing.Size(215, 22)
         Me.mnuOptionsByContextCheckDataOneVariableSummarise.Text = "One Variable Summarise..."
         '
         'mnuOptionsByContextCheckDataOneVariableGraph
         '
         Me.mnuOptionsByContextCheckDataOneVariableGraph.Name = "mnuOptionsByContextCheckDataOneVariableGraph"
-        Me.mnuOptionsByContextCheckDataOneVariableGraph.Size = New System.Drawing.Size(268, 26)
+        Me.mnuOptionsByContextCheckDataOneVariableGraph.Size = New System.Drawing.Size(215, 22)
         Me.mnuOptionsByContextCheckDataOneVariableGraph.Text = "One Variable Graph..."
         '
         'mnuOptionsByContextCheckDataOneVariableFrequencies
         '
         Me.mnuOptionsByContextCheckDataOneVariableFrequencies.Name = "mnuOptionsByContextCheckDataOneVariableFrequencies"
-        Me.mnuOptionsByContextCheckDataOneVariableFrequencies.Size = New System.Drawing.Size(268, 26)
+        Me.mnuOptionsByContextCheckDataOneVariableFrequencies.Size = New System.Drawing.Size(215, 22)
         Me.mnuOptionsByContextCheckDataOneVariableFrequencies.Text = "One Variable Frequencies..."
         '
         'mnuOptionsByContextDefine
         '
         Me.mnuOptionsByContextDefine.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDefineOnStation, Me.mnuOptionsByContextDefineOnFarm})
         Me.mnuOptionsByContextDefine.Name = "mnuOptionsByContextDefine"
-        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(224, 26)
+        Me.mnuOptionsByContextDefine.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextDefine.Text = "Define"
         '
         'mnuOptionsByContextDefineOnStation
         '
         Me.mnuOptionsByContextDefineOnStation.Name = "mnuOptionsByContextDefineOnStation"
-        Me.mnuOptionsByContextDefineOnStation.Size = New System.Drawing.Size(181, 26)
+        Me.mnuOptionsByContextDefineOnStation.Size = New System.Drawing.Size(147, 22)
         Me.mnuOptionsByContextDefineOnStation.Text = "On - Station..."
         '
         'mnuOptionsByContextDefineOnFarm
         '
         Me.mnuOptionsByContextDefineOnFarm.Name = "mnuOptionsByContextDefineOnFarm"
-        Me.mnuOptionsByContextDefineOnFarm.Size = New System.Drawing.Size(181, 26)
+        Me.mnuOptionsByContextDefineOnFarm.Size = New System.Drawing.Size(147, 22)
         Me.mnuOptionsByContextDefineOnFarm.Text = "On - Farm..."
         '
         'mnuOptionsByContextPrepare
         '
         Me.mnuOptionsByContextPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions, Me.ToolStripSeparator48, Me.mnuOptionsByContextMergeAdditionalData, Me.mnuOptionsByContextPrepareStack, Me.mnuOptionsByContextPrepareUnstack})
         Me.mnuOptionsByContextPrepare.Name = "mnuOptionsByContextPrepare"
-        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(224, 26)
+        Me.mnuOptionsByContextPrepare.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextPrepare.Text = "Prepare"
         '
         'mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions
         '
         Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions.Name = "mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions"
-        Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions.Size = New System.Drawing.Size(352, 26)
+        Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions.Size = New System.Drawing.Size(282, 22)
         Me.mnuOptionsByContextPrepareCalculateDIfferenceBetweenOptions.Text = "Calculate Difference Between Options..."
         '
         'ToolStripSeparator48
         '
         Me.ToolStripSeparator48.Name = "ToolStripSeparator48"
-        Me.ToolStripSeparator48.Size = New System.Drawing.Size(349, 6)
+        Me.ToolStripSeparator48.Size = New System.Drawing.Size(279, 6)
         '
         'mnuOptionsByContextMergeAdditionalData
         '
         Me.mnuOptionsByContextMergeAdditionalData.Name = "mnuOptionsByContextMergeAdditionalData"
-        Me.mnuOptionsByContextMergeAdditionalData.Size = New System.Drawing.Size(352, 26)
+        Me.mnuOptionsByContextMergeAdditionalData.Size = New System.Drawing.Size(282, 22)
         Me.mnuOptionsByContextMergeAdditionalData.Text = "Merge Additional Data..."
         '
         'mnuOptionsByContextPrepareStack
         '
         Me.mnuOptionsByContextPrepareStack.Name = "mnuOptionsByContextPrepareStack"
-        Me.mnuOptionsByContextPrepareStack.Size = New System.Drawing.Size(352, 26)
+        Me.mnuOptionsByContextPrepareStack.Size = New System.Drawing.Size(282, 22)
         Me.mnuOptionsByContextPrepareStack.Text = "Stack (Pivot Longer)..."
         '
         'mnuOptionsByContextPrepareUnstack
         '
         Me.mnuOptionsByContextPrepareUnstack.Name = "mnuOptionsByContextPrepareUnstack"
-        Me.mnuOptionsByContextPrepareUnstack.Size = New System.Drawing.Size(352, 26)
+        Me.mnuOptionsByContextPrepareUnstack.Size = New System.Drawing.Size(282, 22)
         Me.mnuOptionsByContextPrepareUnstack.Text = "Unstack (Pivot Wider)..."
         '
         'mnuOptionsByContextDescribe
         '
         Me.mnuOptionsByContextDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextDescribeCompareTwoTreatments, Me.mnuOptionsByContextDescribeCompareMultipleTreatments, Me.mnuOptionsByContextDescribeBoxplot})
         Me.mnuOptionsByContextDescribe.Name = "mnuOptionsByContextDescribe"
-        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(224, 26)
+        Me.mnuOptionsByContextDescribe.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextDescribe.Text = "Describe"
         '
         'mnuOptionsByContextDescribeCompareTwoTreatments
         '
         Me.mnuOptionsByContextDescribeCompareTwoTreatments.Name = "mnuOptionsByContextDescribeCompareTwoTreatments"
-        Me.mnuOptionsByContextDescribeCompareTwoTreatments.Size = New System.Drawing.Size(277, 26)
+        Me.mnuOptionsByContextDescribeCompareTwoTreatments.Size = New System.Drawing.Size(224, 22)
         Me.mnuOptionsByContextDescribeCompareTwoTreatments.Text = "Compare Two Options..."
         '
         'mnuOptionsByContextDescribeCompareMultipleTreatments
         '
         Me.mnuOptionsByContextDescribeCompareMultipleTreatments.Enabled = False
         Me.mnuOptionsByContextDescribeCompareMultipleTreatments.Name = "mnuOptionsByContextDescribeCompareMultipleTreatments"
-        Me.mnuOptionsByContextDescribeCompareMultipleTreatments.Size = New System.Drawing.Size(277, 26)
+        Me.mnuOptionsByContextDescribeCompareMultipleTreatments.Size = New System.Drawing.Size(224, 22)
         Me.mnuOptionsByContextDescribeCompareMultipleTreatments.Text = "Compare Multiple Options..."
         '
         'mnuOptionsByContextDescribeBoxplot
         '
         Me.mnuOptionsByContextDescribeBoxplot.Name = "mnuOptionsByContextDescribeBoxplot"
-        Me.mnuOptionsByContextDescribeBoxplot.Size = New System.Drawing.Size(277, 26)
+        Me.mnuOptionsByContextDescribeBoxplot.Size = New System.Drawing.Size(224, 22)
         Me.mnuOptionsByContextDescribeBoxplot.Text = "Boxplot..."
         '
         'mnuExperimentsDesign
         '
         Me.mnuExperimentsDesign.Enabled = False
         Me.mnuExperimentsDesign.Name = "mnuExperimentsDesign"
-        Me.mnuExperimentsDesign.Size = New System.Drawing.Size(224, 26)
+        Me.mnuExperimentsDesign.Size = New System.Drawing.Size(180, 22)
         Me.mnuExperimentsDesign.Text = "Design"
         '
         'mnuOptionsByContextModel
         '
         Me.mnuOptionsByContextModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextModelFitModel, Me.mnuOptionsByContextGeneralFitModel, Me.mnuExperimentsOneButton, Me.mnuMultipleComparisons})
         Me.mnuOptionsByContextModel.Name = "mnuOptionsByContextModel"
-        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(224, 26)
+        Me.mnuOptionsByContextModel.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextModel.Text = "Model"
         '
         'mnuOptionsByContextModelFitModel
         '
         Me.mnuOptionsByContextModelFitModel.Name = "mnuOptionsByContextModelFitModel"
-        Me.mnuOptionsByContextModelFitModel.Size = New System.Drawing.Size(246, 26)
+        Me.mnuOptionsByContextModelFitModel.Size = New System.Drawing.Size(200, 22)
         Me.mnuOptionsByContextModelFitModel.Text = "Fit Model..."
         '
         'mnuOptionsByContextGeneralFitModel
         '
         Me.mnuOptionsByContextGeneralFitModel.Name = "mnuOptionsByContextGeneralFitModel"
-        Me.mnuOptionsByContextGeneralFitModel.Size = New System.Drawing.Size(246, 26)
+        Me.mnuOptionsByContextGeneralFitModel.Size = New System.Drawing.Size(200, 22)
         Me.mnuOptionsByContextGeneralFitModel.Text = "General Fit Model..."
         '
         'mnuExperimentsOneButton
         '
-        Me.mnuExperimentsOneButton.Enabled = False
         Me.mnuExperimentsOneButton.Name = "mnuExperimentsOneButton"
-        Me.mnuExperimentsOneButton.Size = New System.Drawing.Size(246, 26)
+        Me.mnuExperimentsOneButton.Size = New System.Drawing.Size(200, 22)
         Me.mnuExperimentsOneButton.Text = "One Button..."
         '
         'mnuMultipleComparisons
         '
         Me.mnuMultipleComparisons.Enabled = False
         Me.mnuMultipleComparisons.Name = "mnuMultipleComparisons"
-        Me.mnuMultipleComparisons.Size = New System.Drawing.Size(246, 26)
+        Me.mnuMultipleComparisons.Size = New System.Drawing.Size(200, 22)
         Me.mnuMultipleComparisons.Text = "Multiple Comparisons..."
         '
         'mnuOptionsByContextCropModel
         '
         Me.mnuOptionsByContextCropModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuOptionsByContextCropModelApsimxExamples})
         Me.mnuOptionsByContextCropModel.Name = "mnuOptionsByContextCropModel"
-        Me.mnuOptionsByContextCropModel.Size = New System.Drawing.Size(224, 26)
+        Me.mnuOptionsByContextCropModel.Size = New System.Drawing.Size(180, 22)
         Me.mnuOptionsByContextCropModel.Text = "Crop Model"
         '
         'mnuOptionsByContextCropModelApsimxExamples
         '
         Me.mnuOptionsByContextCropModelApsimxExamples.Name = "mnuOptionsByContextCropModelApsimxExamples"
-        Me.mnuOptionsByContextCropModelApsimxExamples.Size = New System.Drawing.Size(217, 26)
+        Me.mnuOptionsByContextCropModelApsimxExamples.Size = New System.Drawing.Size(174, 22)
         Me.mnuOptionsByContextCropModelApsimxExamples.Text = "Apsimx Examples..."
         '
         'mnuProcurement
         '
         Me.mnuProcurement.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementOpenFromLibrary, Me.mnuProcurementDefineData, Me.mnuProcurementPrepare, Me.mnuProcurementDescribe, Me.mnuProcurementMapping, Me.mnuProcurementModel, Me.ToolStripSeparator45, Me.mnuProcurementDefineRedFlags, Me.mnuProcurementUseCRI})
         Me.mnuProcurement.Name = "mnuProcurement"
-        Me.mnuProcurement.Size = New System.Drawing.Size(107, 24)
+        Me.mnuProcurement.Size = New System.Drawing.Size(88, 20)
         Me.mnuProcurement.Text = "Procurement"
         '
         'mnuProcurementOpenFromLibrary
         '
         Me.mnuProcurementOpenFromLibrary.Name = "mnuProcurementOpenFromLibrary"
-        Me.mnuProcurementOpenFromLibrary.Size = New System.Drawing.Size(271, 26)
+        Me.mnuProcurementOpenFromLibrary.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementOpenFromLibrary.Text = "Open From Library..."
         '
         'mnuProcurementDefineData
         '
         Me.mnuProcurementDefineData.Name = "mnuProcurementDefineData"
-        Me.mnuProcurementDefineData.Size = New System.Drawing.Size(271, 26)
+        Me.mnuProcurementDefineData.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementDefineData.Text = "Define Procurement Data..."
         '
         'mnuProcurementPrepare
         '
         Me.mnuProcurementPrepare.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementPrepareFilterByCountry, Me.ToolStripSeparator42, Me.mnuProcurementPrepareDefineContractValueCategories, Me.mnuProcurementPrepareRecodeNumericIntoQuantiles, Me.mnuProcurementPrepareSetFactorReferenceLevel, Me.mnuProcurementPrepareUseAwardDate, Me.ToolStripSeparator43, Me.mnuProcurementPrepareSummariseRedFlagsByCountryorOther, Me.mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther, Me.mnuProcurementPrepareMergeAdditionalData})
         Me.mnuProcurementPrepare.Name = "mnuProcurementPrepare"
-        Me.mnuProcurementPrepare.Size = New System.Drawing.Size(271, 26)
+        Me.mnuProcurementPrepare.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementPrepare.Text = "Prepare"
         '
         'mnuProcurementPrepareFilterByCountry
         '
         Me.mnuProcurementPrepareFilterByCountry.Name = "mnuProcurementPrepareFilterByCountry"
-        Me.mnuProcurementPrepareFilterByCountry.Size = New System.Drawing.Size(445, 26)
+        Me.mnuProcurementPrepareFilterByCountry.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareFilterByCountry.Text = "Filter by Country (or other)..."
         '
         'ToolStripSeparator42
         '
         Me.ToolStripSeparator42.Name = "ToolStripSeparator42"
-        Me.ToolStripSeparator42.Size = New System.Drawing.Size(442, 6)
+        Me.ToolStripSeparator42.Size = New System.Drawing.Size(355, 6)
         '
         'mnuProcurementPrepareDefineContractValueCategories
         '
         Me.mnuProcurementPrepareDefineContractValueCategories.Name = "mnuProcurementPrepareDefineContractValueCategories"
-        Me.mnuProcurementPrepareDefineContractValueCategories.Size = New System.Drawing.Size(445, 26)
+        Me.mnuProcurementPrepareDefineContractValueCategories.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareDefineContractValueCategories.Text = "Define Contract Value Categories..."
         '
         'mnuProcurementPrepareRecodeNumericIntoQuantiles
         '
         Me.mnuProcurementPrepareRecodeNumericIntoQuantiles.Name = "mnuProcurementPrepareRecodeNumericIntoQuantiles"
-        Me.mnuProcurementPrepareRecodeNumericIntoQuantiles.Size = New System.Drawing.Size(445, 26)
+        Me.mnuProcurementPrepareRecodeNumericIntoQuantiles.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareRecodeNumericIntoQuantiles.Text = "Recode Numeric into Quantiles..."
         '
         'mnuProcurementPrepareSetFactorReferenceLevel
         '
         Me.mnuProcurementPrepareSetFactorReferenceLevel.Name = "mnuProcurementPrepareSetFactorReferenceLevel"
-        Me.mnuProcurementPrepareSetFactorReferenceLevel.Size = New System.Drawing.Size(445, 26)
+        Me.mnuProcurementPrepareSetFactorReferenceLevel.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareSetFactorReferenceLevel.Text = "Set Factor Reference Level..."
         '
         'mnuProcurementPrepareUseAwardDate
         '
         Me.mnuProcurementPrepareUseAwardDate.Name = "mnuProcurementPrepareUseAwardDate"
-        Me.mnuProcurementPrepareUseAwardDate.Size = New System.Drawing.Size(445, 26)
+        Me.mnuProcurementPrepareUseAwardDate.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareUseAwardDate.Text = "Use Award Date (or other)..."
         '
         'ToolStripSeparator43
         '
         Me.ToolStripSeparator43.Name = "ToolStripSeparator43"
-        Me.ToolStripSeparator43.Size = New System.Drawing.Size(442, 6)
+        Me.ToolStripSeparator43.Size = New System.Drawing.Size(355, 6)
         '
         'mnuProcurementPrepareSummariseRedFlagsByCountryorOther
         '
         Me.mnuProcurementPrepareSummariseRedFlagsByCountryorOther.Name = "mnuProcurementPrepareSummariseRedFlagsByCountryorOther"
-        Me.mnuProcurementPrepareSummariseRedFlagsByCountryorOther.Size = New System.Drawing.Size(445, 26)
+        Me.mnuProcurementPrepareSummariseRedFlagsByCountryorOther.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareSummariseRedFlagsByCountryorOther.Text = "Summarise Red Flags by Country (or other)..."
         '
         'mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther
         '
         Me.mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther.Name = "mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther"
-        Me.mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther.Size = New System.Drawing.Size(445, 26)
+        Me.mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareSummariseRedFlagsByCountryAndYearorOther.Text = "Summarise Red Flags by Country and Year (or other)..."
         '
         'mnuProcurementPrepareMergeAdditionalData
         '
         Me.mnuProcurementPrepareMergeAdditionalData.Name = "mnuProcurementPrepareMergeAdditionalData"
-        Me.mnuProcurementPrepareMergeAdditionalData.Size = New System.Drawing.Size(445, 26)
+        Me.mnuProcurementPrepareMergeAdditionalData.Size = New System.Drawing.Size(358, 22)
         Me.mnuProcurementPrepareMergeAdditionalData.Text = "Merge Additional Data..."
         '
         'mnuProcurementDescribe
         '
         Me.mnuProcurementDescribe.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementDescribeOneVariableSummarise, Me.mnuProcurementDescribeOneVariableGraph, Me.ToolStripSeparator44, Me.mnuProcurementDescribeCategorical, Me.mnuProcurementDescribeNumeric})
         Me.mnuProcurementDescribe.Name = "mnuProcurementDescribe"
-        Me.mnuProcurementDescribe.Size = New System.Drawing.Size(271, 26)
+        Me.mnuProcurementDescribe.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementDescribe.Text = "Describe"
         '
         'mnuProcurementDescribeOneVariableSummarise
         '
         Me.mnuProcurementDescribeOneVariableSummarise.Name = "mnuProcurementDescribeOneVariableSummarise"
-        Me.mnuProcurementDescribeOneVariableSummarise.Size = New System.Drawing.Size(263, 26)
+        Me.mnuProcurementDescribeOneVariableSummarise.Size = New System.Drawing.Size(211, 22)
         Me.mnuProcurementDescribeOneVariableSummarise.Text = "One Variable Summarise..."
         '
         'mnuProcurementDescribeOneVariableGraph
         '
         Me.mnuProcurementDescribeOneVariableGraph.Name = "mnuProcurementDescribeOneVariableGraph"
-        Me.mnuProcurementDescribeOneVariableGraph.Size = New System.Drawing.Size(263, 26)
+        Me.mnuProcurementDescribeOneVariableGraph.Size = New System.Drawing.Size(211, 22)
         Me.mnuProcurementDescribeOneVariableGraph.Text = "One Variable Graph..."
         '
         'ToolStripSeparator44
         '
         Me.ToolStripSeparator44.Name = "ToolStripSeparator44"
-        Me.ToolStripSeparator44.Size = New System.Drawing.Size(260, 6)
+        Me.ToolStripSeparator44.Size = New System.Drawing.Size(208, 6)
         '
         'mnuProcurementDescribeCategorical
         '
         Me.mnuProcurementDescribeCategorical.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementDescribeCategoricalOneVarFreq, Me.mnuProcurementDescribeCategoricalTwoVarFreq, Me.ToolStripSeparator52, Me.mnuProcurementDescribeCategoricalBarCharts, Me.mnuProcurementDescribeCategoricalMosaic, Me.mnuProcurementDescribeCategoricalTreemap, Me.DisplayTopNToolStripMenuItem})
         Me.mnuProcurementDescribeCategorical.Name = "mnuProcurementDescribeCategorical"
-        Me.mnuProcurementDescribeCategorical.Size = New System.Drawing.Size(263, 26)
+        Me.mnuProcurementDescribeCategorical.Size = New System.Drawing.Size(211, 22)
         Me.mnuProcurementDescribeCategorical.Text = "Categorical"
         '
         'mnuProcurementDescribeCategoricalOneVarFreq
         '
         Me.mnuProcurementDescribeCategoricalOneVarFreq.Name = "mnuProcurementDescribeCategoricalOneVarFreq"
-        Me.mnuProcurementDescribeCategoricalOneVarFreq.Size = New System.Drawing.Size(401, 26)
+        Me.mnuProcurementDescribeCategoricalOneVarFreq.Size = New System.Drawing.Size(320, 22)
         Me.mnuProcurementDescribeCategoricalOneVarFreq.Text = "One Variable Frequencies..."
         '
         'mnuProcurementDescribeCategoricalTwoVarFreq
         '
         Me.mnuProcurementDescribeCategoricalTwoVarFreq.Name = "mnuProcurementDescribeCategoricalTwoVarFreq"
-        Me.mnuProcurementDescribeCategoricalTwoVarFreq.Size = New System.Drawing.Size(401, 26)
+        Me.mnuProcurementDescribeCategoricalTwoVarFreq.Size = New System.Drawing.Size(320, 22)
         Me.mnuProcurementDescribeCategoricalTwoVarFreq.Text = "Two Variable Frequencies by Sector (or other)..."
         '
         'ToolStripSeparator52
         '
         Me.ToolStripSeparator52.Name = "ToolStripSeparator52"
-        Me.ToolStripSeparator52.Size = New System.Drawing.Size(398, 6)
+        Me.ToolStripSeparator52.Size = New System.Drawing.Size(317, 6)
         '
         'mnuProcurementDescribeCategoricalBarCharts
         '
         Me.mnuProcurementDescribeCategoricalBarCharts.Name = "mnuProcurementDescribeCategoricalBarCharts"
-        Me.mnuProcurementDescribeCategoricalBarCharts.Size = New System.Drawing.Size(401, 26)
+        Me.mnuProcurementDescribeCategoricalBarCharts.Size = New System.Drawing.Size(320, 22)
         Me.mnuProcurementDescribeCategoricalBarCharts.Text = "Bar Chart..."
         '
         'mnuProcurementDescribeCategoricalMosaic
         '
         Me.mnuProcurementDescribeCategoricalMosaic.Name = "mnuProcurementDescribeCategoricalMosaic"
-        Me.mnuProcurementDescribeCategoricalMosaic.Size = New System.Drawing.Size(401, 26)
+        Me.mnuProcurementDescribeCategoricalMosaic.Size = New System.Drawing.Size(320, 22)
         Me.mnuProcurementDescribeCategoricalMosaic.Text = "Mosaic Plot..."
         '
         'mnuProcurementDescribeCategoricalTreemap
         '
         Me.mnuProcurementDescribeCategoricalTreemap.Name = "mnuProcurementDescribeCategoricalTreemap"
-        Me.mnuProcurementDescribeCategoricalTreemap.Size = New System.Drawing.Size(401, 26)
+        Me.mnuProcurementDescribeCategoricalTreemap.Size = New System.Drawing.Size(320, 22)
         Me.mnuProcurementDescribeCategoricalTreemap.Text = "Treemap..."
         '
         'DisplayTopNToolStripMenuItem
         '
         Me.DisplayTopNToolStripMenuItem.Name = "DisplayTopNToolStripMenuItem"
-        Me.DisplayTopNToolStripMenuItem.Size = New System.Drawing.Size(401, 26)
+        Me.DisplayTopNToolStripMenuItem.Size = New System.Drawing.Size(320, 22)
         Me.DisplayTopNToolStripMenuItem.Text = "Display Top N..."
         '
         'mnuProcurementDescribeNumeric
         '
         Me.mnuProcurementDescribeNumeric.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementDescribeNumericBoxplot, Me.HistogramToolStripMenuItem, Me.ToolStripSeparator53, Me.mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers})
         Me.mnuProcurementDescribeNumeric.Name = "mnuProcurementDescribeNumeric"
-        Me.mnuProcurementDescribeNumeric.Size = New System.Drawing.Size(263, 26)
+        Me.mnuProcurementDescribeNumeric.Size = New System.Drawing.Size(211, 22)
         Me.mnuProcurementDescribeNumeric.Text = "Numeric"
         '
         'mnuProcurementDescribeNumericBoxplot
         '
         Me.mnuProcurementDescribeNumericBoxplot.Name = "mnuProcurementDescribeNumericBoxplot"
-        Me.mnuProcurementDescribeNumericBoxplot.Size = New System.Drawing.Size(322, 26)
+        Me.mnuProcurementDescribeNumericBoxplot.Size = New System.Drawing.Size(258, 22)
         Me.mnuProcurementDescribeNumericBoxplot.Text = "Boxplot..."
         '
         'HistogramToolStripMenuItem
         '
         Me.HistogramToolStripMenuItem.Name = "HistogramToolStripMenuItem"
-        Me.HistogramToolStripMenuItem.Size = New System.Drawing.Size(322, 26)
+        Me.HistogramToolStripMenuItem.Size = New System.Drawing.Size(258, 22)
         Me.HistogramToolStripMenuItem.Text = "Histogram..."
         '
         'ToolStripSeparator53
         '
         Me.ToolStripSeparator53.Name = "ToolStripSeparator53"
-        Me.ToolStripSeparator53.Size = New System.Drawing.Size(319, 6)
+        Me.ToolStripSeparator53.Size = New System.Drawing.Size(255, 6)
         '
         'mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers
         '
         Me.mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers.Name = "mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers"
-        Me.mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers.Size = New System.Drawing.Size(322, 26)
+        Me.mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers.Size = New System.Drawing.Size(258, 22)
         Me.mnuProcurementDescribeNumericCorrelationsRedFlagsOrOthers.Text = "Correlations (Red Flags or others)..."
         '
         'mnuProcurementMapping
         '
         Me.mnuProcurementMapping.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementMappingMapCountryValues})
         Me.mnuProcurementMapping.Name = "mnuProcurementMapping"
-        Me.mnuProcurementMapping.Size = New System.Drawing.Size(271, 26)
+        Me.mnuProcurementMapping.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementMapping.Text = "Mapping"
         '
         'mnuProcurementMappingMapCountryValues
         '
         Me.mnuProcurementMappingMapCountryValues.Name = "mnuProcurementMappingMapCountryValues"
-        Me.mnuProcurementMappingMapCountryValues.Size = New System.Drawing.Size(232, 26)
+        Me.mnuProcurementMappingMapCountryValues.Size = New System.Drawing.Size(189, 22)
         Me.mnuProcurementMappingMapCountryValues.Text = "Map Country Values..."
         '
         'mnuProcurementModel
         '
         Me.mnuProcurementModel.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementModelDefineCorruption, Me.mnuProcurementModelFitModelToolStripMenuItem})
         Me.mnuProcurementModel.Name = "mnuProcurementModel"
-        Me.mnuProcurementModel.Size = New System.Drawing.Size(271, 26)
+        Me.mnuProcurementModel.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementModel.Text = "Model"
         '
         'mnuProcurementModelDefineCorruption
         '
         Me.mnuProcurementModelDefineCorruption.Name = "mnuProcurementModelDefineCorruption"
-        Me.mnuProcurementModelDefineCorruption.Size = New System.Drawing.Size(289, 26)
+        Me.mnuProcurementModelDefineCorruption.Size = New System.Drawing.Size(233, 22)
         Me.mnuProcurementModelDefineCorruption.Text = "Define Corruption Indicators..."
         '
         'mnuProcurementModelFitModelToolStripMenuItem
         '
         Me.mnuProcurementModelFitModelToolStripMenuItem.Name = "mnuProcurementModelFitModelToolStripMenuItem"
-        Me.mnuProcurementModelFitModelToolStripMenuItem.Size = New System.Drawing.Size(289, 26)
+        Me.mnuProcurementModelFitModelToolStripMenuItem.Size = New System.Drawing.Size(233, 22)
         Me.mnuProcurementModelFitModelToolStripMenuItem.Text = "Fit Model..."
         '
         'ToolStripSeparator45
         '
         Me.ToolStripSeparator45.Name = "ToolStripSeparator45"
-        Me.ToolStripSeparator45.Size = New System.Drawing.Size(268, 6)
+        Me.ToolStripSeparator45.Size = New System.Drawing.Size(213, 6)
         '
         'mnuProcurementDefineRedFlags
         '
         Me.mnuProcurementDefineRedFlags.Name = "mnuProcurementDefineRedFlags"
-        Me.mnuProcurementDefineRedFlags.Size = New System.Drawing.Size(271, 26)
+        Me.mnuProcurementDefineRedFlags.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementDefineRedFlags.Text = "Define Red Flag Variables..."
         '
         'mnuProcurementUseCRI
         '
         Me.mnuProcurementUseCRI.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuProcurementCTFVCalculateCRI, Me.mnuProcurementUseCRISummariseCRIbyCountry})
         Me.mnuProcurementUseCRI.Name = "mnuProcurementUseCRI"
-        Me.mnuProcurementUseCRI.Size = New System.Drawing.Size(271, 26)
+        Me.mnuProcurementUseCRI.Size = New System.Drawing.Size(216, 22)
         Me.mnuProcurementUseCRI.Text = "Corruption Risk Index (CRI)"
         '
         'mnuProcurementCTFVCalculateCRI
         '
         Me.mnuProcurementCTFVCalculateCRI.Name = "mnuProcurementCTFVCalculateCRI"
-        Me.mnuProcurementCTFVCalculateCRI.Size = New System.Drawing.Size(342, 26)
+        Me.mnuProcurementCTFVCalculateCRI.Size = New System.Drawing.Size(278, 22)
         Me.mnuProcurementCTFVCalculateCRI.Text = "Define Corruption Risk Index (CRI)..."
         '
         'mnuProcurementUseCRISummariseCRIbyCountry
         '
         Me.mnuProcurementUseCRISummariseCRIbyCountry.Name = "mnuProcurementUseCRISummariseCRIbyCountry"
-        Me.mnuProcurementUseCRISummariseCRIbyCountry.Size = New System.Drawing.Size(342, 26)
+        Me.mnuProcurementUseCRISummariseCRIbyCountry.Size = New System.Drawing.Size(278, 22)
         Me.mnuProcurementUseCRISummariseCRIbyCountry.Text = "Summarise CRI by Country (or other)..."
         '
         'mnuTools
         '
         Me.mnuTools.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.mnuToolsRestartR, Me.mnuToolsCheckForUpdates, Me.mnuToolsClearOutputWindow, Me.ToolStripSeparator5, Me.mnuToolsRestoreBackup, Me.mnuToolsInstallRPackage, Me.mnuToolsOptions})
         Me.mnuTools.Name = "mnuTools"
-        Me.mnuTools.Size = New System.Drawing.Size(58, 24)
+        Me.mnuTools.Size = New System.Drawing.Size(47, 20)
         Me.mnuTools.Text = "Tools"
         '
         'mnuToolsRestartR
         '
         Me.mnuToolsRestartR.Enabled = False
         Me.mnuToolsRestartR.Name = "mnuToolsRestartR"
-        Me.mnuToolsRestartR.Size = New System.Drawing.Size(270, 26)
+        Me.mnuToolsRestartR.Size = New System.Drawing.Size(217, 22)
         Me.mnuToolsRestartR.Tag = "Restart_R"
         Me.mnuToolsRestartR.Text = "Restart R"
         '
         'mnuToolsCheckForUpdates
         '
         Me.mnuToolsCheckForUpdates.Name = "mnuToolsCheckForUpdates"
-        Me.mnuToolsCheckForUpdates.Size = New System.Drawing.Size(270, 26)
+        Me.mnuToolsCheckForUpdates.Size = New System.Drawing.Size(217, 22)
         Me.mnuToolsCheckForUpdates.Tag = "Check_for_Updates (Online)"
         Me.mnuToolsCheckForUpdates.Text = "Check for Updates (Online)"
         '
         'mnuToolsClearOutputWindow
         '
         Me.mnuToolsClearOutputWindow.Name = "mnuToolsClearOutputWindow"
-        Me.mnuToolsClearOutputWindow.Size = New System.Drawing.Size(270, 26)
+        Me.mnuToolsClearOutputWindow.Size = New System.Drawing.Size(217, 22)
         Me.mnuToolsClearOutputWindow.Tag = "Clear_Output_Window..."
         Me.mnuToolsClearOutputWindow.Text = "Clear Output Window..."
         '
         'ToolStripSeparator5
         '
         Me.ToolStripSeparator5.Name = "ToolStripSeparator5"
-        Me.ToolStripSeparator5.Size = New System.Drawing.Size(267, 6)
+        Me.ToolStripSeparator5.Size = New System.Drawing.Size(214, 6)
         '
         'mnuToolsRestoreBackup
         '
         Me.mnuToolsRestoreBackup.Name = "mnuToolsRestoreBackup"
-        Me.mnuToolsRestoreBackup.Size = New System.Drawing.Size(270, 26)
+        Me.mnuToolsRestoreBackup.Size = New System.Drawing.Size(217, 22)
         Me.mnuToolsRestoreBackup.Tag = "Load_Options..."
         Me.mnuToolsRestoreBackup.Text = "Restore Backup..."
         '
         'mnuToolsInstallRPackage
         '
         Me.mnuToolsInstallRPackage.Name = "mnuToolsInstallRPackage"
-        Me.mnuToolsInstallRPackage.Size = New System.Drawing.Size(270, 26)
+        Me.mnuToolsInstallRPackage.Size = New System.Drawing.Size(217, 22)
         Me.mnuToolsInstallRPackage.Text = "Install R Package... (Online)"
         '
         'mnuToolsOptions
         '
         Me.mnuToolsOptions.Name = "mnuToolsOptions"
-        Me.mnuToolsOptions.Size = New System.Drawing.Size(270, 26)
+        Me.mnuToolsOptions.Size = New System.Drawing.Size(217, 22)
         Me.mnuToolsOptions.Tag = "Options..."
         Me.mnuToolsOptions.Text = "Options..."
         '
@@ -5639,7 +5638,7 @@ Partial Class frmMain
         '
         Me.splOverall.BackColor = System.Drawing.Color.LightGray
         Me.splOverall.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.splOverall.Location = New System.Drawing.Point(0, 65)
+        Me.splOverall.Location = New System.Drawing.Point(0, 61)
         Me.splOverall.Margin = New System.Windows.Forms.Padding(2)
         Me.splOverall.Name = "splOverall"
         Me.splOverall.Orientation = System.Windows.Forms.Orientation.Horizontal
@@ -5653,9 +5652,9 @@ Partial Class frmMain
         '
         Me.splOverall.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splOverall.Panel2.Controls.Add(Me.splDataOutput)
-        Me.splOverall.Size = New System.Drawing.Size(1000, 486)
-        Me.splOverall.SplitterDistance = 177
-        Me.splOverall.SplitterWidth = 8
+        Me.splOverall.Size = New System.Drawing.Size(800, 379)
+        Me.splOverall.SplitterDistance = 138
+        Me.splOverall.SplitterWidth = 6
         Me.splOverall.TabIndex = 10
         '
         'splExtraWindows
@@ -5675,9 +5674,9 @@ Partial Class frmMain
         '
         Me.splExtraWindows.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splExtraWindows.Panel2.Controls.Add(Me.ucrScriptWindow)
-        Me.splExtraWindows.Size = New System.Drawing.Size(1000, 177)
-        Me.splExtraWindows.SplitterDistance = 300
-        Me.splExtraWindows.SplitterWidth = 8
+        Me.splExtraWindows.Size = New System.Drawing.Size(800, 138)
+        Me.splExtraWindows.SplitterDistance = 240
+        Me.splExtraWindows.SplitterWidth = 6
         Me.splExtraWindows.TabIndex = 0
         '
         'splMetadata
@@ -5696,9 +5695,9 @@ Partial Class frmMain
         '
         Me.splMetadata.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splMetadata.Panel2.Controls.Add(Me.ucrDataFrameMeta)
-        Me.splMetadata.Size = New System.Drawing.Size(300, 177)
-        Me.splMetadata.SplitterDistance = 75
-        Me.splMetadata.SplitterWidth = 8
+        Me.splMetadata.Size = New System.Drawing.Size(240, 138)
+        Me.splMetadata.SplitterDistance = 60
+        Me.splMetadata.SplitterWidth = 6
         Me.splMetadata.TabIndex = 0
         '
         'ucrColumnMeta
@@ -5709,9 +5708,9 @@ Partial Class frmMain
         Me.ucrColumnMeta.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrColumnMeta.IsEnabled = False
         Me.ucrColumnMeta.Location = New System.Drawing.Point(0, 0)
-        Me.ucrColumnMeta.Margin = New System.Windows.Forms.Padding(5, 8, 5, 8)
+        Me.ucrColumnMeta.Margin = New System.Windows.Forms.Padding(4, 6, 4, 6)
         Me.ucrColumnMeta.Name = "ucrColumnMeta"
-        Me.ucrColumnMeta.Size = New System.Drawing.Size(75, 177)
+        Me.ucrColumnMeta.Size = New System.Drawing.Size(60, 138)
         Me.ucrColumnMeta.TabIndex = 0
         '
         'ucrDataFrameMeta
@@ -5720,9 +5719,9 @@ Partial Class frmMain
         Me.ucrDataFrameMeta.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
         Me.ucrDataFrameMeta.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrDataFrameMeta.Location = New System.Drawing.Point(0, 0)
-        Me.ucrDataFrameMeta.Margin = New System.Windows.Forms.Padding(5, 8, 5, 8)
+        Me.ucrDataFrameMeta.Margin = New System.Windows.Forms.Padding(4, 6, 4, 6)
         Me.ucrDataFrameMeta.Name = "ucrDataFrameMeta"
-        Me.ucrDataFrameMeta.Size = New System.Drawing.Size(217, 177)
+        Me.ucrDataFrameMeta.Size = New System.Drawing.Size(174, 138)
         Me.ucrDataFrameMeta.TabIndex = 0
         '
         'ucrScriptWindow
@@ -5731,9 +5730,9 @@ Partial Class frmMain
         Me.ucrScriptWindow.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
         Me.ucrScriptWindow.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrScriptWindow.Location = New System.Drawing.Point(0, 0)
-        Me.ucrScriptWindow.Margin = New System.Windows.Forms.Padding(5, 8, 5, 8)
+        Me.ucrScriptWindow.Margin = New System.Windows.Forms.Padding(4, 6, 4, 6)
         Me.ucrScriptWindow.Name = "ucrScriptWindow"
-        Me.ucrScriptWindow.Size = New System.Drawing.Size(692, 177)
+        Me.ucrScriptWindow.Size = New System.Drawing.Size(554, 138)
         Me.ucrScriptWindow.strActiveTabText = ""
         Me.ucrScriptWindow.TabIndex = 2
         Me.ucrScriptWindow.Tag = "Script_Window"
@@ -5755,9 +5754,9 @@ Partial Class frmMain
         '
         Me.splDataOutput.Panel2.BackColor = System.Drawing.SystemColors.Control
         Me.splDataOutput.Panel2.Controls.Add(Me.ucrOutput)
-        Me.splDataOutput.Size = New System.Drawing.Size(1000, 301)
-        Me.splDataOutput.SplitterDistance = 450
-        Me.splDataOutput.SplitterWidth = 8
+        Me.splDataOutput.Size = New System.Drawing.Size(800, 235)
+        Me.splDataOutput.SplitterDistance = 360
+        Me.splDataOutput.SplitterWidth = 6
         Me.splDataOutput.TabIndex = 0
         '
         'ucrDataViewer
@@ -5767,9 +5766,9 @@ Partial Class frmMain
         Me.ucrDataViewer.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
         Me.ucrDataViewer.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrDataViewer.Location = New System.Drawing.Point(0, 0)
-        Me.ucrDataViewer.Margin = New System.Windows.Forms.Padding(5, 8, 5, 8)
+        Me.ucrDataViewer.Margin = New System.Windows.Forms.Padding(4, 6, 4, 6)
         Me.ucrDataViewer.Name = "ucrDataViewer"
-        Me.ucrDataViewer.Size = New System.Drawing.Size(450, 301)
+        Me.ucrDataViewer.Size = New System.Drawing.Size(360, 235)
         Me.ucrDataViewer.TabIndex = 0
         Me.ucrDataViewer.Tag = "Data_View"
         '
@@ -5779,9 +5778,9 @@ Partial Class frmMain
         Me.ucrOutput.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
         Me.ucrOutput.Dock = System.Windows.Forms.DockStyle.Fill
         Me.ucrOutput.Location = New System.Drawing.Point(0, 0)
-        Me.ucrOutput.Margin = New System.Windows.Forms.Padding(5, 8, 5, 8)
+        Me.ucrOutput.Margin = New System.Windows.Forms.Padding(4, 6, 4, 6)
         Me.ucrOutput.Name = "ucrOutput"
-        Me.ucrOutput.Size = New System.Drawing.Size(542, 301)
+        Me.ucrOutput.Size = New System.Drawing.Size(434, 235)
         Me.ucrOutput.TabIndex = 0
         '
         'mnuPlotly
@@ -5827,9 +5826,9 @@ Partial Class frmMain
         '
         'frmMain
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(120.0!, 120.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
-        Me.ClientSize = New System.Drawing.Size(1000, 577)
+        Me.ClientSize = New System.Drawing.Size(800, 462)
         Me.Controls.Add(Me.splOverall)
         Me.Controls.Add(Me.stsStrip)
         Me.Controls.Add(Me.Tool_strip)

--- a/instat/frmMain.resx
+++ b/instat/frmMain.resx
@@ -136,7 +136,7 @@
   <data name="mnuLastGraph.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAASDSURBVEhLvZd/TBtlGMdPE/ePM4txOGBsRreiBOhPWlqg
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAASDSURBVEhLvZd/TBtlGMdPE/ePM4txOGBsRreiBOhPWlqg
         QIFhtqGMyBIWMxPNlqh/zJkYjHEmaiDVJSyTkGUUF0OiiQPDMtlctuGcM3MDSmlhI4FQ2OJglMKgP7je
         lV6/5t5Cy11pwQh8/rm753nf+977vM/7vO9RWGBikoO1bx5AcNG0rlCLN3XfuaHINW+88IXfaGQX9Qq9
         6wgRdrkD2F8yhKwcy8aOeNzBIi35CmRZ6xVqPnc4gSUc6uEpGnmlfQLn/yeI5vNuZL10EwVF9+BjmLCH
@@ -162,7 +162,7 @@
   <data name="mnuMetadata.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAG8AAABvCAYAAADixZ5gAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAlGSURBVHhe7V1La1VXGD0RhFbwBTGodCL4gD4sFCTE1x9w
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAlGSURBVHhe7V1La1VXGD0RhFbwBTGodCL4gD4sFCTE1x9w
         oJhQO6+aUC06Ep10oJhJO2ixFIpaRaG2Kn0MrLU6sFJLO5HEDPpAW1rpRBNNxCQ3RrPLOu01N9/e997v
         O3vvc/dOzoIFNX7nW99ey+bec+4+5yaqQLRI6A8KxIMivIhRhBcxivAiRhFexCjCixhFeBEjU3ijo6Oq
         s7NTNTU1qSRJCmYk/IOP8DMLxOE9ePBAtbW1aYMUzE74ef/+fWp1XYjCGxkZUa2trZp4QXvC1+HhYWp5

--- a/instat/translations/en/r_instat_not_menus.json
+++ b/instat/translations/en/r_instat_not_menus.json
@@ -6917,5 +6917,15 @@
   "One Button": "One Button",
   "Multiple Comparisons": "Multiple Comparisons",
   "Variable Names": "Variable Names",
-  "Limit Length": "Limit Length"
+  "Limit Length": "Limit Length",
+  "Special": "Special",
+  "Factorial": "Factorial",
+  "rbd": "rbd",
+  "Response:": "Response:",
+  "Rep :": "Rep :",
+  "Factor A:": "Factor A:",
+  "Factor B:": "Factor B:",
+  "Design:": "Design:",
+  "Treat :": "Treat :",
+  "Generate Plot": "Generate Plot"
 }


### PR DESCRIPTION
@rdstern @berylwaswa 
@lilyclements . This touches on the frmMain and it forms the base of the dialog before other changes

This is a template of first part of the issue #10436
I checked the code with @Vitalis95 

## Changes
- New dialog with `General`/`Special` tabs supporting two designs: **rbd** and **Factorial**
- For `rbd`: user selects Response, Treatment (Factors), and Rep, and runs `BKBreed::bk_rbd()`
- For `Factorial`: user selects Response, Factor A, Factor B, and Rep, and runs `BKBreed::bk_frbd()`

<img width="480" height="321" alt="image" src="https://github.com/user-attachments/assets/1a6f755a-df5f-4986-9c6f-7cb7bb31ac71" />


### This is for RBD

<img width="531" height="537" alt="image" src="https://github.com/user-attachments/assets/832343cc-635c-4bee-a57c-8aa07f4c882c" />

<img width="855" height="656" alt="image" src="https://github.com/user-attachments/assets/e96616bc-3146-4350-adf8-1a02c52f5da4" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/7eecd69e-c61d-471f-acb5-8fac07d638db" />

-------

### This is for Factorial

<img width="531" height="537" alt="image" src="https://github.com/user-attachments/assets/75250eae-21e6-4a30-a11a-5497c415f69c" />

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/a22b8d92-8937-49cd-942f-db46693caaf4" />

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/c7ed98e4-483a-42e4-876f-4ed87b834c56" />


