### PR TITLE
Implements in the Multiple Comparisons dialog plus the autoplot function

### DIFF
--- a/instat/dlgModelMultipleComparisons.Designer.vb
+++ b/instat/dlgModelMultipleComparisons.Designer.vb
@@ -24,8 +24,11 @@ Partial Class dlgModelMultipleComparisons
     Private Sub InitializeComponent()
         Me.lblMultipleMeanComparisonModeltoUse = New System.Windows.Forms.Label()
         Me.lblVariabletoUse = New System.Windows.Forms.Label()
-        Me.lblBy = New System.Windows.Forms.Label()
         Me.btnTransformation = New System.Windows.Forms.Button()
+        Me.ucrSaveGraph = New instat.ucrSave()
+        Me.ucrInputGenerateMultipleComparisonGraphs = New instat.ucrInputComboBox()
+        Me.ucrChkGenerateMultipleComparisonPlot = New instat.ucrCheck()
+        Me.ucrChkByOptional = New instat.ucrCheck()
         Me.ucrInputComboBoxAdjustment = New instat.ucrInputComboBox()
         Me.ucrChkAdjustment = New instat.ucrCheck()
         Me.ucrInputComboBoxDescending = New instat.ucrInputComboBox()
@@ -47,9 +50,11 @@ Partial Class dlgModelMultipleComparisons
         'lblMultipleMeanComparisonModeltoUse
         '
         Me.lblMultipleMeanComparisonModeltoUse.AutoSize = True
-        Me.lblMultipleMeanComparisonModeltoUse.Location = New System.Drawing.Point(230, 44)
+        Me.lblMultipleMeanComparisonModeltoUse.ImageAlign = System.Drawing.ContentAlignment.BottomLeft
+        Me.lblMultipleMeanComparisonModeltoUse.Location = New System.Drawing.Point(322, 57)
+        Me.lblMultipleMeanComparisonModeltoUse.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMultipleMeanComparisonModeltoUse.Name = "lblMultipleMeanComparisonModeltoUse"
-        Me.lblMultipleMeanComparisonModeltoUse.Size = New System.Drawing.Size(84, 13)
+        Me.lblMultipleMeanComparisonModeltoUse.Size = New System.Drawing.Size(105, 16)
         Me.lblMultipleMeanComparisonModeltoUse.TabIndex = 28
         Me.lblMultipleMeanComparisonModeltoUse.Tag = "Selected_Model:"
         Me.lblMultipleMeanComparisonModeltoUse.Text = "Selected Model:"
@@ -57,33 +62,67 @@ Partial Class dlgModelMultipleComparisons
         'lblVariabletoUse
         '
         Me.lblVariabletoUse.AutoSize = True
-        Me.lblVariabletoUse.Location = New System.Drawing.Point(231, 87)
+        Me.lblVariabletoUse.ImageAlign = System.Drawing.ContentAlignment.BottomLeft
+        Me.lblVariabletoUse.Location = New System.Drawing.Point(323, 111)
+        Me.lblVariabletoUse.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblVariabletoUse.Name = "lblVariabletoUse"
-        Me.lblVariabletoUse.Size = New System.Drawing.Size(77, 13)
+        Me.lblVariabletoUse.Size = New System.Drawing.Size(98, 16)
         Me.lblVariabletoUse.TabIndex = 30
         Me.lblVariabletoUse.Tag = "Label_Variable:"
         Me.lblVariabletoUse.Text = "Label Variable:"
         '
-        'lblBy
-        '
-        Me.lblBy.AutoSize = True
-        Me.lblBy.Location = New System.Drawing.Point(231, 130)
-        Me.lblBy.Name = "lblBy"
-        Me.lblBy.Size = New System.Drawing.Size(70, 13)
-        Me.lblBy.TabIndex = 32
-        Me.lblBy.Tag = "By_Optional:"
-        Me.lblBy.Text = "By (Optional):"
-        '
         'btnTransformation
         '
         Me.btnTransformation.Enabled = False
-        Me.btnTransformation.Location = New System.Drawing.Point(230, 180)
+        Me.btnTransformation.Location = New System.Drawing.Point(322, 226)
+        Me.btnTransformation.Margin = New System.Windows.Forms.Padding(4)
         Me.btnTransformation.Name = "btnTransformation"
-        Me.btnTransformation.Size = New System.Drawing.Size(120, 25)
+        Me.btnTransformation.Size = New System.Drawing.Size(160, 31)
         Me.btnTransformation.TabIndex = 34
         Me.btnTransformation.Tag = "Transformation"
         Me.btnTransformation.Text = "Transformation"
         Me.btnTransformation.UseVisualStyleBackColor = True
+        '
+        'ucrSaveGraph
+        '
+        Me.ucrSaveGraph.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrSaveGraph.Location = New System.Drawing.Point(12, 494)
+        Me.ucrSaveGraph.Margin = New System.Windows.Forms.Padding(5, 6, 5, 6)
+        Me.ucrSaveGraph.Name = "ucrSaveGraph"
+        Me.ucrSaveGraph.Size = New System.Drawing.Size(408, 30)
+        Me.ucrSaveGraph.TabIndex = 60
+        '
+        'ucrInputGenerateMultipleComparisonGraphs
+        '
+        Me.ucrInputGenerateMultipleComparisonGraphs.AddQuotesIfUnrecognised = False
+        Me.ucrInputGenerateMultipleComparisonGraphs.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrInputGenerateMultipleComparisonGraphs.GetSetSelectedIndex = -1
+        Me.ucrInputGenerateMultipleComparisonGraphs.IsReadOnly = False
+        Me.ucrInputGenerateMultipleComparisonGraphs.Location = New System.Drawing.Point(205, 280)
+        Me.ucrInputGenerateMultipleComparisonGraphs.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrInputGenerateMultipleComparisonGraphs.Name = "ucrInputGenerateMultipleComparisonGraphs"
+        Me.ucrInputGenerateMultipleComparisonGraphs.Size = New System.Drawing.Size(112, 27)
+        Me.ucrInputGenerateMultipleComparisonGraphs.TabIndex = 47
+        '
+        'ucrChkGenerateMultipleComparisonPlot
+        '
+        Me.ucrChkGenerateMultipleComparisonPlot.AutoSize = True
+        Me.ucrChkGenerateMultipleComparisonPlot.Checked = False
+        Me.ucrChkGenerateMultipleComparisonPlot.Location = New System.Drawing.Point(12, 280)
+        Me.ucrChkGenerateMultipleComparisonPlot.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrChkGenerateMultipleComparisonPlot.Name = "ucrChkGenerateMultipleComparisonPlot"
+        Me.ucrChkGenerateMultipleComparisonPlot.Size = New System.Drawing.Size(187, 30)
+        Me.ucrChkGenerateMultipleComparisonPlot.TabIndex = 46
+        '
+        'ucrChkByOptional
+        '
+        Me.ucrChkByOptional.AutoSize = True
+        Me.ucrChkByOptional.Checked = False
+        Me.ucrChkByOptional.Location = New System.Drawing.Point(322, 164)
+        Me.ucrChkByOptional.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrChkByOptional.Name = "ucrChkByOptional"
+        Me.ucrChkByOptional.Size = New System.Drawing.Size(105, 29)
+        Me.ucrChkByOptional.TabIndex = 45
         '
         'ucrInputComboBoxAdjustment
         '
