### PR TITLE
Add Multiple Mean Comparison dialog using biometryassist

### DIFF
--- a/instat/dlgModelMultipleComparisons.Designer.vb
+++ b/instat/dlgModelMultipleComparisons.Designer.vb
@@ -30,6 +30,8 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrChkAdjustment = New instat.ucrCheck()
         Me.ucrInputComboBoxDescending = New instat.ucrInputComboBox()
         Me.ucrChkDescending = New instat.ucrCheck()
+        Me.ucrInputComboBoxDisplayLetters = New instat.ucrInputComboBox()
+        Me.ucrChkDisplayLetters = New instat.ucrCheck()
         Me.ucrInputComboBoxConfidenceInterval = New instat.ucrInputComboBox()
         Me.ucrChkConfidenceInterval = New instat.ucrCheck()
         Me.ucrInputComboBoxAlpha = New instat.ucrInputComboBox()
@@ -45,7 +47,7 @@ Partial Class dlgModelMultipleComparisons
         'lblMultipleMeanComparisonModeltoUse
         '
         Me.lblMultipleMeanComparisonModeltoUse.AutoSize = True
-        Me.lblMultipleMeanComparisonModeltoUse.Location = New System.Drawing.Point(231, 44)
+        Me.lblMultipleMeanComparisonModeltoUse.Location = New System.Drawing.Point(230, 44)
         Me.lblMultipleMeanComparisonModeltoUse.Name = "lblMultipleMeanComparisonModeltoUse"
         Me.lblMultipleMeanComparisonModeltoUse.Size = New System.Drawing.Size(84, 13)
         Me.lblMultipleMeanComparisonModeltoUse.TabIndex = 28
@@ -55,7 +57,7 @@ Partial Class dlgModelMultipleComparisons
         'lblVariabletoUse
         '
         Me.lblVariabletoUse.AutoSize = True
-        Me.lblVariabletoUse.Location = New System.Drawing.Point(231, 85)
+        Me.lblVariabletoUse.Location = New System.Drawing.Point(231, 87)
         Me.lblVariabletoUse.Name = "lblVariabletoUse"
         Me.lblVariabletoUse.Size = New System.Drawing.Size(77, 13)
         Me.lblVariabletoUse.TabIndex = 30
@@ -65,7 +67,7 @@ Partial Class dlgModelMultipleComparisons
         'lblBy
         '
         Me.lblBy.AutoSize = True
-        Me.lblBy.Location = New System.Drawing.Point(231, 126)
+        Me.lblBy.Location = New System.Drawing.Point(231, 130)
         Me.lblBy.Name = "lblBy"
         Me.lblBy.Size = New System.Drawing.Size(70, 13)
         Me.lblBy.TabIndex = 32
@@ -75,7 +77,7 @@ Partial Class dlgModelMultipleComparisons
         'btnTransformation
         '
         Me.btnTransformation.Enabled = False
-        Me.btnTransformation.Location = New System.Drawing.Point(230, 173)
+        Me.btnTransformation.Location = New System.Drawing.Point(230, 180)
         Me.btnTransformation.Name = "btnTransformation"
         Me.btnTransformation.Size = New System.Drawing.Size(120, 25)
         Me.btnTransformation.TabIndex = 34
@@ -89,21 +91,21 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputComboBoxAdjustment.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxAdjustment.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxAdjustment.IsReadOnly = False
-        Me.ucrInputComboBoxAdjustment.Location = New System.Drawing.Point(95, 286)
+        Me.ucrInputComboBoxAdjustment.Location = New System.Drawing.Point(138, 314)
         Me.ucrInputComboBoxAdjustment.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxAdjustment.Name = "ucrInputComboBoxAdjustment"
         Me.ucrInputComboBoxAdjustment.Size = New System.Drawing.Size(84, 22)
-        Me.ucrInputComboBoxAdjustment.TabIndex = 42
+        Me.ucrInputComboBoxAdjustment.TabIndex = 44
         '
         'ucrChkAdjustment
         '
         Me.ucrChkAdjustment.AutoSize = True
         Me.ucrChkAdjustment.Checked = False
-        Me.ucrChkAdjustment.Location = New System.Drawing.Point(9, 286)
+        Me.ucrChkAdjustment.Location = New System.Drawing.Point(9, 314)
         Me.ucrChkAdjustment.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkAdjustment.Name = "ucrChkAdjustment"
         Me.ucrChkAdjustment.Size = New System.Drawing.Size(140, 24)
-        Me.ucrChkAdjustment.TabIndex = 41
+        Me.ucrChkAdjustment.TabIndex = 43
         '
         'ucrInputComboBoxDescending
         '
@@ -111,21 +113,43 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputComboBoxDescending.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxDescending.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxDescending.IsReadOnly = False
-        Me.ucrInputComboBoxDescending.Location = New System.Drawing.Point(95, 258)
+        Me.ucrInputComboBoxDescending.Location = New System.Drawing.Point(138, 286)
         Me.ucrInputComboBoxDescending.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxDescending.Name = "ucrInputComboBoxDescending"
         Me.ucrInputComboBoxDescending.Size = New System.Drawing.Size(84, 22)
-        Me.ucrInputComboBoxDescending.TabIndex = 40
+        Me.ucrInputComboBoxDescending.TabIndex = 42
         '
         'ucrChkDescending
         '
         Me.ucrChkDescending.AutoSize = True
         Me.ucrChkDescending.Checked = False
-        Me.ucrChkDescending.Location = New System.Drawing.Point(9, 258)
+        Me.ucrChkDescending.Location = New System.Drawing.Point(9, 286)
         Me.ucrChkDescending.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkDescending.Name = "ucrChkDescending"
         Me.ucrChkDescending.Size = New System.Drawing.Size(140, 24)
-        Me.ucrChkDescending.TabIndex = 39
+        Me.ucrChkDescending.TabIndex = 41
+        '
+        'ucrInputComboBoxDisplayLetters
+        '
+        Me.ucrInputComboBoxDisplayLetters.AddQuotesIfUnrecognised = False
+        Me.ucrInputComboBoxDisplayLetters.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputComboBoxDisplayLetters.GetSetSelectedIndex = -1
+        Me.ucrInputComboBoxDisplayLetters.IsReadOnly = True
+        Me.ucrInputComboBoxDisplayLetters.Location = New System.Drawing.Point(138, 258)
+        Me.ucrInputComboBoxDisplayLetters.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrInputComboBoxDisplayLetters.Name = "ucrInputComboBoxDisplayLetters"
+        Me.ucrInputComboBoxDisplayLetters.Size = New System.Drawing.Size(84, 22)
+        Me.ucrInputComboBoxDisplayLetters.TabIndex = 40
+        '
+        'ucrChkDisplayLetters
+        '
+        Me.ucrChkDisplayLetters.AutoSize = True
+        Me.ucrChkDisplayLetters.Checked = False
+        Me.ucrChkDisplayLetters.Location = New System.Drawing.Point(9, 258)
+        Me.ucrChkDisplayLetters.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrChkDisplayLetters.Name = "ucrChkDisplayLetters"
+        Me.ucrChkDisplayLetters.Size = New System.Drawing.Size(140, 24)
+        Me.ucrChkDisplayLetters.TabIndex = 39
         '
         'ucrInputComboBoxConfidenceInterval
         '
