### PR TITLE
Fixed new columns always being appended in Calculator dialog

### DIFF
--- a/instat/dlgCalculator.vb
+++ b/instat/dlgCalculator.vb
@@ -269,7 +269,13 @@ Public Class dlgCalculator
                 clsAddColumnsToData.AddParameter("data_name", Chr(34) & strDF & Chr(34), iPosition:=0)
                 clsAddColumnsToData.AddParameter("col_name", Chr(34) & strCol & Chr(34), iPosition:=1)
                 clsAddColumnsToData.AddParameter("col_data", "calc_full", bIncludeArgumentName:=True, iPosition:=2)
-                clsAddColumnsToData.AddParameter("before", "FALSE", iPosition:=3)
+                clsAddColumnsToData.AddParameter("before", ucrCalc.ucrSaveResultInto.GetText(ucrSave.SaveLocation.before), iPosition:=3)
+
+                Dim strAdjacentColumn As String = ucrCalc.ucrSaveResultInto.GetText(ucrSave.SaveLocation.adjacentColumn)
+                If Not String.IsNullOrEmpty(strAdjacentColumn) Then
+                    strAdjacentColumn = strAdjacentColumn.Trim(Chr(34))
+                    clsAddColumnsToData.AddParameter("adjacent_column", Chr(34) & strAdjacentColumn & Chr(34), iPosition:=4)
+                End If
 
                 ucrBase.clsRsyntax.AddToAfterCodes(clsFilterIndexAssign, 120)
                 ucrBase.clsRsyntax.AddToAfterCodes(clsCalcFullAssign, 121)

--- a/instat/ucrSave.vb
+++ b/instat/ucrSave.vb
@@ -1027,6 +1027,7 @@ Public Class ucrSave
         bKeepExistingPosition = sdgSaveColumnPosition.KeepExistingPosition
 
         UpdateAssignTo()
+        OnControlValueChanged()
     End Sub
 
     '''--------------------------------------------------------------------------------------------


### PR DESCRIPTION
@rdstern @berylwaswa @lilyclements @Vitalis95 @kisinga

### **Fixed new columns always being appended to the end in the Calculator dialog**

_Fixes issue #10331_ 

The Calculator dialog now correctly respects the selected column position (start, end, before, or after an existing column). Previously, new columns were always appended to the end.

This PR supersedes _#10341_, which did not fully resolve the positioning issue. I go ahead and close _#10341_ in favour of this PR.