@@ -91,20 +130,20 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputComboBoxAdjustment.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxAdjustment.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxAdjustment.IsReadOnly = False
-        Me.ucrInputComboBoxAdjustment.Location = New System.Drawing.Point(138, 314)
+        Me.ucrInputComboBoxAdjustment.Location = New System.Drawing.Point(205, 342)
         Me.ucrInputComboBoxAdjustment.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxAdjustment.Name = "ucrInputComboBoxAdjustment"
-        Me.ucrInputComboBoxAdjustment.Size = New System.Drawing.Size(84, 22)
+        Me.ucrInputComboBoxAdjustment.Size = New System.Drawing.Size(112, 27)
         Me.ucrInputComboBoxAdjustment.TabIndex = 44
         '
         'ucrChkAdjustment
         '
         Me.ucrChkAdjustment.AutoSize = True
         Me.ucrChkAdjustment.Checked = False
-        Me.ucrChkAdjustment.Location = New System.Drawing.Point(9, 314)
+        Me.ucrChkAdjustment.Location = New System.Drawing.Point(12, 342)
         Me.ucrChkAdjustment.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkAdjustment.Name = "ucrChkAdjustment"
-        Me.ucrChkAdjustment.Size = New System.Drawing.Size(140, 24)
+        Me.ucrChkAdjustment.Size = New System.Drawing.Size(187, 30)
         Me.ucrChkAdjustment.TabIndex = 43
         '
         'ucrInputComboBoxDescending
@@ -113,20 +152,20 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputComboBoxDescending.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxDescending.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxDescending.IsReadOnly = False
-        Me.ucrInputComboBoxDescending.Location = New System.Drawing.Point(138, 286)
+        Me.ucrInputComboBoxDescending.Location = New System.Drawing.Point(205, 311)
         Me.ucrInputComboBoxDescending.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxDescending.Name = "ucrInputComboBoxDescending"
-        Me.ucrInputComboBoxDescending.Size = New System.Drawing.Size(84, 22)
+        Me.ucrInputComboBoxDescending.Size = New System.Drawing.Size(112, 27)
         Me.ucrInputComboBoxDescending.TabIndex = 42
         '
         'ucrChkDescending
         '
         Me.ucrChkDescending.AutoSize = True
         Me.ucrChkDescending.Checked = False
-        Me.ucrChkDescending.Location = New System.Drawing.Point(9, 286)
+        Me.ucrChkDescending.Location = New System.Drawing.Point(12, 311)
         Me.ucrChkDescending.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkDescending.Name = "ucrChkDescending"
-        Me.ucrChkDescending.Size = New System.Drawing.Size(140, 24)
+        Me.ucrChkDescending.Size = New System.Drawing.Size(187, 30)
         Me.ucrChkDescending.TabIndex = 41
         '
         'ucrInputComboBoxDisplayLetters
@@ -135,20 +174,20 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputComboBoxDisplayLetters.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxDisplayLetters.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxDisplayLetters.IsReadOnly = True
-        Me.ucrInputComboBoxDisplayLetters.Location = New System.Drawing.Point(138, 258)
+        Me.ucrInputComboBoxDisplayLetters.Location = New System.Drawing.Point(205, 404)
         Me.ucrInputComboBoxDisplayLetters.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxDisplayLetters.Name = "ucrInputComboBoxDisplayLetters"
-        Me.ucrInputComboBoxDisplayLetters.Size = New System.Drawing.Size(84, 22)
+        Me.ucrInputComboBoxDisplayLetters.Size = New System.Drawing.Size(112, 27)
         Me.ucrInputComboBoxDisplayLetters.TabIndex = 40
         '
         'ucrChkDisplayLetters
         '
         Me.ucrChkDisplayLetters.AutoSize = True
         Me.ucrChkDisplayLetters.Checked = False
-        Me.ucrChkDisplayLetters.Location = New System.Drawing.Point(9, 258)
+        Me.ucrChkDisplayLetters.Location = New System.Drawing.Point(12, 404)
         Me.ucrChkDisplayLetters.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkDisplayLetters.Name = "ucrChkDisplayLetters"
-        Me.ucrChkDisplayLetters.Size = New System.Drawing.Size(140, 24)
+        Me.ucrChkDisplayLetters.Size = New System.Drawing.Size(187, 30)
         Me.ucrChkDisplayLetters.TabIndex = 39
         '
         'ucrInputComboBoxConfidenceInterval
@@ -157,53 +196,53 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputComboBoxConfidenceInterval.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxConfidenceInterval.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxConfidenceInterval.IsReadOnly = False
-        Me.ucrInputComboBoxConfidenceInterval.Location = New System.Drawing.Point(138, 230)
+        Me.ucrInputComboBoxConfidenceInterval.Location = New System.Drawing.Point(205, 373)
         Me.ucrInputComboBoxConfidenceInterval.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxConfidenceInterval.Name = "ucrInputComboBoxConfidenceInterval"
-        Me.ucrInputComboBoxConfidenceInterval.Size = New System.Drawing.Size(84, 22)
+        Me.ucrInputComboBoxConfidenceInterval.Size = New System.Drawing.Size(112, 27)
         Me.ucrInputComboBoxConfidenceInterval.TabIndex = 38
         '
         'ucrChkConfidenceInterval
         '
         Me.ucrChkConfidenceInterval.AutoSize = True
         Me.ucrChkConfidenceInterval.Checked = False
-        Me.ucrChkConfidenceInterval.Location = New System.Drawing.Point(9, 230)
+        Me.ucrChkConfidenceInterval.Location = New System.Drawing.Point(12, 373)
         Me.ucrChkConfidenceInterval.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkConfidenceInterval.Name = "ucrChkConfidenceInterval"
-        Me.ucrChkConfidenceInterval.Size = New System.Drawing.Size(140, 24)
+        Me.ucrChkConfidenceInterval.Size = New System.Drawing.Size(187, 30)
         Me.ucrChkConfidenceInterval.TabIndex = 37
         '
         'ucrInputComboBoxAlpha
         '
-        Me.ucrInputComboBoxAlpha.AddQuotesIfUnrecognised = False
+        Me.ucrInputComboBoxAlpha.AddQuotesIfUnrecognised = True
         Me.ucrInputComboBoxAlpha.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxAlpha.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxAlpha.IsReadOnly = True
-        Me.ucrInputComboBoxAlpha.Location = New System.Drawing.Point(138, 202)
+        Me.ucrInputComboBoxAlpha.Location = New System.Drawing.Point(205, 249)
         Me.ucrInputComboBoxAlpha.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxAlpha.Name = "ucrInputComboBoxAlpha"
-        Me.ucrInputComboBoxAlpha.Size = New System.Drawing.Size(84, 22)
+        Me.ucrInputComboBoxAlpha.Size = New System.Drawing.Size(112, 27)
         Me.ucrInputComboBoxAlpha.TabIndex = 36
         '
         'ucrChkAlpha
         '
         Me.ucrChkAlpha.AutoSize = True
         Me.ucrChkAlpha.Checked = False