@@ -133,10 +157,10 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputComboBoxConfidenceInterval.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxConfidenceInterval.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxConfidenceInterval.IsReadOnly = False
-        Me.ucrInputComboBoxConfidenceInterval.Location = New System.Drawing.Point(136, 230)
+        Me.ucrInputComboBoxConfidenceInterval.Location = New System.Drawing.Point(138, 230)
         Me.ucrInputComboBoxConfidenceInterval.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxConfidenceInterval.Name = "ucrInputComboBoxConfidenceInterval"
-        Me.ucrInputComboBoxConfidenceInterval.Size = New System.Drawing.Size(68, 22)
+        Me.ucrInputComboBoxConfidenceInterval.Size = New System.Drawing.Size(84, 22)
         Me.ucrInputComboBoxConfidenceInterval.TabIndex = 38
         '
         'ucrChkConfidenceInterval
@@ -155,10 +179,10 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputComboBoxAlpha.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxAlpha.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxAlpha.IsReadOnly = True
-        Me.ucrInputComboBoxAlpha.Location = New System.Drawing.Point(95, 202)
+        Me.ucrInputComboBoxAlpha.Location = New System.Drawing.Point(138, 202)
         Me.ucrInputComboBoxAlpha.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxAlpha.Name = "ucrInputComboBoxAlpha"
-        Me.ucrInputComboBoxAlpha.Size = New System.Drawing.Size(72, 22)
+        Me.ucrInputComboBoxAlpha.Size = New System.Drawing.Size(84, 22)
         Me.ucrInputComboBoxAlpha.TabIndex = 36
         '
         'ucrChkAlpha
@@ -175,7 +199,7 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrReceiverBy.AutoSize = True
         Me.ucrReceiverBy.frmParent = Me
-        Me.ucrReceiverBy.Location = New System.Drawing.Point(230, 145)
+        Me.ucrReceiverBy.Location = New System.Drawing.Point(230, 147)
         Me.ucrReceiverBy.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverBy.Name = "ucrReceiverBy"
         Me.ucrReceiverBy.Selector = Nothing
@@ -201,7 +225,7 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrReceiverMultipleMeanComparisonUseModel.AutoSize = True
         Me.ucrReceiverMultipleMeanComparisonUseModel.frmParent = Me
-        Me.ucrReceiverMultipleMeanComparisonUseModel.Location = New System.Drawing.Point(230, 63)
+        Me.ucrReceiverMultipleMeanComparisonUseModel.Location = New System.Drawing.Point(230, 61)
         Me.ucrReceiverMultipleMeanComparisonUseModel.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMultipleMeanComparisonUseModel.Name = "ucrReceiverMultipleMeanComparisonUseModel"
         Me.ucrReceiverMultipleMeanComparisonUseModel.Selector = Nothing
@@ -213,7 +237,7 @@ Partial Class dlgModelMultipleComparisons
         'ucrSaveModelMultipleComparisons
         '
         Me.ucrSaveModelMultipleComparisons.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveModelMultipleComparisons.Location = New System.Drawing.Point(9, 328)
+        Me.ucrSaveModelMultipleComparisons.Location = New System.Drawing.Point(9, 351)
         Me.ucrSaveModelMultipleComparisons.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrSaveModelMultipleComparisons.Name = "ucrSaveModelMultipleComparisons"
         Me.ucrSaveModelMultipleComparisons.Size = New System.Drawing.Size(306, 24)
@@ -223,8 +247,8 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(9, 360)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
+        Me.ucrBase.Location = New System.Drawing.Point(6, 383)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(408, 52)
         Me.ucrBase.TabIndex = 24
@@ -245,11 +269,13 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(429, 422)
+        Me.ClientSize = New System.Drawing.Size(419, 439)
         Me.Controls.Add(Me.ucrInputComboBoxAdjustment)
         Me.Controls.Add(Me.ucrChkAdjustment)
         Me.Controls.Add(Me.ucrInputComboBoxDescending)
         Me.Controls.Add(Me.ucrChkDescending)
+        Me.Controls.Add(Me.ucrInputComboBoxDisplayLetters)
+        Me.Controls.Add(Me.ucrChkDisplayLetters)
         Me.Controls.Add(Me.ucrInputComboBoxConfidenceInterval)
         Me.Controls.Add(Me.ucrChkConfidenceInterval)
         Me.Controls.Add(Me.ucrInputComboBoxAlpha)
@@ -288,6 +314,8 @@ Partial Class dlgModelMultipleComparisons
     Friend WithEvents btnTransformation As Button
     Friend WithEvents ucrChkConfidenceInterval As ucrCheck
     Friend WithEvents ucrInputComboBoxConfidenceInterval As ucrInputComboBox
+    Friend WithEvents ucrChkDisplayLetters As ucrCheck
+    Friend WithEvents ucrInputComboBoxDisplayLetters As ucrInputComboBox
     Friend WithEvents ucrChkDescending As ucrCheck
     Friend WithEvents ucrInputComboBoxDescending As ucrInputComboBox
     Friend WithEvents ucrChkAdjustment As ucrCheck

--- a/instat/dlgModelMultipleComparisons.Designer.vb
+++ b/instat/dlgModelMultipleComparisons.Designer.vb
@@ -22,55 +22,211 @@ Partial Class dlgModelMultipleComparisons
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
-        Me.lblFirstVariables = New System.Windows.Forms.Label()
+        Me.lblMultipleMeanComparisonModeltoUse = New System.Windows.Forms.Label()
+        Me.lblVariabletoUse = New System.Windows.Forms.Label()
+        Me.lblBy = New System.Windows.Forms.Label()
+        Me.btnTransformation = New System.Windows.Forms.Button()
+        Me.ucrInputComboBoxAdjustment = New instat.ucrInputComboBox()
+        Me.ucrChkAdjustment = New instat.ucrCheck()
+        Me.ucrInputComboBoxDescending = New instat.ucrInputComboBox()
+        Me.ucrChkDescending = New instat.ucrCheck()
+        Me.ucrInputComboBoxConfidenceInterval = New instat.ucrInputComboBox()
+        Me.ucrChkConfidenceInterval = New instat.ucrCheck()
+        Me.ucrInputComboBoxAlpha = New instat.ucrInputComboBox()
+        Me.ucrChkAlpha = New instat.ucrCheck()
+        Me.ucrReceiverBy = New instat.ucrReceiverSingle()
+        Me.ucrReceiverLabelVariable = New instat.ucrReceiverSingle()
+        Me.ucrReceiverMultipleMeanComparisonUseModel = New instat.ucrReceiverSingle()
         Me.ucrSaveModelMultipleComparisons = New instat.ucrSave()
-        Me.ucrReceiverFirstVariables = New instat.ucrReceiverMultiple()
         Me.ucrBase = New instat.ucrButtons()
         Me.ucrSelectorModelMultipleComparisons = New instat.ucrSelectorByDataFrameAddRemove()
         Me.SuspendLayout()
         '
-        'lblFirstVariables
+        'lblMultipleMeanComparisonModeltoUse
         '
