### PR TITLE
Fixed tolerance control in Compare Columns dialog

### DIFF
--- a/instat/dlgCompareColumns.vb
+++ b/instat/dlgCompareColumns.vb
@@ -254,7 +254,7 @@ Public Class dlgCompareColumns
                 If rdoByRow.Checked Then
                     ucrInputTolerance.Visible = True
                     clsLessorEqualToOperator.AddParameter("first", clsRFunctionParameter:=clsAbsoluteFunction, iPosition:=0)
-                    clsLessorEqualToOperator.AddParameter("tol", "0", iPosition:=1)
+                    'clsLessorEqualToOperator.AddParameter("tol", "0", iPosition:=1)
                     clsSummaryFunction.AddParameter("object", clsROperatorParameter:=clsLessorEqualToOperator, iPosition:=1)
                     clsDummyOperator = clsLessorEqualToOperator
                 End If
@@ -262,7 +262,7 @@ Public Class dlgCompareColumns
                 If rdoByRow.Checked Then
                     ucrInputTolerance.Visible = True
                     clsLessorEqualToOperator.AddParameter("first", clsRFunctionParameter:=clsAbsoluteFunction, iPosition:=0)
-                    clsLessorEqualToOperator.AddParameter("tol", "0", iPosition:=1)
+                    ucrInputTolerance.SetRCode(clsLessorEqualToOperator, False)
                     clsSummaryFunction.AddParameter("object", clsROperatorParameter:=clsLessorEqualToOperator, iPosition:=1)
                     clsDummyOperator = clsLessorEqualToOperator
                 End If


### PR DESCRIPTION
Fixes #10440, specifically the tolerance control issue.

The tolerance value was resetting to 0 when reopening the dialog, and any non-zero value entered was being ignored. The dialog now correctly retains and uses the specified tolerance value.

@rdstern @berylwaswa Kindly review


@rdstern I haven’t worked on (b) yet. I’d probably prefer to have a short session or make a quick video demonstrating how the dialog works once and then stops, as it seems to be working correctly on my side.