-        Me.ucrChkAlpha.Location = New System.Drawing.Point(9, 202)
+        Me.ucrChkAlpha.Location = New System.Drawing.Point(12, 249)
         Me.ucrChkAlpha.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkAlpha.Name = "ucrChkAlpha"
-        Me.ucrChkAlpha.Size = New System.Drawing.Size(80, 24)
+        Me.ucrChkAlpha.Size = New System.Drawing.Size(187, 30)
         Me.ucrChkAlpha.TabIndex = 35
         '
         'ucrReceiverBy
         '
         Me.ucrReceiverBy.AutoSize = True
         Me.ucrReceiverBy.frmParent = Me
-        Me.ucrReceiverBy.Location = New System.Drawing.Point(230, 147)
+        Me.ucrReceiverBy.Location = New System.Drawing.Point(322, 196)
         Me.ucrReceiverBy.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverBy.Name = "ucrReceiverBy"
         Me.ucrReceiverBy.Selector = Nothing
-        Me.ucrReceiverBy.Size = New System.Drawing.Size(120, 22)
+        Me.ucrReceiverBy.Size = New System.Drawing.Size(160, 27)
         Me.ucrReceiverBy.strNcFilePath = ""
         Me.ucrReceiverBy.TabIndex = 33
         Me.ucrReceiverBy.ucrSelector = Nothing
@@ -212,11 +251,11 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrReceiverLabelVariable.AutoSize = True
         Me.ucrReceiverLabelVariable.frmParent = Me
-        Me.ucrReceiverLabelVariable.Location = New System.Drawing.Point(230, 104)
+        Me.ucrReceiverLabelVariable.Location = New System.Drawing.Point(322, 128)
         Me.ucrReceiverLabelVariable.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverLabelVariable.Name = "ucrReceiverLabelVariable"
         Me.ucrReceiverLabelVariable.Selector = Nothing
-        Me.ucrReceiverLabelVariable.Size = New System.Drawing.Size(120, 22)
+        Me.ucrReceiverLabelVariable.Size = New System.Drawing.Size(160, 27)
         Me.ucrReceiverLabelVariable.strNcFilePath = ""
         Me.ucrReceiverLabelVariable.TabIndex = 31
         Me.ucrReceiverLabelVariable.ucrSelector = Nothing
@@ -225,11 +264,11 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrReceiverMultipleMeanComparisonUseModel.AutoSize = True
         Me.ucrReceiverMultipleMeanComparisonUseModel.frmParent = Me
-        Me.ucrReceiverMultipleMeanComparisonUseModel.Location = New System.Drawing.Point(230, 61)
+        Me.ucrReceiverMultipleMeanComparisonUseModel.Location = New System.Drawing.Point(322, 75)
         Me.ucrReceiverMultipleMeanComparisonUseModel.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMultipleMeanComparisonUseModel.Name = "ucrReceiverMultipleMeanComparisonUseModel"
         Me.ucrReceiverMultipleMeanComparisonUseModel.Selector = Nothing
-        Me.ucrReceiverMultipleMeanComparisonUseModel.Size = New System.Drawing.Size(120, 22)
+        Me.ucrReceiverMultipleMeanComparisonUseModel.Size = New System.Drawing.Size(160, 27)
         Me.ucrReceiverMultipleMeanComparisonUseModel.strNcFilePath = ""
         Me.ucrReceiverMultipleMeanComparisonUseModel.TabIndex = 29
         Me.ucrReceiverMultipleMeanComparisonUseModel.ucrSelector = Nothing
@@ -237,20 +276,20 @@ Partial Class dlgModelMultipleComparisons
         'ucrSaveModelMultipleComparisons
         '
         Me.ucrSaveModelMultipleComparisons.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveModelMultipleComparisons.Location = New System.Drawing.Point(9, 351)
-        Me.ucrSaveModelMultipleComparisons.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.ucrSaveModelMultipleComparisons.Location = New System.Drawing.Point(12, 458)
+        Me.ucrSaveModelMultipleComparisons.Margin = New System.Windows.Forms.Padding(5, 6, 5, 6)
         Me.ucrSaveModelMultipleComparisons.Name = "ucrSaveModelMultipleComparisons"
-        Me.ucrSaveModelMultipleComparisons.Size = New System.Drawing.Size(306, 24)
+        Me.ucrSaveModelMultipleComparisons.Size = New System.Drawing.Size(408, 30)
         Me.ucrSaveModelMultipleComparisons.TabIndex = 27
         '
         'ucrBase
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(6, 383)
-        Me.ucrBase.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrBase.Location = New System.Drawing.Point(8, 533)
+        Me.ucrBase.Margin = New System.Windows.Forms.Padding(8, 7, 8, 7)
         Me.ucrBase.Name = "ucrBase"
-        Me.ucrBase.Size = New System.Drawing.Size(408, 52)
+        Me.ucrBase.Size = New System.Drawing.Size(511, 65)
         Me.ucrBase.TabIndex = 24
         '
         'ucrSelectorModelMultipleComparisons
@@ -259,17 +298,21 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrSelectorModelMultipleComparisons.bDropUnusedFilterLevels = False
         Me.ucrSelectorModelMultipleComparisons.bShowHiddenColumns = False
         Me.ucrSelectorModelMultipleComparisons.bUseCurrentFilter = True
-        Me.ucrSelectorModelMultipleComparisons.Location = New System.Drawing.Point(9, 12)
+        Me.ucrSelectorModelMultipleComparisons.Location = New System.Drawing.Point(12, 15)
         Me.ucrSelectorModelMultipleComparisons.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorModelMultipleComparisons.Name = "ucrSelectorModelMultipleComparisons"
-        Me.ucrSelectorModelMultipleComparisons.Size = New System.Drawing.Size(213, 184)
+        Me.ucrSelectorModelMultipleComparisons.Size = New System.Drawing.Size(284, 227)
         Me.ucrSelectorModelMultipleComparisons.TabIndex = 5
         '
         'dlgModelMultipleComparisons
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 16.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(419, 439)
+        Me.ClientSize = New System.Drawing.Size(552, 604)
+        Me.Controls.Add(Me.ucrSaveGraph)
+        Me.Controls.Add(Me.ucrInputGenerateMultipleComparisonGraphs)
+        Me.Controls.Add(Me.ucrChkGenerateMultipleComparisonPlot)
+        Me.Controls.Add(Me.ucrChkByOptional)
         Me.Controls.Add(Me.ucrInputComboBoxAdjustment)
         Me.Controls.Add(Me.ucrChkAdjustment)
         Me.Controls.Add(Me.ucrInputComboBoxDescending)
@@ -282,7 +325,6 @@ Partial Class dlgModelMultipleComparisons
         Me.Controls.Add(Me.ucrChkAlpha)
         Me.Controls.Add(Me.btnTransformation)
         Me.Controls.Add(Me.ucrReceiverBy)
-        Me.Controls.Add(Me.lblBy)
         Me.Controls.Add(Me.lblVariabletoUse)
         Me.Controls.Add(Me.ucrReceiverLabelVariable)
         Me.Controls.Add(Me.lblMultipleMeanComparisonModeltoUse)