-        Me.lblFirstVariables.AutoSize = True
-        Me.lblFirstVariables.ImeMode = System.Windows.Forms.ImeMode.NoControl
-        Me.lblFirstVariables.Location = New System.Drawing.Point(377, 64)
-        Me.lblFirstVariables.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.lblFirstVariables.Name = "lblFirstVariables"
-        Me.lblFirstVariables.Size = New System.Drawing.Size(68, 16)
-        Me.lblFirstVariables.TabIndex = 25
-        Me.lblFirstVariables.Tag = ""
-        Me.lblFirstVariables.Text = "Variables:"
+        Me.lblMultipleMeanComparisonModeltoUse.AutoSize = True
+        Me.lblMultipleMeanComparisonModeltoUse.Location = New System.Drawing.Point(231, 44)
+        Me.lblMultipleMeanComparisonModeltoUse.Name = "lblMultipleMeanComparisonModeltoUse"
+        Me.lblMultipleMeanComparisonModeltoUse.Size = New System.Drawing.Size(84, 13)
+        Me.lblMultipleMeanComparisonModeltoUse.TabIndex = 28
+        Me.lblMultipleMeanComparisonModeltoUse.Tag = "Selected_Model:"
+        Me.lblMultipleMeanComparisonModeltoUse.Text = "Selected Model:"
+        '
+        'lblVariabletoUse
+        '
+        Me.lblVariabletoUse.AutoSize = True
+        Me.lblVariabletoUse.Location = New System.Drawing.Point(231, 85)
+        Me.lblVariabletoUse.Name = "lblVariabletoUse"
+        Me.lblVariabletoUse.Size = New System.Drawing.Size(77, 13)
+        Me.lblVariabletoUse.TabIndex = 30
+        Me.lblVariabletoUse.Tag = "Label_Variable:"
+        Me.lblVariabletoUse.Text = "Label Variable:"
+        '
+        'lblBy
+        '
+        Me.lblBy.AutoSize = True
+        Me.lblBy.Location = New System.Drawing.Point(231, 126)
+        Me.lblBy.Name = "lblBy"
+        Me.lblBy.Size = New System.Drawing.Size(70, 13)
+        Me.lblBy.TabIndex = 32
+        Me.lblBy.Tag = "By_Optional:"
+        Me.lblBy.Text = "By (Optional):"
+        '
+        'btnTransformation
+        '
+        Me.btnTransformation.Enabled = False
+        Me.btnTransformation.Location = New System.Drawing.Point(230, 173)
+        Me.btnTransformation.Name = "btnTransformation"
+        Me.btnTransformation.Size = New System.Drawing.Size(120, 25)
+        Me.btnTransformation.TabIndex = 34
+        Me.btnTransformation.Tag = "Transformation"
+        Me.btnTransformation.Text = "Transformation"
+        Me.btnTransformation.UseVisualStyleBackColor = True
+        '
+        'ucrInputComboBoxAdjustment
+        '
+        Me.ucrInputComboBoxAdjustment.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboBoxAdjustment.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputComboBoxAdjustment.GetSetSelectedIndex = -1
+        Me.ucrInputComboBoxAdjustment.IsReadOnly = False
+        Me.ucrInputComboBoxAdjustment.Location = New System.Drawing.Point(95, 286)
+        Me.ucrInputComboBoxAdjustment.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrInputComboBoxAdjustment.Name = "ucrInputComboBoxAdjustment"
+        Me.ucrInputComboBoxAdjustment.Size = New System.Drawing.Size(84, 22)
+        Me.ucrInputComboBoxAdjustment.TabIndex = 42
+        '
+        'ucrChkAdjustment
+        '
+        Me.ucrChkAdjustment.AutoSize = True
+        Me.ucrChkAdjustment.Checked = False
+        Me.ucrChkAdjustment.Location = New System.Drawing.Point(9, 286)
+        Me.ucrChkAdjustment.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrChkAdjustment.Name = "ucrChkAdjustment"
+        Me.ucrChkAdjustment.Size = New System.Drawing.Size(140, 24)
+        Me.ucrChkAdjustment.TabIndex = 41
+        '
+        'ucrInputComboBoxDescending
+        '
+        Me.ucrInputComboBoxDescending.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboBoxDescending.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputComboBoxDescending.GetSetSelectedIndex = -1
+        Me.ucrInputComboBoxDescending.IsReadOnly = False
+        Me.ucrInputComboBoxDescending.Location = New System.Drawing.Point(95, 258)
+        Me.ucrInputComboBoxDescending.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrInputComboBoxDescending.Name = "ucrInputComboBoxDescending"
+        Me.ucrInputComboBoxDescending.Size = New System.Drawing.Size(84, 22)
+        Me.ucrInputComboBoxDescending.TabIndex = 40
+        '
+        'ucrChkDescending
+        '
+        Me.ucrChkDescending.AutoSize = True
+        Me.ucrChkDescending.Checked = False
+        Me.ucrChkDescending.Location = New System.Drawing.Point(9, 258)
+        Me.ucrChkDescending.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrChkDescending.Name = "ucrChkDescending"
+        Me.ucrChkDescending.Size = New System.Drawing.Size(140, 24)
+        Me.ucrChkDescending.TabIndex = 39
+        '
+        'ucrInputComboBoxConfidenceInterval
+        '
+        Me.ucrInputComboBoxConfidenceInterval.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboBoxConfidenceInterval.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputComboBoxConfidenceInterval.GetSetSelectedIndex = -1
+        Me.ucrInputComboBoxConfidenceInterval.IsReadOnly = False
+        Me.ucrInputComboBoxConfidenceInterval.Location = New System.Drawing.Point(136, 230)
+        Me.ucrInputComboBoxConfidenceInterval.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrInputComboBoxConfidenceInterval.Name = "ucrInputComboBoxConfidenceInterval"
+        Me.ucrInputComboBoxConfidenceInterval.Size = New System.Drawing.Size(68, 22)
+        Me.ucrInputComboBoxConfidenceInterval.TabIndex = 38
+        '
+        'ucrChkConfidenceInterval
+        '
+        Me.ucrChkConfidenceInterval.AutoSize = True
+        Me.ucrChkConfidenceInterval.Checked = False
+        Me.ucrChkConfidenceInterval.Location = New System.Drawing.Point(9, 230)
+        Me.ucrChkConfidenceInterval.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrChkConfidenceInterval.Name = "ucrChkConfidenceInterval"
+        Me.ucrChkConfidenceInterval.Size = New System.Drawing.Size(140, 24)
+        Me.ucrChkConfidenceInterval.TabIndex = 37
+        '
+        'ucrInputComboBoxAlpha
+        '
+        Me.ucrInputComboBoxAlpha.AddQuotesIfUnrecognised = False
+        Me.ucrInputComboBoxAlpha.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputComboBoxAlpha.GetSetSelectedIndex = -1
+        Me.ucrInputComboBoxAlpha.IsReadOnly = True
+        Me.ucrInputComboBoxAlpha.Location = New System.Drawing.Point(95, 202)
+        Me.ucrInputComboBoxAlpha.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrInputComboBoxAlpha.Name = "ucrInputComboBoxAlpha"
+        Me.ucrInputComboBoxAlpha.Size = New System.Drawing.Size(72, 22)
+        Me.ucrInputComboBoxAlpha.TabIndex = 36
+        '
+        'ucrChkAlpha
+        '
+        Me.ucrChkAlpha.AutoSize = True
+        Me.ucrChkAlpha.Checked = False
+        Me.ucrChkAlpha.Location = New System.Drawing.Point(9, 202)
+        Me.ucrChkAlpha.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrChkAlpha.Name = "ucrChkAlpha"
+        Me.ucrChkAlpha.Size = New System.Drawing.Size(80, 24)
+        Me.ucrChkAlpha.TabIndex = 35
+        '
+        'ucrReceiverBy
+        '
+        Me.ucrReceiverBy.AutoSize = True
+        Me.ucrReceiverBy.frmParent = Me
+        Me.ucrReceiverBy.Location = New System.Drawing.Point(230, 145)
+        Me.ucrReceiverBy.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverBy.Name = "ucrReceiverBy"
+        Me.ucrReceiverBy.Selector = Nothing
+        Me.ucrReceiverBy.Size = New System.Drawing.Size(120, 22)
+        Me.ucrReceiverBy.strNcFilePath = ""
+        Me.ucrReceiverBy.TabIndex = 33
+        Me.ucrReceiverBy.ucrSelector = Nothing
+        '
+        'ucrReceiverLabelVariable
+        '
+        Me.ucrReceiverLabelVariable.AutoSize = True
+        Me.ucrReceiverLabelVariable.frmParent = Me
+        Me.ucrReceiverLabelVariable.Location = New System.Drawing.Point(230, 104)
+        Me.ucrReceiverLabelVariable.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverLabelVariable.Name = "ucrReceiverLabelVariable"
+        Me.ucrReceiverLabelVariable.Selector = Nothing
+        Me.ucrReceiverLabelVariable.Size = New System.Drawing.Size(120, 22)
+        Me.ucrReceiverLabelVariable.strNcFilePath = ""
+        Me.ucrReceiverLabelVariable.TabIndex = 31
+        Me.ucrReceiverLabelVariable.ucrSelector = Nothing
+        '
+        'ucrReceiverMultipleMeanComparisonUseModel
+        '
+        Me.ucrReceiverMultipleMeanComparisonUseModel.AutoSize = True
+        Me.ucrReceiverMultipleMeanComparisonUseModel.frmParent = Me
+        Me.ucrReceiverMultipleMeanComparisonUseModel.Location = New System.Drawing.Point(230, 63)
+        Me.ucrReceiverMultipleMeanComparisonUseModel.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverMultipleMeanComparisonUseModel.Name = "ucrReceiverMultipleMeanComparisonUseModel"
+        Me.ucrReceiverMultipleMeanComparisonUseModel.Selector = Nothing
+        Me.ucrReceiverMultipleMeanComparisonUseModel.Size = New System.Drawing.Size(120, 22)
+        Me.ucrReceiverMultipleMeanComparisonUseModel.strNcFilePath = ""
+        Me.ucrReceiverMultipleMeanComparisonUseModel.TabIndex = 29
+        Me.ucrReceiverMultipleMeanComparisonUseModel.ucrSelector = Nothing
         '
         'ucrSaveModelMultipleComparisons
         '
         Me.ucrSaveModelMultipleComparisons.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveModelMultipleComparisons.Location = New System.Drawing.Point(12, 368)
-        Me.ucrSaveModelMultipleComparisons.Margin = New System.Windows.Forms.Padding(5, 6, 5, 6)
+        Me.ucrSaveModelMultipleComparisons.Location = New System.Drawing.Point(9, 328)
+        Me.ucrSaveModelMultipleComparisons.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.ucrSaveModelMultipleComparisons.Name = "ucrSaveModelMultipleComparisons"
-        Me.ucrSaveModelMultipleComparisons.Size = New System.Drawing.Size(408, 30)
+        Me.ucrSaveModelMultipleComparisons.Size = New System.Drawing.Size(306, 24)
         Me.ucrSaveModelMultipleComparisons.TabIndex = 27
-        '
-        'ucrReceiverFirstVariables
-        '
-        Me.ucrReceiverFirstVariables.AutoSize = True
-        Me.ucrReceiverFirstVariables.frmParent = Me
-        Me.ucrReceiverFirstVariables.Location = New System.Drawing.Point(377, 82)
-        Me.ucrReceiverFirstVariables.Margin = New System.Windows.Forms.Padding(0)
-        Me.ucrReceiverFirstVariables.Name = "ucrReceiverFirstVariables"
-        Me.ucrReceiverFirstVariables.Selector = Nothing
-        Me.ucrReceiverFirstVariables.Size = New System.Drawing.Size(160, 97)
-        Me.ucrReceiverFirstVariables.strNcFilePath = ""
-        Me.ucrReceiverFirstVariables.TabIndex = 26
-        Me.ucrReceiverFirstVariables.ucrSelector = Nothing
         '
         'ucrBase
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(12, 425)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(8, 7, 8, 7)
+        Me.ucrBase.Location = New System.Drawing.Point(9, 360)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(511, 65)
+        Me.ucrBase.Size = New System.Drawing.Size(408, 52)
         Me.ucrBase.TabIndex = 24
         '
         'ucrSelectorModelMultipleComparisons
@@ -79,24 +235,36 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrSelectorModelMultipleComparisons.bDropUnusedFilterLevels = False
         Me.ucrSelectorModelMultipleComparisons.bShowHiddenColumns = False
         Me.ucrSelectorModelMultipleComparisons.bUseCurrentFilter = True
-        Me.ucrSelectorModelMultipleComparisons.Location = New System.Drawing.Point(12, 43)
+        Me.ucrSelectorModelMultipleComparisons.Location = New System.Drawing.Point(9, 12)
         Me.ucrSelectorModelMultipleComparisons.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorModelMultipleComparisons.Name = "ucrSelectorModelMultipleComparisons"
-        Me.ucrSelectorModelMultipleComparisons.Size = New System.Drawing.Size(284, 227)
+        Me.ucrSelectorModelMultipleComparisons.Size = New System.Drawing.Size(213, 184)
         Me.ucrSelectorModelMultipleComparisons.TabIndex = 5
         '
         'dlgModelMultipleComparisons
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 16.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(568, 507)
+        Me.ClientSize = New System.Drawing.Size(429, 422)
+        Me.Controls.Add(Me.ucrInputComboBoxAdjustment)
+        Me.Controls.Add(Me.ucrChkAdjustment)
+        Me.Controls.Add(Me.ucrInputComboBoxDescending)
+        Me.Controls.Add(Me.ucrChkDescending)
+        Me.Controls.Add(Me.ucrInputComboBoxConfidenceInterval)
+        Me.Controls.Add(Me.ucrChkConfidenceInterval)
+        Me.Controls.Add(Me.ucrInputComboBoxAlpha)
+        Me.Controls.Add(Me.ucrChkAlpha)
+        Me.Controls.Add(Me.btnTransformation)
+        Me.Controls.Add(Me.ucrReceiverBy)
+        Me.Controls.Add(Me.lblBy)
+        Me.Controls.Add(Me.lblVariabletoUse)
+        Me.Controls.Add(Me.ucrReceiverLabelVariable)
+        Me.Controls.Add(Me.lblMultipleMeanComparisonModeltoUse)
+        Me.Controls.Add(Me.ucrReceiverMultipleMeanComparisonUseModel)
         Me.Controls.Add(Me.ucrSaveModelMultipleComparisons)
-        Me.Controls.Add(Me.ucrReceiverFirstVariables)
-        Me.Controls.Add(Me.lblFirstVariables)
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.ucrSelectorModelMultipleComparisons)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
-        Me.Margin = New System.Windows.Forms.Padding(4)
         Me.MinimizeBox = False
         Me.Name = "dlgModelMultipleComparisons"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
@@ -108,7 +276,20 @@ Partial Class dlgModelMultipleComparisons
 
     Friend WithEvents ucrSelectorModelMultipleComparisons As ucrSelectorByDataFrameAddRemove
     Friend WithEvents ucrBase As ucrButtons
-    Friend WithEvents ucrReceiverFirstVariables As ucrReceiverMultiple
-    Friend WithEvents lblFirstVariables As Label
     Friend WithEvents ucrSaveModelMultipleComparisons As ucrSave