@@ -291,6 +333,7 @@ Partial Class dlgModelMultipleComparisons
         Me.Controls.Add(Me.ucrBase)
         Me.Controls.Add(Me.ucrSelectorModelMultipleComparisons)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(4)
         Me.MinimizeBox = False
         Me.Name = "dlgModelMultipleComparisons"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
@@ -307,7 +350,6 @@ Partial Class dlgModelMultipleComparisons
     Friend WithEvents ucrReceiverMultipleMeanComparisonUseModel As ucrReceiverSingle
     Friend WithEvents lblVariabletoUse As Label
     Friend WithEvents ucrReceiverLabelVariable As ucrReceiverSingle
-    Friend WithEvents lblBy As Label
     Friend WithEvents ucrReceiverBy As ucrReceiverSingle
     Friend WithEvents ucrChkAlpha As ucrCheck
     Friend WithEvents ucrInputComboBoxAlpha As ucrInputComboBox
@@ -320,4 +362,8 @@ Partial Class dlgModelMultipleComparisons
     Friend WithEvents ucrInputComboBoxDescending As ucrInputComboBox
     Friend WithEvents ucrChkAdjustment As ucrCheck
     Friend WithEvents ucrInputComboBoxAdjustment As ucrInputComboBox
+    Friend WithEvents ucrChkByOptional As ucrCheck
+    Friend WithEvents ucrInputGenerateMultipleComparisonGraphs As ucrInputComboBox
+    Friend WithEvents ucrChkGenerateMultipleComparisonPlot As ucrCheck
+    Friend WithEvents ucrSaveGraph As ucrSave
 End Class

--- a/instat/dlgModelMultipleComparisons.vb
+++ b/instat/dlgModelMultipleComparisons.vb
@@ -15,16 +15,27 @@
 ' along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Imports instat.Translations
+Imports RDotNet
 
 Public Class dlgModelMultipleComparisons
     Private bFirstLoad As Boolean = True
     Private bReset As Boolean = True
+    Private lstModelFactorNames As New List(Of String)
+
+    Private ReadOnly strModelTmpName As String = "model_tmp"
+    Private ReadOnly strLastMctName As String = "last_mct"
+    Private ReadOnly strLastGraphName As String = "last_graph"
+    Private ReadOnly strDefaultGraphType As String = "Point"
 
     Private clsMultipleComparisonsFunction As New RFunction
     Private clsGetModelFunction As New RFunction
     Private clsAssignModelOperator As New ROperator
     Private clsRmFunction As New RFunction
+    Private clsAutoplotFunction As New RFunction
 
+    Private clsCheckGraphFunction As New RFunction
+    Private clsAddPlotObjectFunction As New RFunction
+    Private clsGetPlotObjectDataFunction As New RFunction
     Private Sub dlgModelMultipleComparisons_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
             InitialiseDialog()
@@ -60,26 +71,15 @@ Public Class dlgModelMultipleComparisons
         ucrReceiverBy.SetParameterIsString()
         ucrReceiverBy.SetIncludedDataTypes({"factor"})
 
+        ucrChkByOptional.SetText("By (Optional):")
+        ucrChkByOptional.AddToLinkedControls({ucrReceiverBy}, {True}, bNewLinkedHideIfParameterMissing:=True)
+
         ucrChkAlpha.SetText("Alpha")
         ucrInputComboBoxAlpha.SetItems({"0.001", "0.01", "0.02", "0.05", "0.1"})
         ucrInputComboBoxAlpha.SetDropDownStyleAsNonEditable()
         ucrInputComboBoxAlpha.AddQuotesIfUnrecognised = False
         ucrInputComboBoxAlpha.SetParameter(New RParameter("sig", 3))
         ucrChkAlpha.AddToLinkedControls(ucrInputComboBoxAlpha, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="0.05")
-
-        ucrChkConfidenceInterval.SetText("Confidence Interval")
-        ucrInputComboBoxConfidenceInterval.SetItems({"ci", "tukey", "1se", "2se", "none"})
-        ucrInputComboBoxConfidenceInterval.SetDropDownStyleAsNonEditable()
-        ucrInputComboBoxConfidenceInterval.AddQuotesIfUnrecognised = True
-        ucrInputComboBoxConfidenceInterval.SetParameter(New RParameter("int.type", 4))
-        ucrChkConfidenceInterval.AddToLinkedControls(ucrInputComboBoxConfidenceInterval, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="ci")
-
-        ucrChkDisplayLetters.SetText("Display Letters")
-        ucrInputComboBoxDisplayLetters.SetItems({"TRUE", "FALSE"})
-        ucrInputComboBoxDisplayLetters.SetDropDownStyleAsNonEditable()
-        ucrInputComboBoxDisplayLetters.AddQuotesIfUnrecognised = False
-        ucrInputComboBoxDisplayLetters.SetParameter(New RParameter("groups", 7))
-        ucrChkDisplayLetters.AddToLinkedControls(ucrInputComboBoxDisplayLetters, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="TRUE")
 
         ucrChkDescending.SetText("Descending")
         ucrInputComboBoxDescending.SetItems({"TRUE", "FALSE"})
@@ -95,70 +95,260 @@ Public Class dlgModelMultipleComparisons
         ucrInputComboBoxAdjustment.SetParameter(New RParameter("adjust", 6))
         ucrChkAdjustment.AddToLinkedControls(ucrInputComboBoxAdjustment, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="tukey")
 
+        ucrChkConfidenceInterval.SetText("Confidence Interval")
+        ucrInputComboBoxConfidenceInterval.SetItems({"ci", "tukey", "1se", "2se", "none"})
+        ucrInputComboBoxConfidenceInterval.SetDropDownStyleAsNonEditable()
+        ucrInputComboBoxConfidenceInterval.AddQuotesIfUnrecognised = True
+        ucrInputComboBoxConfidenceInterval.SetParameter(New RParameter("int.type", 4))
+        ucrChkConfidenceInterval.AddToLinkedControls(ucrInputComboBoxConfidenceInterval, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="ci")
+
+        ucrChkDisplayLetters.SetText("Display Letters")
+        ucrInputComboBoxDisplayLetters.SetItems({"TRUE", "FALSE"})
+        ucrInputComboBoxDisplayLetters.SetDropDownStyleAsNonEditable()
+        ucrInputComboBoxDisplayLetters.AddQuotesIfUnrecognised = False
+        ucrInputComboBoxDisplayLetters.SetParameter(New RParameter("groups", 7))
+        ucrChkDisplayLetters.AddToLinkedControls(ucrInputComboBoxDisplayLetters, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="TRUE")
+
         ucrSaveModelMultipleComparisons.SetPrefix("mct")
         ucrSaveModelMultipleComparisons.SetCheckBoxText("Store mct:")
         ucrSaveModelMultipleComparisons.SetIsComboBox()
         ucrSaveModelMultipleComparisons.SetSaveType(strRObjectType:=RObjectTypeLabel.Summary, strRObjectFormat:=RObjectFormat.Text)
+
+        ucrChkGenerateMultipleComparisonPlot.SetText("Generate Plot")
+        ucrInputGenerateMultipleComparisonGraphs.SetItems({strDefaultGraphType, "Line", "Bar"})
+        ucrInputGenerateMultipleComparisonGraphs.SetDropDownStyleAsNonEditable()
+        ucrInputGenerateMultipleComparisonGraphs.AddQuotesIfUnrecognised = True
+        ucrInputGenerateMultipleComparisonGraphs.SetParameter(New RParameter("type", 1))
+        ucrInputGenerateMultipleComparisonGraphs.SetRDefault(Chr(34) & strDefaultGraphType.ToLower() & Chr(34))
+        ucrChkGenerateMultipleComparisonPlot.AddToLinkedControls(ucrInputGenerateMultipleComparisonGraphs, {True}, bNewLinkedHideIfParameterMissing:=False, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=strDefaultGraphType)
+        ucrChkGenerateMultipleComparisonPlot.AddToLinkedControls(ucrSaveGraph, {True}, bNewLinkedHideIfParameterMissing:=False)
+
+        ucrSaveGraph.SetIsComboBox()
+        ucrSaveGraph.SetCheckBoxText("Store Graph")
+        ucrSaveGraph.SetDataFrameSelector(ucrSelectorModelMultipleComparisons.ucrAvailableDataFrames)
+        ucrSaveGraph.SetSaveTypeAsGraph()
+        ucrSaveGraph.SetPrefix("mct_plot")
+        ucrSaveGraph.SetAssignToIfUncheckedValue(strLastGraphName)
+        ucrSaveGraph.Enabled = False
     End Sub
 
     Private Sub SetDefaults()
 
         clsGetModelFunction = New RFunction
-        clsGetModelFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_object_data")
-
         clsAssignModelOperator = New ROperator
-        clsAssignModelOperator.SetOperation("<-")
-        clsAssignModelOperator.AddParameter("left", "model_tmp", iPosition:=0)
-        clsAssignModelOperator.AddParameter("right", clsRFunctionParameter:=clsGetModelFunction, iPosition:=1)
-        clsAssignModelOperator.bToScriptAsRString = False
-
-
         clsMultipleComparisonsFunction = New RFunction
-        clsMultipleComparisonsFunction.SetPackageName("biometryassist")
-        clsMultipleComparisonsFunction.SetRCommand("multiple_comparisons")
-        clsMultipleComparisonsFunction.AddParameter("model.obj", "model_tmp", iPosition:=0)
-
         clsRmFunction = New RFunction
-        clsRmFunction.SetRCommand("rm")
-        clsRmFunction.AddParameter("list", "c(""model_tmp"")", bIncludeArgumentName:=True, iPosition:=0)
-        clsRmFunction.bToScriptAsRString = False
+        clsAutoplotFunction = New RFunction
+        clsCheckGraphFunction = New RFunction
+        clsAddPlotObjectFunction = New RFunction
+        clsGetPlotObjectDataFunction = New RFunction
 
         ucrSelectorModelMultipleComparisons.Reset()
         ucrSaveModelMultipleComparisons.Reset()
         ucrSaveModelMultipleComparisons.ucrChkSave.Checked = False
+        ucrSaveGraph.Reset()
+        ucrSaveGraph.ucrChkSave.Checked = False
+        ucrSaveGraph.Enabled = False
+        ucrChkByOptional.Checked = False
+        ucrChkGenerateMultipleComparisonPlot.Checked = False
+        ucrReceiverBy.Visible = False
+        ucrInputGenerateMultipleComparisonGraphs.Visible = False
 
-        ucrBase.clsRsyntax.ClearCodes()
-        ucrBase.clsRsyntax.AddToBeforeCodes(clsAssignModelOperator)
-        ucrBase.clsRsyntax.SetBaseRFunction(clsMultipleComparisonsFunction)
-        ucrBase.clsRsyntax.AddToAfterCodes(clsRmFunction)
+        lstModelFactorNames = New List(Of String)
+
+        clsGetModelFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_object_data")
+
+        clsAssignModelOperator.SetOperation("<-")
+        clsAssignModelOperator.AddParameter("left", strModelTmpName, iPosition:=0)
+        clsAssignModelOperator.AddParameter("right", clsRFunctionParameter:=clsGetModelFunction, iPosition:=1)
+        clsAssignModelOperator.bToScriptAsRString = False
+
+        clsMultipleComparisonsFunction.SetPackageName("biometryassist")
+        clsMultipleComparisonsFunction.SetRCommand("multiple_comparisons")
+        clsMultipleComparisonsFunction.AddParameter("model.obj", strModelTmpName, iPosition:=0)
+
+        clsRmFunction.SetRCommand("rm")
+        clsRmFunction.bToScriptAsRString = False
+
+        clsAutoplotFunction.SetPackageName("biometryassist")
+        clsAutoplotFunction.SetRCommand("autoplot")
+
+        clsCheckGraphFunction.SetPackageName("instatExtras")
+        clsCheckGraphFunction.SetRCommand("check_graph")
+
+        clsAddPlotObjectFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$add_object")
+        clsGetPlotObjectDataFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_object_data")
+
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
 
-        ucrReceiverLabelVariable.SetRCode(clsMultipleComparisonsFunction, bReset)
-        ucrReceiverBy.SetRCode(clsMultipleComparisonsFunction, bReset)
         ucrInputComboBoxDisplayLetters.SetRCode(clsMultipleComparisonsFunction, bReset)
         ucrInputComboBoxConfidenceInterval.SetRCode(clsMultipleComparisonsFunction, bReset)
-
         ucrInputComboBoxAlpha.SetRCode(clsMultipleComparisonsFunction, bReset)
         ucrInputComboBoxDescending.SetRCode(clsMultipleComparisonsFunction, bReset)
         ucrInputComboBoxAdjustment.SetRCode(clsMultipleComparisonsFunction, bReset)
 
         If bReset Then
-
             ucrChkAlpha.SetRCode(clsMultipleComparisonsFunction, bReset)
             ucrChkConfidenceInterval.SetRCode(clsMultipleComparisonsFunction, bReset)
             ucrChkDisplayLetters.SetRCode(clsMultipleComparisonsFunction, bReset)
             ucrChkDescending.SetRCode(clsMultipleComparisonsFunction, bReset)
             ucrChkAdjustment.SetRCode(clsMultipleComparisonsFunction, bReset)
+            ucrChkGenerateMultipleComparisonPlot.SetRCode(clsMultipleComparisonsFunction, bReset)
+        End If
 