+    Friend WithEvents lblMultipleMeanComparisonModeltoUse As Label
+    Friend WithEvents ucrReceiverMultipleMeanComparisonUseModel As ucrReceiverSingle
+    Friend WithEvents lblVariabletoUse As Label
+    Friend WithEvents ucrReceiverLabelVariable As ucrReceiverSingle
+    Friend WithEvents lblBy As Label
+    Friend WithEvents ucrReceiverBy As ucrReceiverSingle
+    Friend WithEvents ucrChkAlpha As ucrCheck
+    Friend WithEvents ucrInputComboBoxAlpha As ucrInputComboBox
+    Friend WithEvents btnTransformation As Button
+    Friend WithEvents ucrChkConfidenceInterval As ucrCheck
+    Friend WithEvents ucrInputComboBoxConfidenceInterval As ucrInputComboBox
+    Friend WithEvents ucrChkDescending As ucrCheck
+    Friend WithEvents ucrInputComboBoxDescending As ucrInputComboBox
+    Friend WithEvents ucrChkAdjustment As ucrCheck
+    Friend WithEvents ucrInputComboBoxAdjustment As ucrInputComboBox
 End Class

--- a/instat/dlgModelMultipleComparisons.vb
+++ b/instat/dlgModelMultipleComparisons.vb
@@ -142,11 +142,9 @@ Public Class dlgModelMultipleComparisons
             ucrChkAdjustment.SetRCode(clsMultipleComparisonsFunction, bReset)
 
             ucrBase.clsRsyntax.AddToBeforeCodes(clsAssignModelOperator)
-
             ucrBase.clsRsyntax.SetBaseRFunction(clsMultipleComparisonsFunction)
-            ucrBase.clsRsyntax.SetAssignTo(ucrSaveModelMultipleComparisons.GetText())
-
             ucrBase.clsRsyntax.AddToAfterCodes(clsRmFunction)
+
         End If
     End Sub
 
@@ -187,7 +185,12 @@ Public Class dlgModelMultipleComparisons
 
     Private Sub ucrSaveModelMultipleComparisons_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSaveModelMultipleComparisons.ControlValueChanged
         If ucrSaveModelMultipleComparisons.GetText() <> "" AndAlso ucrSaveModelMultipleComparisons.IsComplete() Then
-            ucrBase.clsRsyntax.SetAssignTo(ucrSaveModelMultipleComparisons.GetText())
+            clsMultipleComparisonsFunction.SetAssignToOutputObject(
+            strRObjectToAssignTo:=ucrSaveModelMultipleComparisons.GetText(),
+            strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Summary,
+            strRObjectFormatToAssignTo:=RObjectFormat.Text,
+            strRDataFrameNameToAddObjectTo:=ucrSelectorModelMultipleComparisons.strCurrentDataFrame,
+            strObjectName:=ucrSaveModelMultipleComparisons.GetText())
         End If
     End Sub
 

--- a/instat/dlgModelMultipleComparisons.vb
+++ b/instat/dlgModelMultipleComparisons.vb
@@ -14,66 +14,196 @@
 ' You should have received a copy of the GNU General Public License 
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-Imports instat
 Imports instat.Translations
+
 Public Class dlgModelMultipleComparisons
-
-
     Private bFirstLoad As Boolean = True
+    Private bReset As Boolean = True
+
+    Private clsMultipleComparisonsFunction As New RFunction
+    Private clsGetModelFunction As New RFunction
+    Private clsAssignModelOperator As New ROperator
+    Private clsRmFunction As New RFunction
 
     Private Sub dlgModelMultipleComparisons_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
             InitialiseDialog()
             bFirstLoad = False
         End If
-
+        If bReset Then
+            SetDefaults()
+        End If
+        SetRCodeForControls(bReset)
+        bReset = False
+        autoTranslate(Me)
+        TestOkEnabled()
     End Sub
 
     Private Sub InitialiseDialog()
 
+        ucrBase.iHelpTopicID = 0
+        ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
+        ucrBase.clsRsyntax.iCallType = 2
 
+        ucrReceiverMultipleMeanComparisonUseModel.SetItemType(RObjectTypeLabel.Model)
+        ucrReceiverMultipleMeanComparisonUseModel.Selector = ucrSelectorModelMultipleComparisons
+        ucrReceiverMultipleMeanComparisonUseModel.SetMeAsReceiver()
+        ucrReceiverMultipleMeanComparisonUseModel.strSelectorHeading = "Models"
+
+        ucrReceiverLabelVariable.Selector = ucrSelectorModelMultipleComparisons
+        ucrReceiverLabelVariable.SetParameter(New RParameter("classify", 1))
+        ucrReceiverLabelVariable.SetParameterIsString()
+        ucrReceiverLabelVariable.SetIncludedDataTypes({"factor"})
+
+        ucrReceiverBy.Selector = ucrSelectorModelMultipleComparisons
+        ucrReceiverBy.SetParameter(New RParameter("by", 2))
+        ucrReceiverBy.SetParameterIsString()
+        ucrReceiverBy.SetIncludedDataTypes({"factor"})
+
+        ucrChkAlpha.SetText("Alpha")
+        ucrInputComboBoxAlpha.SetItems({"0.001", "0.01", "0.02", "0.05", "0.1"})
+        ucrInputComboBoxAlpha.SetDropDownStyleAsNonEditable()
+        ucrInputComboBoxAlpha.AddQuotesIfUnrecognised = False
+        ucrInputComboBoxAlpha.SetParameter(New RParameter("sig", 3))
+        ucrInputComboBoxAlpha.SetRDefault("0.05")
+        ucrChkAlpha.AddToLinkedControls(ucrInputComboBoxAlpha, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="0.05")
+
+        ucrChkConfidenceInterval.SetText("Confidence Interval")
+        ucrInputComboBoxConfidenceInterval.SetItems({"ci", "tukey", "1se", "2se", "none"})
+        ucrInputComboBoxConfidenceInterval.SetDropDownStyleAsNonEditable()
+        ucrInputComboBoxConfidenceInterval.AddQuotesIfUnrecognised = True
+        ucrInputComboBoxConfidenceInterval.SetParameter(New RParameter("int.type", 4))
+        ucrInputComboBoxConfidenceInterval.SetRDefault(Chr(34) & "ci" & Chr(34))
+        ucrChkConfidenceInterval.AddToLinkedControls(ucrInputComboBoxConfidenceInterval, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="ci")
+
+        ucrChkDescending.SetText("Descending")
+        ucrInputComboBoxDescending.SetItems({"TRUE", "FALSE"})
+        ucrInputComboBoxDescending.SetDropDownStyleAsNonEditable()
+        ucrInputComboBoxDescending.AddQuotesIfUnrecognised = False
+        ucrInputComboBoxDescending.SetParameter(New RParameter("descending", 5))
+        ucrInputComboBoxDescending.SetRDefault("TRUE")
+        ucrChkDescending.AddToLinkedControls(ucrInputComboBoxDescending, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="TRUE")
+
+        ucrChkAdjustment.SetText("Adjustment")
+        ucrInputComboBoxAdjustment.SetItems({"tukey", "bonferroni", "holm", "hochberg", "hommel", "BH", "BY", "none"})
+        ucrInputComboBoxAdjustment.SetDropDownStyleAsNonEditable()
+        ucrInputComboBoxAdjustment.AddQuotesIfUnrecognised = True
+        ucrInputComboBoxAdjustment.SetParameter(New RParameter("adjust", 6))
+        ucrInputComboBoxAdjustment.SetRDefault(Chr(34) & "tukey" & Chr(34))
+        ucrChkAdjustment.AddToLinkedControls(ucrInputComboBoxAdjustment, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="tukey")
+
+        ucrSaveModelMultipleComparisons.SetLabelText("Store mct:")
+        ucrSaveModelMultipleComparisons.SetIsComboBox()
+        ucrSaveModelMultipleComparisons.SetSaveType(strRObjectType:=RObjectTypeLabel.Summary, strRObjectFormat:=RObjectFormat.Text)
     End Sub
 
     Private Sub SetDefaults()
 