+        UpdateClassifyAndByParameters()
+        UpdateAssignTo()
+        UpdateGraphCode()
+    End Sub
+
+
+    ' Builds the classify (and, when By is in use, the by:classify interaction)
+    ' and by arguments on clsMultipleComparisonsFunction from the current receiver selections.`
+    Private Sub UpdateClassifyAndByParameters()
+        Dim bByInUse As Boolean = ucrChkByOptional.Checked AndAlso Not ucrReceiverBy.IsEmpty()
+
+        If Not ucrReceiverLabelVariable.IsEmpty() Then
+            Dim strClassify As String = ucrReceiverLabelVariable.GetVariableNames(bWithQuotes:=False)
+            If bByInUse Then
+                Dim strBy As String = ucrReceiverBy.GetVariableNames(bWithQuotes:=False)
+                clsMultipleComparisonsFunction.AddParameter("classify", Chr(34) & strBy & ":" & strClassify & Chr(34), iPosition:=1)
+            Else
+                clsMultipleComparisonsFunction.AddParameter("classify", Chr(34) & strClassify & Chr(34), iPosition:=1)
+            End If
+        Else
+            clsMultipleComparisonsFunction.RemoveParameterByName("classify")
+        End If
+
+        If bByInUse Then
+            clsMultipleComparisonsFunction.AddParameter("by", Chr(34) & ucrReceiverBy.GetVariableNames(bWithQuotes:=False) & Chr(34), iPosition:=2)
+        Else
+            clsMultipleComparisonsFunction.AddParameter("by", "NULL", iPosition:=2, bIncludeArgumentName:=True)
         End If
     End Sub
 
+    Private Sub UpdateAssignTo()
+        If ucrSaveModelMultipleComparisons.ucrChkSave.Checked AndAlso ucrSaveModelMultipleComparisons.GetText() <> "" AndAlso ucrSaveModelMultipleComparisons.IsComplete() Then
+            clsMultipleComparisonsFunction.SetAssignToOutputObject(
+                strRObjectToAssignTo:=ucrSaveModelMultipleComparisons.GetText(),
+                strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Summary,
+                strRObjectFormatToAssignTo:=RObjectFormat.Text,
+                strRDataFrameNameToAddObjectTo:=ucrSelectorModelMultipleComparisons.strCurrentDataFrame,
+                strObjectName:=ucrSaveModelMultipleComparisons.GetText())
+        Else
+            clsMultipleComparisonsFunction.RemoveAssignTo()
+            clsMultipleComparisonsFunction.SetAssignTo(strLastMctName)
+        End If
+    End Sub
+
+
+    ' Rebuilds the graph pipeline: produce the plot, validate it, register it in the object store,
+    ' then pull it back out for display. Uses ClearCodes() and rebuilds everything from scratch
+    ' rather than incrementally adding/removing pieces.
+    Private Sub UpdateGraphCode()
+        ucrBase.clsRsyntax.ClearCodes()
+        ucrBase.clsRsyntax.AddToBeforeCodes(clsAssignModelOperator)
+        ucrBase.clsRsyntax.SetBaseRFunction(clsMultipleComparisonsFunction)
+
+        Dim strMctName As String = GetMctName()
+        Dim strRmList As String = BuildRemovalList(strMctName)
+
+        If ucrChkGenerateMultipleComparisonPlot.Checked Then
+            Dim strGraphName As String = GetGraphName()
+            BuildGraphPipeline(strMctName, strGraphName)
+
+            If Not ucrSaveGraph.ucrChkSave.Checked Then
+                strRmList &= ", " & Chr(34) & strLastGraphName & Chr(34)
+            End If
+        End If
+
+        AddCleanupCode(strRmList)
+    End Sub
+
+
+    ' Name the current mct object will be assigned to (or the transient default if not saved).
+    Private Function GetMctName() As String
+        Return If(ucrSaveModelMultipleComparisons.ucrChkSave.Checked AndAlso ucrSaveModelMultipleComparisons.GetText() <> "",
+                   ucrSaveModelMultipleComparisons.GetText(), strLastMctName)
+    End Function
+
+
+    ' Name the current graph object will be assigned to (or the transient default if not saved).
+    Private Function GetGraphName() As String
+        Return If(ucrSaveGraph.ucrChkSave.Checked AndAlso ucrSaveGraph.GetText() <> "",
+                  ucrSaveGraph.GetText(), strLastGraphName)
+    End Function
+
+
+    ' Starts the rm list with the temporary model object, adding the mct object too if it wasn't saved.
+    Private Function BuildRemovalList(strMctName As String) As String
+        Dim strRmList As String = Chr(34) & strModelTmpName & Chr(34)
+        If Not ucrSaveModelMultipleComparisons.ucrChkSave.Checked Then
+            strRmList &= ", " & Chr(34) & strLastMctName & Chr(34)
+        End If
+        Return strRmList
+    End Function
+
+
+    ' Wires up autoplot() -> check_graph() -> add_object() -> get_object_data() and appends them
+    ' to the after-codes so the graph is built, validated, stored, and pulled back out for display.
+    Private Sub BuildGraphPipeline(strMctName As String, strGraphName As String)
+        Dim strDataFrame As String = ucrSelectorModelMultipleComparisons.strCurrentDataFrame
+
+        ' autoplot
+        clsAutoplotFunction.ClearParameters()
+        clsAutoplotFunction.AddParameter("object", strMctName, iPosition:=0, bIncludeArgumentName:=False)
+        Dim strType As String = ucrInputGenerateMultipleComparisonGraphs.GetText()
+        If strType = "" Then strType = strDefaultGraphType
+        clsAutoplotFunction.AddParameter("type", Chr(34) & strType.ToLower() & Chr(34), iPosition:=1)
+        clsAutoplotFunction.AddParameter("label_height", "0.1", iPosition:=2) ' fraction of plot height reserved for group letters
+        clsAutoplotFunction.SetAssignTo(strGraphName)
+
+        ' check_graph
+        clsCheckGraphFunction.ClearParameters()
+        clsCheckGraphFunction.AddParameter("graph_object", strGraphName, iPosition:=0)
+
+        ' add_object
+        clsAddPlotObjectFunction.ClearParameters()
+        If Not String.IsNullOrEmpty(strDataFrame) Then
+            clsAddPlotObjectFunction.AddParameter("data_name", Chr(34) & strDataFrame & Chr(34), iPosition:=0)
+        End If
+        clsAddPlotObjectFunction.AddParameter("object_name", Chr(34) & strGraphName & Chr(34), iPosition:=1)
+        clsAddPlotObjectFunction.AddParameter("object_type_label", Chr(34) & "graph" & Chr(34), iPosition:=2)
+        clsAddPlotObjectFunction.AddParameter("object_format", Chr(34) & "image" & Chr(34), iPosition:=3)
+        clsAddPlotObjectFunction.AddParameter("object", clsRFunctionParameter:=clsCheckGraphFunction, iPosition:=4)
+
+        ' get_object_data
+        clsGetPlotObjectDataFunction.ClearParameters()
+        If Not String.IsNullOrEmpty(strDataFrame) Then
+            clsGetPlotObjectDataFunction.AddParameter("data_name", Chr(34) & strDataFrame & Chr(34), iPosition:=0)
+        End If
+        clsGetPlotObjectDataFunction.AddParameter("object_name", Chr(34) & strGraphName & Chr(34), iPosition:=1)
+        clsGetPlotObjectDataFunction.AddParameter("as_file", "TRUE", iPosition:=2)
+
+        ucrBase.clsRsyntax.AddToAfterCodes(clsAutoplotFunction)
+        ucrBase.clsRsyntax.AddToAfterCodes(clsAddPlotObjectFunction)
+        ucrBase.clsRsyntax.AddToAfterCodes(clsGetPlotObjectDataFunction)
+    End Sub
+
+
+    ' rm call that clears out unsaved objects at the end of the script.
+    Private Sub AddCleanupCode(strRmList As String)
+        clsRmFunction.ClearParameters()
+        clsRmFunction.AddParameter("list", "c(" & strRmList & ")", bIncludeArgumentName:=True, iPosition:=0)
+        ucrBase.clsRsyntax.AddToAfterCodes(clsRmFunction)
+    End Sub
+
     Private Sub TestOkEnabled()