-        TestOkEnabled()
+        clsGetModelFunction = New RFunction
+        clsGetModelFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_object_data")
+
+        clsAssignModelOperator = New ROperator
+        clsAssignModelOperator.SetOperation("<-")
+        clsAssignModelOperator.AddParameter("left", "model_tmp", iPosition:=0)
+        clsAssignModelOperator.AddParameter("right", clsRFunctionParameter:=clsGetModelFunction, iPosition:=1)
+        clsAssignModelOperator.bToScriptAsRString = False
+
+        clsMultipleComparisonsFunction = New RFunction
+        clsMultipleComparisonsFunction.SetPackageName("biometryassist")
+        clsMultipleComparisonsFunction.SetRCommand("multiple_comparisons")
+        clsMultipleComparisonsFunction.AddParameter("model.obj", "model_tmp", iPosition:=0)
+
+        clsRmFunction = New RFunction
+        clsRmFunction.SetRCommand("rm")
+        clsRmFunction.AddParameter("list", "c(""model_tmp"")", bIncludeArgumentName:=True, iPosition:=0)
+        clsRmFunction.bToScriptAsRString = False
+
+        ucrSelectorModelMultipleComparisons.Reset()
+
+        ucrSaveModelMultipleComparisons.Reset()
+        ucrSaveModelMultipleComparisons.SetName("mct_obj")
     End Sub
 
-    Public Sub SetRCodeForControls(bReset As Boolean)
+    Private Sub SetRCodeForControls(bReset As Boolean)
 
+        ucrReceiverLabelVariable.SetRCode(clsMultipleComparisonsFunction, bReset)
+        ucrReceiverBy.SetRCode(clsMultipleComparisonsFunction, bReset)
 
+        ucrInputComboBoxAlpha.SetRCode(clsMultipleComparisonsFunction, bReset)
+        ucrInputComboBoxConfidenceInterval.SetRCode(clsMultipleComparisonsFunction, bReset)
+        ucrInputComboBoxDescending.SetRCode(clsMultipleComparisonsFunction, bReset)
+        ucrInputComboBoxAdjustment.SetRCode(clsMultipleComparisonsFunction, bReset)
+
+        If bReset Then
+
+            ucrChkAlpha.SetRCode(clsMultipleComparisonsFunction, bReset)
+            ucrChkConfidenceInterval.SetRCode(clsMultipleComparisonsFunction, bReset)
+            ucrChkDescending.SetRCode(clsMultipleComparisonsFunction, bReset)
+            ucrChkAdjustment.SetRCode(clsMultipleComparisonsFunction, bReset)
+
+            ucrBase.clsRsyntax.AddToBeforeCodes(clsAssignModelOperator)
+
+            ucrBase.clsRsyntax.SetBaseRFunction(clsMultipleComparisonsFunction)
+            ucrBase.clsRsyntax.SetAssignTo(ucrSaveModelMultipleComparisons.GetText())
+
+            ucrBase.clsRsyntax.AddToAfterCodes(clsRmFunction)
+        End If
     End Sub
 
     Private Sub TestOkEnabled()
+        Dim bOKEnabled As Boolean = Not ucrReceiverMultipleMeanComparisonUseModel.IsEmpty() AndAlso
+                                    Not ucrReceiverLabelVariable.IsEmpty() AndAlso
+                                    ucrSaveModelMultipleComparisons.IsComplete()
 
+        ucrBase.OKEnabled(bOKEnabled)
     End Sub
 
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
         SetDefaults()
         SetRCodeForControls(True)
+
+        If Not String.IsNullOrEmpty(ucrSelectorModelMultipleComparisons.strCurrentDataFrame) Then
+            clsGetModelFunction.AddParameter("data_name", Chr(34) & ucrSelectorModelMultipleComparisons.strCurrentDataFrame & Chr(34))
+        End If
+
         TestOkEnabled()
     End Sub
 
-    Private Sub ucrReceiverFirstVariables_Load(sender As Object, e As EventArgs) Handles ucrReceiverFirstVariables.Load
-
+    Private Sub ucrReceiverMultipleMeanComparisonUseModel_SelectionChanged(sender As Object, e As EventArgs) Handles ucrReceiverMultipleMeanComparisonUseModel.SelectionChanged
+        If Not ucrReceiverMultipleMeanComparisonUseModel.IsEmpty() Then
+            clsGetModelFunction.AddParameter("object_name", ucrReceiverMultipleMeanComparisonUseModel.GetVariableNames())
+        Else
+            clsGetModelFunction.RemoveParameterByName("object_name")
+        End If
+        TestOkEnabled()
     End Sub
 
-    Private Sub ucrBase_Load(sender As Object, e As EventArgs) Handles ucrBase.Load
-
+    Private Sub ucrSelectorModelMultipleComparisons_DataFrameChanged() Handles ucrSelectorModelMultipleComparisons.DataFrameChanged
+        If Not String.IsNullOrEmpty(ucrSelectorModelMultipleComparisons.strCurrentDataFrame) Then
+            clsGetModelFunction.AddParameter("data_name", Chr(34) & ucrSelectorModelMultipleComparisons.strCurrentDataFrame & Chr(34))
+        End If
+        TestOkEnabled()
     End Sub
 
-    Private Sub ucrSaveModelMultipleComparisons_Load(sender As Object, e As EventArgs) Handles ucrSaveModelMultipleComparisons.Load
-
+    Private Sub ucrSaveModelMultipleComparisons_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSaveModelMultipleComparisons.ControlValueChanged
+        If ucrSaveModelMultipleComparisons.GetText() <> "" AndAlso ucrSaveModelMultipleComparisons.IsComplete() Then
+            ucrBase.clsRsyntax.SetAssignTo(ucrSaveModelMultipleComparisons.GetText())
+        End If
     End Sub
 
-    Private Sub ucrModelMultipleComparisons_Load(sender As Object, e As EventArgs) Handles ucrSelectorModelMultipleComparisons.Load
+    Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles _
+        ucrReceiverLabelVariable.ControlContentsChanged,
+        ucrReceiverBy.ControlContentsChanged,
+        ucrSaveModelMultipleComparisons.ControlContentsChanged,
+        ucrChkAlpha.ControlContentsChanged,
+        ucrInputComboBoxAlpha.ControlContentsChanged,
+        ucrChkConfidenceInterval.ControlContentsChanged,
+        ucrInputComboBoxConfidenceInterval.ControlContentsChanged,
+        ucrChkDescending.ControlContentsChanged,
+        ucrInputComboBoxDescending.ControlContentsChanged,
+        ucrChkAdjustment.ControlContentsChanged,
+        ucrInputComboBoxAdjustment.ControlContentsChanged
 
+        TestOkEnabled()
     End Sub
 End Class
-
-
-
-
-
-
-

--- a/instat/dlgModelMultipleComparisons.vb
+++ b/instat/dlgModelMultipleComparisons.vb
@@ -125,6 +125,12 @@ Public Class dlgModelMultipleComparisons
 
         ucrSelectorModelMultipleComparisons.Reset()
         ucrSaveModelMultipleComparisons.Reset()
+        ucrSaveModelMultipleComparisons.ucrChkSave.Checked = False
+
+        ucrBase.clsRsyntax.ClearCodes()
+        ucrBase.clsRsyntax.AddToBeforeCodes(clsAssignModelOperator)
+        ucrBase.clsRsyntax.SetBaseRFunction(clsMultipleComparisonsFunction)
+        ucrBase.clsRsyntax.AddToAfterCodes(clsRmFunction)
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
@@ -146,10 +152,6 @@ Public Class dlgModelMultipleComparisons
             ucrChkDescending.SetRCode(clsMultipleComparisonsFunction, bReset)
             ucrChkAdjustment.SetRCode(clsMultipleComparisonsFunction, bReset)
 
-            ucrBase.clsRsyntax.AddToBeforeCodes(clsAssignModelOperator)
-            ucrBase.clsRsyntax.SetBaseRFunction(clsMultipleComparisonsFunction)
-            ucrBase.clsRsyntax.AddToAfterCodes(clsRmFunction)
-
         End If
     End Sub
 
@@ -164,11 +166,6 @@ Public Class dlgModelMultipleComparisons
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
         SetDefaults()
         SetRCodeForControls(True)
-
-        If Not String.IsNullOrEmpty(ucrSelectorModelMultipleComparisons.strCurrentDataFrame) Then
-            clsGetModelFunction.AddParameter("data_name", Chr(34) & ucrSelectorModelMultipleComparisons.strCurrentDataFrame & Chr(34))
-        End If
-
         TestOkEnabled()
     End Sub
 

--- a/instat/dlgModelMultipleComparisons.vb
+++ b/instat/dlgModelMultipleComparisons.vb
@@ -43,7 +43,7 @@ Public Class dlgModelMultipleComparisons
 
         ucrBase.iHelpTopicID = 0
         ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
-        ucrBase.clsRsyntax.iCallType = 2
+        ucrBase.clsRsyntax.iCallType = 3
 
         ucrReceiverMultipleMeanComparisonUseModel.SetItemType(RObjectTypeLabel.Model)
         ucrReceiverMultipleMeanComparisonUseModel.Selector = ucrSelectorModelMultipleComparisons
@@ -65,7 +65,6 @@ Public Class dlgModelMultipleComparisons
         ucrInputComboBoxAlpha.SetDropDownStyleAsNonEditable()
         ucrInputComboBoxAlpha.AddQuotesIfUnrecognised = False
         ucrInputComboBoxAlpha.SetParameter(New RParameter("sig", 3))
-        ucrInputComboBoxAlpha.SetRDefault("0.05")
         ucrChkAlpha.AddToLinkedControls(ucrInputComboBoxAlpha, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="0.05")
 
         ucrChkConfidenceInterval.SetText("Confidence Interval")
@@ -73,15 +72,20 @@ Public Class dlgModelMultipleComparisons
         ucrInputComboBoxConfidenceInterval.SetDropDownStyleAsNonEditable()
         ucrInputComboBoxConfidenceInterval.AddQuotesIfUnrecognised = True
         ucrInputComboBoxConfidenceInterval.SetParameter(New RParameter("int.type", 4))
-        ucrInputComboBoxConfidenceInterval.SetRDefault(Chr(34) & "ci" & Chr(34))
         ucrChkConfidenceInterval.AddToLinkedControls(ucrInputComboBoxConfidenceInterval, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="ci")
+
+        ucrChkDisplayLetters.SetText("Display Letters")
+        ucrInputComboBoxDisplayLetters.SetItems({"TRUE", "FALSE"})
+        ucrInputComboBoxDisplayLetters.SetDropDownStyleAsNonEditable()
+        ucrInputComboBoxDisplayLetters.AddQuotesIfUnrecognised = False
+        ucrInputComboBoxDisplayLetters.SetParameter(New RParameter("groups", 7))
+        ucrChkDisplayLetters.AddToLinkedControls(ucrInputComboBoxDisplayLetters, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="TRUE")
 
         ucrChkDescending.SetText("Descending")
         ucrInputComboBoxDescending.SetItems({"TRUE", "FALSE"})
         ucrInputComboBoxDescending.SetDropDownStyleAsNonEditable()
         ucrInputComboBoxDescending.AddQuotesIfUnrecognised = False
         ucrInputComboBoxDescending.SetParameter(New RParameter("descending", 5))
-        ucrInputComboBoxDescending.SetRDefault("TRUE")
         ucrChkDescending.AddToLinkedControls(ucrInputComboBoxDescending, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="TRUE")
 
         ucrChkAdjustment.SetText("Adjustment")
@@ -89,10 +93,10 @@ Public Class dlgModelMultipleComparisons
         ucrInputComboBoxAdjustment.SetDropDownStyleAsNonEditable()
         ucrInputComboBoxAdjustment.AddQuotesIfUnrecognised = True
         ucrInputComboBoxAdjustment.SetParameter(New RParameter("adjust", 6))
-        ucrInputComboBoxAdjustment.SetRDefault(Chr(34) & "tukey" & Chr(34))
         ucrChkAdjustment.AddToLinkedControls(ucrInputComboBoxAdjustment, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="tukey")
 
-        ucrSaveModelMultipleComparisons.SetLabelText("Store mct:")
+        ucrSaveModelMultipleComparisons.SetPrefix("mct")
+        ucrSaveModelMultipleComparisons.SetCheckBoxText("Store mct:")
         ucrSaveModelMultipleComparisons.SetIsComboBox()
         ucrSaveModelMultipleComparisons.SetSaveType(strRObjectType:=RObjectTypeLabel.Summary, strRObjectFormat:=RObjectFormat.Text)
     End Sub
@@ -108,6 +112,7 @@ Public Class dlgModelMultipleComparisons
         clsAssignModelOperator.AddParameter("right", clsRFunctionParameter:=clsGetModelFunction, iPosition:=1)
         clsAssignModelOperator.bToScriptAsRString = False
 
+
         clsMultipleComparisonsFunction = New RFunction
         clsMultipleComparisonsFunction.SetPackageName("biometryassist")
         clsMultipleComparisonsFunction.SetRCommand("multiple_comparisons")
@@ -119,18 +124,17 @@ Public Class dlgModelMultipleComparisons
         clsRmFunction.bToScriptAsRString = False
 
         ucrSelectorModelMultipleComparisons.Reset()
-
         ucrSaveModelMultipleComparisons.Reset()
-        ucrSaveModelMultipleComparisons.SetName("mct_obj")
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
 
         ucrReceiverLabelVariable.SetRCode(clsMultipleComparisonsFunction, bReset)
         ucrReceiverBy.SetRCode(clsMultipleComparisonsFunction, bReset)
+        ucrInputComboBoxDisplayLetters.SetRCode(clsMultipleComparisonsFunction, bReset)
+        ucrInputComboBoxConfidenceInterval.SetRCode(clsMultipleComparisonsFunction, bReset)
 
         ucrInputComboBoxAlpha.SetRCode(clsMultipleComparisonsFunction, bReset)
-        ucrInputComboBoxConfidenceInterval.SetRCode(clsMultipleComparisonsFunction, bReset)
         ucrInputComboBoxDescending.SetRCode(clsMultipleComparisonsFunction, bReset)
         ucrInputComboBoxAdjustment.SetRCode(clsMultipleComparisonsFunction, bReset)
 
@@ -138,6 +142,7 @@ Public Class dlgModelMultipleComparisons
 
             ucrChkAlpha.SetRCode(clsMultipleComparisonsFunction, bReset)
             ucrChkConfidenceInterval.SetRCode(clsMultipleComparisonsFunction, bReset)