+        Dim bByDuplicatesLabel As Boolean = ucrChkByOptional.Checked AndAlso Not ucrReceiverBy.IsEmpty() AndAlso
+                                             ucrReceiverBy.GetVariableNames(bWithQuotes:=False) = ucrReceiverLabelVariable.GetVariableNames(bWithQuotes:=False)
+
         Dim bOKEnabled As Boolean = Not ucrReceiverMultipleMeanComparisonUseModel.IsEmpty() AndAlso
                                     Not ucrReceiverLabelVariable.IsEmpty() AndAlso
-                                    ucrSaveModelMultipleComparisons.IsComplete()
+                                    Not bByDuplicatesLabel AndAlso
+                                    ucrSaveModelMultipleComparisons.IsComplete() AndAlso
+                                    (Not ucrChkGenerateMultipleComparisonPlot.Checked OrElse ucrSaveGraph.IsComplete())
 
         ucrBase.OKEnabled(bOKEnabled)
     End Sub
@@ -176,46 +366,68 @@ Public Class dlgModelMultipleComparisons
         Else
             clsGetModelFunction.RemoveParameterByName("object_name")
         End If
+        UpdateModelFactorNames()
         TestOkEnabled()
-    End Sub
-
-    'Updates the Default name In the "Store mct:" save control based On the currently selected model, rather than the Label Variable
-    'strips off the prefix before the first underscore And uses the remainder As the suffix For the mct Object name
-    Private Sub UpdateSaveName()
-        Dim strModelName As String = ucrReceiverMultipleMeanComparisonUseModel.GetVariableNames(bWithQuotes:=False)
-        Dim iUnderscoreIndex As Integer = strModelName.IndexOf("_"c)
-
-        If iUnderscoreIndex >= 0 AndAlso iUnderscoreIndex < strModelName.Length - 1 Then
-            ucrSaveModelMultipleComparisons.SetName("mct_" & strModelName.Substring(iUnderscoreIndex + 1))
-        Else
-            ucrSaveModelMultipleComparisons.SetName("mct_" & strModelName)
-        End If
     End Sub
 
     Private Sub ucrSelectorModelMultipleComparisons_DataFrameChanged() Handles ucrSelectorModelMultipleComparisons.DataFrameChanged
         If Not String.IsNullOrEmpty(ucrSelectorModelMultipleComparisons.strCurrentDataFrame) Then
             clsGetModelFunction.AddParameter("data_name", Chr(34) & ucrSelectorModelMultipleComparisons.strCurrentDataFrame & Chr(34))
         End If
+        UpdateAssignTo()
+        UpdateGraphCode()
+        UpdateModelFactorNames()
         TestOkEnabled()
     End Sub
 
     Private Sub ucrSaveModelMultipleComparisons_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSaveModelMultipleComparisons.ControlValueChanged
-        If ucrSaveModelMultipleComparisons.ucrChkSave.Checked AndAlso ucrSaveModelMultipleComparisons.GetText() <> "" AndAlso ucrSaveModelMultipleComparisons.IsComplete() Then
-            clsMultipleComparisonsFunction.SetAssignToOutputObject(
-        strRObjectToAssignTo:=ucrSaveModelMultipleComparisons.GetText(),
-        strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Summary,
-        strRObjectFormatToAssignTo:=RObjectFormat.Text,
-        strRDataFrameNameToAddObjectTo:=ucrSelectorModelMultipleComparisons.strCurrentDataFrame,
-        strObjectName:=ucrSaveModelMultipleComparisons.GetText())
-        Else
-            clsMultipleComparisonsFunction.RemoveAssignTo()
-        End If
-    End Sub
-
-    Private Sub ucrReceiverLabelVariable_SelectionChanged(sender As Object, e As EventArgs) Handles ucrReceiverLabelVariable.SelectionChanged
+        UpdateAssignTo()
+        UpdateGraphCode()
         TestOkEnabled()
     End Sub
 
+    Private Sub ucrReceiverLabelVariable_SelectionChanged(sender As Object, e As EventArgs) Handles ucrReceiverLabelVariable.SelectionChanged
+        UpdateClassifyAndByParameters()
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrReceiverBy_SelectionChanged(sender As Object, e As EventArgs) Handles ucrReceiverBy.SelectionChanged
+        UpdateClassifyAndByParameters()
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrChkByOptional_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkByOptional.ControlValueChanged
+        If Not ucrChkByOptional.Checked Then
+            ucrReceiverBy.Clear()
+        End If
+        ucrReceiverBy.Visible = ucrChkByOptional.Checked
+
+        UpdateClassifyAndByParameters()
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrChkGenerateMultipleComparisonPlot_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrChkGenerateMultipleComparisonPlot.ControlValueChanged
+        If ucrChkGenerateMultipleComparisonPlot.Checked Then
+            ucrSaveModelMultipleComparisons.ucrChkSave.Checked = True
+        Else
+            ucrSaveGraph.ucrChkSave.Checked = False
+        End If
+        ucrSaveGraph.Enabled = ucrChkGenerateMultipleComparisonPlot.Checked
+        ucrInputGenerateMultipleComparisonGraphs.Visible = ucrChkGenerateMultipleComparisonPlot.Checked
+        UpdateAssignTo()
+        UpdateGraphCode()
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrInputGenerateMultipleComparisonGraphs_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrInputGenerateMultipleComparisonGraphs.ControlValueChanged
+        UpdateGraphCode()
+    End Sub
+
+    Private Sub ucrSaveGraph_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrSaveGraph.ControlValueChanged
+        UpdateAssignTo()
+        UpdateGraphCode()
+        TestOkEnabled()
+    End Sub
 
     Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles _
         ucrReceiverLabelVariable.ControlContentsChanged,
@@ -229,8 +441,89 @@ Public Class dlgModelMultipleComparisons
         ucrChkDescending.ControlContentsChanged,
         ucrInputComboBoxDescending.ControlContentsChanged,
         ucrChkAdjustment.ControlContentsChanged,
-        ucrInputComboBoxAdjustment.ControlContentsChanged
+        ucrInputComboBoxAdjustment.ControlContentsChanged,
+        ucrChkByOptional.ControlContentsChanged,
+        ucrChkGenerateMultipleComparisonPlot.ControlContentsChanged,
+        ucrInputGenerateMultipleComparisonGraphs.ControlContentsChanged,
+        ucrSaveGraph.ControlContentsChanged
 
         TestOkEnabled()