+            ucrChkDisplayLetters.SetRCode(clsMultipleComparisonsFunction, bReset)
             ucrChkDescending.SetRCode(clsMultipleComparisonsFunction, bReset)
             ucrChkAdjustment.SetRCode(clsMultipleComparisonsFunction, bReset)
 
@@ -170,10 +175,24 @@ Public Class dlgModelMultipleComparisons
     Private Sub ucrReceiverMultipleMeanComparisonUseModel_SelectionChanged(sender As Object, e As EventArgs) Handles ucrReceiverMultipleMeanComparisonUseModel.SelectionChanged
         If Not ucrReceiverMultipleMeanComparisonUseModel.IsEmpty() Then
             clsGetModelFunction.AddParameter("object_name", ucrReceiverMultipleMeanComparisonUseModel.GetVariableNames())
+            UpdateSaveName()
         Else
             clsGetModelFunction.RemoveParameterByName("object_name")
         End If
         TestOkEnabled()
+    End Sub
+
+    'Updates the Default name In the "Store mct:" save control based On the currently selected model, rather than the Label Variable
+    'strips off the prefix before the first underscore And uses the remainder As the suffix For the mct Object name
+    Private Sub UpdateSaveName()
+        Dim strModelName As String = ucrReceiverMultipleMeanComparisonUseModel.GetVariableNames(bWithQuotes:=False)
+        Dim iUnderscoreIndex As Integer = strModelName.IndexOf("_"c)
+
+        If iUnderscoreIndex >= 0 AndAlso iUnderscoreIndex < strModelName.Length - 1 Then
+            ucrSaveModelMultipleComparisons.SetName("mct_" & strModelName.Substring(iUnderscoreIndex + 1))
+        Else
+            ucrSaveModelMultipleComparisons.SetName("mct_" & strModelName)
+        End If
     End Sub
 
     Private Sub ucrSelectorModelMultipleComparisons_DataFrameChanged() Handles ucrSelectorModelMultipleComparisons.DataFrameChanged
@@ -184,15 +203,22 @@ Public Class dlgModelMultipleComparisons
     End Sub
 
     Private Sub ucrSaveModelMultipleComparisons_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSaveModelMultipleComparisons.ControlValueChanged
-        If ucrSaveModelMultipleComparisons.GetText() <> "" AndAlso ucrSaveModelMultipleComparisons.IsComplete() Then
+        If ucrSaveModelMultipleComparisons.ucrChkSave.Checked AndAlso ucrSaveModelMultipleComparisons.GetText() <> "" AndAlso ucrSaveModelMultipleComparisons.IsComplete() Then
             clsMultipleComparisonsFunction.SetAssignToOutputObject(
-            strRObjectToAssignTo:=ucrSaveModelMultipleComparisons.GetText(),
-            strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Summary,
-            strRObjectFormatToAssignTo:=RObjectFormat.Text,
-            strRDataFrameNameToAddObjectTo:=ucrSelectorModelMultipleComparisons.strCurrentDataFrame,
-            strObjectName:=ucrSaveModelMultipleComparisons.GetText())
+        strRObjectToAssignTo:=ucrSaveModelMultipleComparisons.GetText(),
+        strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Summary,
+        strRObjectFormatToAssignTo:=RObjectFormat.Text,
+        strRDataFrameNameToAddObjectTo:=ucrSelectorModelMultipleComparisons.strCurrentDataFrame,
+        strObjectName:=ucrSaveModelMultipleComparisons.GetText())
+        Else
+            clsMultipleComparisonsFunction.RemoveAssignTo()
         End If
     End Sub
+
+    Private Sub ucrReceiverLabelVariable_SelectionChanged(sender As Object, e As EventArgs) Handles ucrReceiverLabelVariable.SelectionChanged
+        TestOkEnabled()
+    End Sub
+
 
     Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles _
         ucrReceiverLabelVariable.ControlContentsChanged,
@@ -201,6 +227,7 @@ Public Class dlgModelMultipleComparisons
         ucrChkAlpha.ControlContentsChanged,
         ucrInputComboBoxAlpha.ControlContentsChanged,
         ucrChkConfidenceInterval.ControlContentsChanged,
+        ucrChkDisplayLetters.ControlContentsChanged,
         ucrInputComboBoxConfidenceInterval.ControlContentsChanged,
         ucrChkDescending.ControlContentsChanged,
         ucrInputComboBoxDescending.ControlContentsChanged,

--- a/instat/frmMain.Designer.vb
+++ b/instat/frmMain.Designer.vb
@@ -5302,7 +5302,6 @@ Partial Class frmMain
         '
         'mnuMultipleComparisons
         '
-        Me.mnuMultipleComparisons.Enabled = False
         Me.mnuMultipleComparisons.Name = "mnuMultipleComparisons"
         Me.mnuMultipleComparisons.Size = New System.Drawing.Size(200, 22)
         Me.mnuMultipleComparisons.Text = "Multiple Comparisons..."

--- a/instat/translations/en/r_instat_not_menus.json
+++ b/instat/translations/en/r_instat_not_menus.json
@@ -6936,5 +6936,6 @@
   "Label Variable:": "Label Variable:",
   "By (Optional):": "By (Optional):",
   "Adjustment": "Adjustment",
-  "Store mct:": "Store mct:"
+  "Store mct:": "Store mct:",
+  "Display Letters": "Display Letters"
 }

--- a/instat/translations/en/r_instat_not_menus.json
+++ b/instat/translations/en/r_instat_not_menus.json
@@ -6870,7 +6870,6 @@
   "Select Filter": "Select Filter",
   "Save Definitions Object:": "Save Definitions Object:",
   "PICSA Trend Graph": "PICSA Trend Graph",
-  "Save Definitions Object:": "Save Definitions Object:",
   "Separated by:": "Separated by:",
   "Trend Graph": "Trend Graph",
   "File Location:": "File Location:",
@@ -6933,5 +6932,9 @@
   "Factor B:": "Factor B:",
   "Design:": "Design:",
   "Treat :": "Treat :",
-  "Generate Plot": "Generate Plot"
+  "Generate Plot": "Generate Plot",
+  "Label Variable:": "Label Variable:",
+  "By (Optional):": "By (Optional):",
+  "Adjustment": "Adjustment",
+  "Store mct:": "Store mct:"
 }


### PR DESCRIPTION
Fixes partly #9751 and #10433

@lilyclements This touches on the frmMain as i had disabled it before. Kindly Check


@rdstern I made the dialog for Multiple Mean Comparison Under Experiments then Model
This is just what I Have done. I am still working on this is the first push

<img width="537" height="567" alt="image" src="https://github.com/user-attachments/assets/b32549be-c0c5-4cdf-bf6b-81885d841b10" />

@berylwaswa For testing I used the Iris data. First You have to have a model for this dialog
I implemented that the two receivers for label Variable and By take only Factors as this was what was requested by @rdstern 

The Transformation Button is disabled for now

<img width="537" height="567" alt="image" src="https://github.com/user-attachments/assets/e1e9349c-f8e6-477a-99d9-4927eef2a0c4" />

---
This is the dialog and the output

<img width="942" height="935" alt="image" src="https://github.com/user-attachments/assets/ed2e0348-9744-4b46-b8cc-9b37da05fe4f" />

This is the code just Three lines

```
# Dialog: Multiple Comparisons

model_tmp <- data_book$get_object_data(data_name="iris", object_name="biometry_model")
mct_obj <- biometryassist::multiple_comparisons(model.obj=model_tmp, classify="Species")
mct_obj
rm(list=c("model_tmp"))
rm(mct_obj)
```

@Vitalis95 Kindly check the code