+    End Sub
+
+
+    'save name derived from the model name.
+    Private Sub UpdateSaveName()
+        Dim strModelName As String = ucrReceiverMultipleMeanComparisonUseModel.GetVariableNames(bWithQuotes:=False)
+        Dim iUnderscoreIndex As Integer = strModelName.IndexOf("_"c)
+
+        If iUnderscoreIndex >= 0 AndAlso iUnderscoreIndex < strModelName.Length - 1 Then
+            ucrSaveModelMultipleComparisons.SetName("mct_" & strModelName.Substring(iUnderscoreIndex + 1))
+        Else
+            ucrSaveModelMultipleComparisons.SetName("mct_" & strModelName)
+        End If
+        UpdateAssignTo()
+        UpdateGraphCode()
+    End Sub
+
+
+    'In the receivers we need to get the factors from the object and not from the data frame.
+    Private Sub UpdateModelFactorNames()
+        Dim strPrvLabelVariable As String = ucrReceiverLabelVariable.GetVariableNames(bWithQuotes:=False)
+        Dim strPrvBy As String = ucrReceiverBy.GetVariableNames(bWithQuotes:=False)
+
+        lstModelFactorNames = New List(Of String)
+
+        If Not ucrReceiverMultipleMeanComparisonUseModel.IsEmpty() AndAlso Not String.IsNullOrEmpty(ucrSelectorModelMultipleComparisons.strCurrentDataFrame) Then
+            Dim strModelName As String = ucrReceiverMultipleMeanComparisonUseModel.GetVariableNames(bWithQuotes:=False)
+            Dim strScript As String = "all.vars(formula(" & frmMain.clsRLink.strInstatDataObject & "$get_object_data(data_name = " &
+                Chr(34) & ucrSelectorModelMultipleComparisons.strCurrentDataFrame & Chr(34) & ", object_name = " &
+                Chr(34) & strModelName & Chr(34) & ")))"
+
+            Dim expModelVariables As SymbolicExpression = frmMain.clsRLink.RunInternalScriptGetValue(strScript, bSilent:=True)
+            If expModelVariables IsNot Nothing AndAlso Not expModelVariables.Type = RDotNet.Internals.SymbolicExpressionType.Null Then
+                lstModelFactorNames = expModelVariables.AsCharacter().ToList()
+            End If
+        End If
+
+        ' If the receivers currently hold a factor that is no longer part of the newly selected model, clear them
+        If Not String.IsNullOrEmpty(strPrvLabelVariable) AndAlso Not lstModelFactorNames.Contains(strPrvLabelVariable) Then
+            ucrReceiverLabelVariable.Clear()
+        End If
+        If Not String.IsNullOrEmpty(strPrvBy) AndAlso Not lstModelFactorNames.Contains(strPrvBy) Then
+            ucrReceiverBy.Clear()
+        End If
+
+        FilterFactorReceiverItems()
+    End Sub
+
+
+    ' Excludes the sibling factor receiver's currently selected variable from the available list,
+    ' alongside the existing model-factor filtering,
+    ' so the same variable can't be picked as both Label Variable and By.`
+    Private Sub FilterFactorReceiverItems()
+        If lstModelFactorNames.Count > 0 AndAlso
+       (ucrSelectorModelMultipleComparisons.CurrentReceiver Is ucrReceiverLabelVariable OrElse
+        ucrSelectorModelMultipleComparisons.CurrentReceiver Is ucrReceiverBy) Then
+
+            ' same variable can't be both the Label Variable and the By variable at once.
+            Dim strSiblingValue As String = If(ucrSelectorModelMultipleComparisons.CurrentReceiver Is ucrReceiverLabelVariable,
+                                            ucrReceiverBy.GetVariableNames(bWithQuotes:=False),
+                                            ucrReceiverLabelVariable.GetVariableNames(bWithQuotes:=False))
+
+            For i As Integer = ucrSelectorModelMultipleComparisons.lstAvailableVariable.Items.Count - 1 To 0 Step -1
+                Dim lviCurrent As ListViewItem = ucrSelectorModelMultipleComparisons.lstAvailableVariable.Items(i)
+                If Not lstModelFactorNames.Contains(lviCurrent.Text) OrElse lviCurrent.Text = strSiblingValue Then
+                    ucrSelectorModelMultipleComparisons.lstAvailableVariable.Items.RemoveAt(i)
+                End If
+            Next
+        End If
+    End Sub
+
+    Private Sub ucrReceiverLabelVariable_Enter(sender As Object, e As EventArgs) Handles ucrReceiverLabelVariable.Enter
+        FilterFactorReceiverItems()
+    End Sub
+
+    Private Sub ucrReceiverBy_Enter(sender As Object, e As EventArgs) Handles ucrReceiverBy.Enter
+        FilterFactorReceiverItems()
     End Sub
 End Class


### PR DESCRIPTION
@rdstern Kindly Check this .
In this Pr here is what I was doing for this dialog. Kindly Check

First is this - In the receivers we need to get the factors from the object and not from the data frame.

> a) The By (Optional): seems a "bigger deal" than I thought earlier. So, could you please add a checkbox at the front, default unchecked. When unchecked the receiver is not shown. (When checked it is as now.)
> b) The code, when the By variable is included, is a bit changed from the obvious. The By is given as you have included already, but the Classify is given as "nitrogen:variety" rather than just variety (so variety within nitrogen, which is what it does.
> c) In the code generated, could you also always include descending = FALSE (or TRUE). (Usually, as you have now, we don't include the default, but here it would help if a user wants to tweak the script.)
> d) Could you also always include the adjust argument, in the command, with the default if it isn't changed.
> e) Could you please reorder the checkboxes on the left, so, under alpha next could be Descending and the third is Adjustment. (This is because they are also used in the other options - pairwise and reference - while the others are not.)
> f) Could you also always include By in the command too. It has By = NULL if not used in the dialog.
> g) Could you add a Graph checkbox, default unchecked. If checked it produces a graph - just as you have done for the One Button dialog. Also, on the same line, if checked, then a Type label becomes visible. This has a drop-down with the 3 options Point, Line, Bar. This generates the additional line biometryassist::autoplot(mct_reg, type="point", label_height = 0.1) as shown in the figure above.
> In the R code please can you always give the type argument and also include the default label_height = 0.1 argument. That will then be easy to edit, if it isn't quite right.
> h) And can you add the Store Graph option - as you have already done in the One Button dialog. This is disabled unless the Graph checkbox is ticked.

------

<img width="520" height="652" alt="image" src="https://github.com/user-attachments/assets/3b2d46da-abaf-4342-baa5-75831d164feb" />

Store Graph is only activated after Generate Plot is checked and the By Receiver is activated only after the checkbox is checked

----------
<img width="520" height="652" alt="image" src="https://github.com/user-attachments/assets/b19548f3-dc4e-4763-a63b-8aaa37335c40" />

Full dialog with everything checked

-----

<img width="872" height="290" alt="image" src="https://github.com/user-attachments/assets/779c76a3-eb7b-4773-a4dd-854cdb74bcf9" />

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/41f50e5a-1585-40a2-bb19-d4f9a9c5a314" />

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/4982ac83-1ea6-498e-920c-9198241edc25" />

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/1f4238a4-bfbb-411d-9e4a-da5016c5e82a" />

----------

Also the plot options on Use Graph don't really work . It throws a warning error so it is not just the development version. I tried with version 0.8.16.133
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/83eaec6b-1758-4d37-aa28-97db27068e68" />


