### PR TITLE
Added radio button for Pairwise and Reference

### DIFF
--- a/instat/dlgModelMultipleComparisons.Designer.vb
+++ b/instat/dlgModelMultipleComparisons.Designer.vb
@@ -443,7 +443,7 @@ Partial Class dlgModelMultipleComparisons
         Me.MinimizeBox = False
         Me.Name = "dlgModelMultipleComparisons"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
-        Me.Text = "Comparisons"
+        Me.Text = "Multiple Comparisons"
         Me.ResumeLayout(False)
         Me.PerformLayout()
 

--- a/instat/dlgModelMultipleComparisons.Designer.vb
+++ b/instat/dlgModelMultipleComparisons.Designer.vb
@@ -22,6 +22,10 @@ Partial Class dlgModelMultipleComparisons
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
+        Me.ucrPnlComparisonType = New instat.UcrPanel()
+        Me.rdoMultiple = New System.Windows.Forms.RadioButton()
+        Me.rdoPairwise = New System.Windows.Forms.RadioButton()
+        Me.rdoReference = New System.Windows.Forms.RadioButton()
         Me.lblMultipleMeanComparisonModeltoUse = New System.Windows.Forms.Label()
         Me.lblVariabletoUse = New System.Windows.Forms.Label()
         Me.btnTransformation = New System.Windows.Forms.Button()
@@ -29,6 +33,7 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputGenerateMultipleComparisonGraphs = New instat.ucrInputComboBox()
         Me.ucrChkGenerateMultipleComparisonPlot = New instat.ucrCheck()
         Me.ucrChkByOptional = New instat.ucrCheck()
+        Me.lblReference = New System.Windows.Forms.Label()
         Me.ucrInputComboBoxAdjustment = New instat.ucrInputComboBox()
         Me.ucrChkAdjustment = New instat.ucrCheck()
         Me.ucrInputComboBoxDescending = New instat.ucrInputComboBox()
@@ -40,6 +45,7 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputComboBoxAlpha = New instat.ucrInputComboBox()
         Me.ucrChkAlpha = New instat.ucrCheck()
         Me.ucrReceiverBy = New instat.ucrReceiverSingle()
+        Me.ucrReceiverReference = New instat.ucrInputComboBox()
         Me.ucrReceiverLabelVariable = New instat.ucrReceiverSingle()
         Me.ucrReceiverMultipleMeanComparisonUseModel = New instat.ucrReceiverSingle()
         Me.ucrSaveModelMultipleComparisons = New instat.ucrSave()
@@ -47,11 +53,81 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrSelectorModelMultipleComparisons = New instat.ucrSelectorByDataFrameAddRemove()
         Me.SuspendLayout()
         '
+        'ucrPnlComparisonType
+        '
+        Me.ucrPnlComparisonType.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrPnlComparisonType.Location = New System.Drawing.Point(92, 15)
+        Me.ucrPnlComparisonType.Margin = New System.Windows.Forms.Padding(6)
+        Me.ucrPnlComparisonType.Name = "ucrPnlComparisonType"
+        Me.ucrPnlComparisonType.Size = New System.Drawing.Size(340, 72)
+        Me.ucrPnlComparisonType.TabIndex = 61
+        '
+        'rdoMultiple
+        '
+        Me.rdoMultiple.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoMultiple.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoMultiple.Checked = True
+        Me.rdoMultiple.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoMultiple.FlatAppearance.BorderSize = 2
+        Me.rdoMultiple.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoMultiple.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoMultiple.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoMultiple.Location = New System.Drawing.Point(103, 24)
+        Me.rdoMultiple.Margin = New System.Windows.Forms.Padding(4)
+        Me.rdoMultiple.Name = "rdoMultiple"
+        Me.rdoMultiple.Size = New System.Drawing.Size(109, 55)
+        Me.rdoMultiple.TabIndex = 0
+        Me.rdoMultiple.TabStop = True
+        Me.rdoMultiple.Tag = "Type"
+        Me.rdoMultiple.Text = "Multiple"
+        Me.rdoMultiple.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoMultiple.UseVisualStyleBackColor = False
+        '
+        'rdoPairwise
+        '
+        Me.rdoPairwise.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoPairwise.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoPairwise.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoPairwise.FlatAppearance.BorderSize = 2
+        Me.rdoPairwise.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoPairwise.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoPairwise.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoPairwise.Location = New System.Drawing.Point(204, 24)
+        Me.rdoPairwise.Margin = New System.Windows.Forms.Padding(4)
+        Me.rdoPairwise.Name = "rdoPairwise"
+        Me.rdoPairwise.Size = New System.Drawing.Size(109, 55)
+        Me.rdoPairwise.TabIndex = 1
+        Me.rdoPairwise.TabStop = True
+        Me.rdoPairwise.Tag = "Type"
+        Me.rdoPairwise.Text = "Pairwise"
+        Me.rdoPairwise.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoPairwise.UseVisualStyleBackColor = False
+        '
+        'rdoReference
+        '
+        Me.rdoReference.Appearance = System.Windows.Forms.Appearance.Button
+        Me.rdoReference.BackColor = System.Drawing.SystemColors.Control
+        Me.rdoReference.FlatAppearance.BorderColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoReference.FlatAppearance.BorderSize = 2
+        Me.rdoReference.FlatAppearance.CheckedBackColor = System.Drawing.SystemColors.ActiveCaption
+        Me.rdoReference.FlatStyle = System.Windows.Forms.FlatStyle.Flat
+        Me.rdoReference.ImeMode = System.Windows.Forms.ImeMode.NoControl
+        Me.rdoReference.Location = New System.Drawing.Point(305, 24)
+        Me.rdoReference.Margin = New System.Windows.Forms.Padding(4)
+        Me.rdoReference.Name = "rdoReference"
+        Me.rdoReference.Size = New System.Drawing.Size(109, 55)
+        Me.rdoReference.TabIndex = 2
+        Me.rdoReference.TabStop = True
+        Me.rdoReference.Tag = "Type"
+        Me.rdoReference.Text = "Reference"
+        Me.rdoReference.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        Me.rdoReference.UseVisualStyleBackColor = False
+        '
         'lblMultipleMeanComparisonModeltoUse
         '
         Me.lblMultipleMeanComparisonModeltoUse.AutoSize = True
         Me.lblMultipleMeanComparisonModeltoUse.ImageAlign = System.Drawing.ContentAlignment.BottomLeft
-        Me.lblMultipleMeanComparisonModeltoUse.Location = New System.Drawing.Point(322, 57)
+        Me.lblMultipleMeanComparisonModeltoUse.Location = New System.Drawing.Point(322, 117)
         Me.lblMultipleMeanComparisonModeltoUse.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblMultipleMeanComparisonModeltoUse.Name = "lblMultipleMeanComparisonModeltoUse"
         Me.lblMultipleMeanComparisonModeltoUse.Size = New System.Drawing.Size(105, 16)
@@ -63,7 +139,7 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.lblVariabletoUse.AutoSize = True
         Me.lblVariabletoUse.ImageAlign = System.Drawing.ContentAlignment.BottomLeft
-        Me.lblVariabletoUse.Location = New System.Drawing.Point(323, 111)
+        Me.lblVariabletoUse.Location = New System.Drawing.Point(323, 171)
         Me.lblVariabletoUse.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.lblVariabletoUse.Name = "lblVariabletoUse"
         Me.lblVariabletoUse.Size = New System.Drawing.Size(98, 16)
@@ -74,7 +150,7 @@ Partial Class dlgModelMultipleComparisons
         'btnTransformation
         '
         Me.btnTransformation.Enabled = False
-        Me.btnTransformation.Location = New System.Drawing.Point(322, 226)
+        Me.btnTransformation.Location = New System.Drawing.Point(322, 339)
         Me.btnTransformation.Margin = New System.Windows.Forms.Padding(4)
         Me.btnTransformation.Name = "btnTransformation"
         Me.btnTransformation.Size = New System.Drawing.Size(160, 31)
@@ -86,7 +162,7 @@ Partial Class dlgModelMultipleComparisons
         'ucrSaveGraph
         '
         Me.ucrSaveGraph.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveGraph.Location = New System.Drawing.Point(12, 494)
+        Me.ucrSaveGraph.Location = New System.Drawing.Point(12, 554)
         Me.ucrSaveGraph.Margin = New System.Windows.Forms.Padding(5, 6, 5, 6)
         Me.ucrSaveGraph.Name = "ucrSaveGraph"
         Me.ucrSaveGraph.Size = New System.Drawing.Size(408, 30)
@@ -98,7 +174,7 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputGenerateMultipleComparisonGraphs.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputGenerateMultipleComparisonGraphs.GetSetSelectedIndex = -1
         Me.ucrInputGenerateMultipleComparisonGraphs.IsReadOnly = False
-        Me.ucrInputGenerateMultipleComparisonGraphs.Location = New System.Drawing.Point(205, 280)
+        Me.ucrInputGenerateMultipleComparisonGraphs.Location = New System.Drawing.Point(205, 340)
         Me.ucrInputGenerateMultipleComparisonGraphs.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputGenerateMultipleComparisonGraphs.Name = "ucrInputGenerateMultipleComparisonGraphs"
         Me.ucrInputGenerateMultipleComparisonGraphs.Size = New System.Drawing.Size(112, 27)
@@ -108,7 +184,7 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrChkGenerateMultipleComparisonPlot.AutoSize = True
         Me.ucrChkGenerateMultipleComparisonPlot.Checked = False
-        Me.ucrChkGenerateMultipleComparisonPlot.Location = New System.Drawing.Point(12, 280)
+        Me.ucrChkGenerateMultipleComparisonPlot.Location = New System.Drawing.Point(12, 340)
         Me.ucrChkGenerateMultipleComparisonPlot.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkGenerateMultipleComparisonPlot.Name = "ucrChkGenerateMultipleComparisonPlot"
         Me.ucrChkGenerateMultipleComparisonPlot.Size = New System.Drawing.Size(187, 30)
@@ -118,11 +194,23 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrChkByOptional.AutoSize = True
         Me.ucrChkByOptional.Checked = False
-        Me.ucrChkByOptional.Location = New System.Drawing.Point(322, 164)
+        Me.ucrChkByOptional.Location = New System.Drawing.Point(322, 224)
         Me.ucrChkByOptional.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkByOptional.Name = "ucrChkByOptional"
         Me.ucrChkByOptional.Size = New System.Drawing.Size(105, 29)
         Me.ucrChkByOptional.TabIndex = 45
+        '
+        'lblReference
+        '
+        Me.lblReference.AutoSize = True
+        Me.lblReference.ImageAlign = System.Drawing.ContentAlignment.BottomLeft
+        Me.lblReference.Location = New System.Drawing.Point(323, 286)
+        Me.lblReference.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.lblReference.Name = "lblReference"
+        Me.lblReference.Size = New System.Drawing.Size(109, 16)
+        Me.lblReference.TabIndex = 62
+        Me.lblReference.Tag = "Reference_Level:"
+        Me.lblReference.Text = "Reference Level:"
         '
         'ucrInputComboBoxAdjustment
         '
@@ -130,7 +218,7 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputComboBoxAdjustment.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxAdjustment.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxAdjustment.IsReadOnly = False
-        Me.ucrInputComboBoxAdjustment.Location = New System.Drawing.Point(205, 342)
+        Me.ucrInputComboBoxAdjustment.Location = New System.Drawing.Point(205, 402)
         Me.ucrInputComboBoxAdjustment.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxAdjustment.Name = "ucrInputComboBoxAdjustment"
         Me.ucrInputComboBoxAdjustment.Size = New System.Drawing.Size(112, 27)
@@ -140,7 +228,7 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrChkAdjustment.AutoSize = True
         Me.ucrChkAdjustment.Checked = False
-        Me.ucrChkAdjustment.Location = New System.Drawing.Point(12, 342)
+        Me.ucrChkAdjustment.Location = New System.Drawing.Point(12, 402)
         Me.ucrChkAdjustment.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkAdjustment.Name = "ucrChkAdjustment"
         Me.ucrChkAdjustment.Size = New System.Drawing.Size(187, 30)
@@ -148,11 +236,11 @@ Partial Class dlgModelMultipleComparisons
         '
         'ucrInputComboBoxDescending
         '
-        Me.ucrInputComboBoxDescending.AddQuotesIfUnrecognised = True
+        Me.ucrInputComboBoxDescending.AddQuotesIfUnrecognised = False
         Me.ucrInputComboBoxDescending.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxDescending.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxDescending.IsReadOnly = False
-        Me.ucrInputComboBoxDescending.Location = New System.Drawing.Point(205, 311)
+        Me.ucrInputComboBoxDescending.Location = New System.Drawing.Point(205, 371)
         Me.ucrInputComboBoxDescending.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxDescending.Name = "ucrInputComboBoxDescending"
         Me.ucrInputComboBoxDescending.Size = New System.Drawing.Size(112, 27)
@@ -162,7 +250,7 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrChkDescending.AutoSize = True
         Me.ucrChkDescending.Checked = False
-        Me.ucrChkDescending.Location = New System.Drawing.Point(12, 311)
+        Me.ucrChkDescending.Location = New System.Drawing.Point(12, 371)
         Me.ucrChkDescending.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkDescending.Name = "ucrChkDescending"
         Me.ucrChkDescending.Size = New System.Drawing.Size(187, 30)
@@ -174,7 +262,7 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputComboBoxDisplayLetters.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxDisplayLetters.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxDisplayLetters.IsReadOnly = True
-        Me.ucrInputComboBoxDisplayLetters.Location = New System.Drawing.Point(205, 404)
+        Me.ucrInputComboBoxDisplayLetters.Location = New System.Drawing.Point(205, 464)
         Me.ucrInputComboBoxDisplayLetters.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxDisplayLetters.Name = "ucrInputComboBoxDisplayLetters"
         Me.ucrInputComboBoxDisplayLetters.Size = New System.Drawing.Size(112, 27)
@@ -184,7 +272,7 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrChkDisplayLetters.AutoSize = True
         Me.ucrChkDisplayLetters.Checked = False
-        Me.ucrChkDisplayLetters.Location = New System.Drawing.Point(12, 404)
+        Me.ucrChkDisplayLetters.Location = New System.Drawing.Point(12, 464)
         Me.ucrChkDisplayLetters.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkDisplayLetters.Name = "ucrChkDisplayLetters"
         Me.ucrChkDisplayLetters.Size = New System.Drawing.Size(187, 30)
@@ -196,7 +284,7 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputComboBoxConfidenceInterval.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxConfidenceInterval.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxConfidenceInterval.IsReadOnly = False
-        Me.ucrInputComboBoxConfidenceInterval.Location = New System.Drawing.Point(205, 373)
+        Me.ucrInputComboBoxConfidenceInterval.Location = New System.Drawing.Point(205, 433)
         Me.ucrInputComboBoxConfidenceInterval.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxConfidenceInterval.Name = "ucrInputComboBoxConfidenceInterval"
         Me.ucrInputComboBoxConfidenceInterval.Size = New System.Drawing.Size(112, 27)
@@ -206,7 +294,7 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrChkConfidenceInterval.AutoSize = True
         Me.ucrChkConfidenceInterval.Checked = False
-        Me.ucrChkConfidenceInterval.Location = New System.Drawing.Point(12, 373)
+        Me.ucrChkConfidenceInterval.Location = New System.Drawing.Point(12, 433)
         Me.ucrChkConfidenceInterval.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkConfidenceInterval.Name = "ucrChkConfidenceInterval"
         Me.ucrChkConfidenceInterval.Size = New System.Drawing.Size(187, 30)
@@ -218,7 +306,7 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrInputComboBoxAlpha.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.ucrInputComboBoxAlpha.GetSetSelectedIndex = -1
         Me.ucrInputComboBoxAlpha.IsReadOnly = True
-        Me.ucrInputComboBoxAlpha.Location = New System.Drawing.Point(205, 249)
+        Me.ucrInputComboBoxAlpha.Location = New System.Drawing.Point(205, 309)
         Me.ucrInputComboBoxAlpha.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrInputComboBoxAlpha.Name = "ucrInputComboBoxAlpha"
         Me.ucrInputComboBoxAlpha.Size = New System.Drawing.Size(112, 27)
@@ -228,7 +316,7 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrChkAlpha.AutoSize = True
         Me.ucrChkAlpha.Checked = False
-        Me.ucrChkAlpha.Location = New System.Drawing.Point(12, 249)
+        Me.ucrChkAlpha.Location = New System.Drawing.Point(12, 309)
         Me.ucrChkAlpha.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrChkAlpha.Name = "ucrChkAlpha"
         Me.ucrChkAlpha.Size = New System.Drawing.Size(187, 30)
@@ -238,7 +326,7 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrReceiverBy.AutoSize = True
         Me.ucrReceiverBy.frmParent = Me
-        Me.ucrReceiverBy.Location = New System.Drawing.Point(322, 196)
+        Me.ucrReceiverBy.Location = New System.Drawing.Point(322, 256)
         Me.ucrReceiverBy.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverBy.Name = "ucrReceiverBy"
         Me.ucrReceiverBy.Selector = Nothing
@@ -247,11 +335,23 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrReceiverBy.TabIndex = 33
         Me.ucrReceiverBy.ucrSelector = Nothing
         '
+        'ucrReceiverReference
+        '
+        Me.ucrReceiverReference.AddQuotesIfUnrecognised = True
+        Me.ucrReceiverReference.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.ucrReceiverReference.GetSetSelectedIndex = -1
+        Me.ucrReceiverReference.IsReadOnly = False
+        Me.ucrReceiverReference.Location = New System.Drawing.Point(322, 305)
+        Me.ucrReceiverReference.Margin = New System.Windows.Forms.Padding(0)
+        Me.ucrReceiverReference.Name = "ucrReceiverReference"
+        Me.ucrReceiverReference.Size = New System.Drawing.Size(160, 27)
+        Me.ucrReceiverReference.TabIndex = 63
+        '
         'ucrReceiverLabelVariable
         '
         Me.ucrReceiverLabelVariable.AutoSize = True
         Me.ucrReceiverLabelVariable.frmParent = Me
-        Me.ucrReceiverLabelVariable.Location = New System.Drawing.Point(322, 128)
+        Me.ucrReceiverLabelVariable.Location = New System.Drawing.Point(322, 188)
         Me.ucrReceiverLabelVariable.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverLabelVariable.Name = "ucrReceiverLabelVariable"
         Me.ucrReceiverLabelVariable.Selector = Nothing
@@ -264,7 +364,7 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrReceiverMultipleMeanComparisonUseModel.AutoSize = True
         Me.ucrReceiverMultipleMeanComparisonUseModel.frmParent = Me
-        Me.ucrReceiverMultipleMeanComparisonUseModel.Location = New System.Drawing.Point(322, 75)
+        Me.ucrReceiverMultipleMeanComparisonUseModel.Location = New System.Drawing.Point(322, 135)
         Me.ucrReceiverMultipleMeanComparisonUseModel.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrReceiverMultipleMeanComparisonUseModel.Name = "ucrReceiverMultipleMeanComparisonUseModel"
         Me.ucrReceiverMultipleMeanComparisonUseModel.Selector = Nothing
@@ -276,7 +376,7 @@ Partial Class dlgModelMultipleComparisons
         'ucrSaveModelMultipleComparisons
         '
         Me.ucrSaveModelMultipleComparisons.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrSaveModelMultipleComparisons.Location = New System.Drawing.Point(12, 458)
+        Me.ucrSaveModelMultipleComparisons.Location = New System.Drawing.Point(12, 518)
         Me.ucrSaveModelMultipleComparisons.Margin = New System.Windows.Forms.Padding(5, 6, 5, 6)
         Me.ucrSaveModelMultipleComparisons.Name = "ucrSaveModelMultipleComparisons"
         Me.ucrSaveModelMultipleComparisons.Size = New System.Drawing.Size(408, 30)
@@ -286,7 +386,7 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.ucrBase.AutoSize = True
         Me.ucrBase.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.ucrBase.Location = New System.Drawing.Point(8, 533)
+        Me.ucrBase.Location = New System.Drawing.Point(8, 593)
         Me.ucrBase.Margin = New System.Windows.Forms.Padding(8, 7, 8, 7)
         Me.ucrBase.Name = "ucrBase"
         Me.ucrBase.Size = New System.Drawing.Size(511, 65)
@@ -298,7 +398,7 @@ Partial Class dlgModelMultipleComparisons
         Me.ucrSelectorModelMultipleComparisons.bDropUnusedFilterLevels = False
         Me.ucrSelectorModelMultipleComparisons.bShowHiddenColumns = False
         Me.ucrSelectorModelMultipleComparisons.bUseCurrentFilter = True
-        Me.ucrSelectorModelMultipleComparisons.Location = New System.Drawing.Point(12, 15)
+        Me.ucrSelectorModelMultipleComparisons.Location = New System.Drawing.Point(12, 75)
         Me.ucrSelectorModelMultipleComparisons.Margin = New System.Windows.Forms.Padding(0)
         Me.ucrSelectorModelMultipleComparisons.Name = "ucrSelectorModelMultipleComparisons"
         Me.ucrSelectorModelMultipleComparisons.Size = New System.Drawing.Size(284, 227)
@@ -308,11 +408,16 @@ Partial Class dlgModelMultipleComparisons
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 16.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(552, 604)
+        Me.ClientSize = New System.Drawing.Size(552, 665)
+        Me.Controls.Add(Me.rdoMultiple)
+        Me.Controls.Add(Me.rdoPairwise)
+        Me.Controls.Add(Me.rdoReference)
+        Me.Controls.Add(Me.ucrPnlComparisonType)
         Me.Controls.Add(Me.ucrSaveGraph)
         Me.Controls.Add(Me.ucrInputGenerateMultipleComparisonGraphs)
         Me.Controls.Add(Me.ucrChkGenerateMultipleComparisonPlot)
         Me.Controls.Add(Me.ucrChkByOptional)
+        Me.Controls.Add(Me.lblReference)
         Me.Controls.Add(Me.ucrInputComboBoxAdjustment)
         Me.Controls.Add(Me.ucrChkAdjustment)
         Me.Controls.Add(Me.ucrInputComboBoxDescending)
@@ -325,6 +430,7 @@ Partial Class dlgModelMultipleComparisons
         Me.Controls.Add(Me.ucrChkAlpha)
         Me.Controls.Add(Me.btnTransformation)
         Me.Controls.Add(Me.ucrReceiverBy)
+        Me.Controls.Add(Me.ucrReceiverReference)
         Me.Controls.Add(Me.lblVariabletoUse)
         Me.Controls.Add(Me.ucrReceiverLabelVariable)
         Me.Controls.Add(Me.lblMultipleMeanComparisonModeltoUse)
@@ -337,20 +443,26 @@ Partial Class dlgModelMultipleComparisons
         Me.MinimizeBox = False
         Me.Name = "dlgModelMultipleComparisons"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
-        Me.Text = "Multiple Comparisons"
+        Me.Text = "Comparisons"
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
     End Sub
 
+    Friend WithEvents ucrPnlComparisonType As instat.UcrPanel
+    Friend WithEvents rdoMultiple As System.Windows.Forms.RadioButton
+    Friend WithEvents rdoPairwise As System.Windows.Forms.RadioButton
+    Friend WithEvents rdoReference As System.Windows.Forms.RadioButton
     Friend WithEvents ucrSelectorModelMultipleComparisons As ucrSelectorByDataFrameAddRemove
     Friend WithEvents ucrBase As ucrButtons
     Friend WithEvents ucrSaveModelMultipleComparisons As ucrSave
     Friend WithEvents lblMultipleMeanComparisonModeltoUse As Label
     Friend WithEvents ucrReceiverMultipleMeanComparisonUseModel As ucrReceiverSingle
     Friend WithEvents lblVariabletoUse As Label
+    Friend WithEvents lblReference As Label
     Friend WithEvents ucrReceiverLabelVariable As ucrReceiverSingle
     Friend WithEvents ucrReceiverBy As ucrReceiverSingle
+    Friend WithEvents ucrReceiverReference As instat.ucrInputComboBox
     Friend WithEvents ucrChkAlpha As ucrCheck
     Friend WithEvents ucrInputComboBoxAlpha As ucrInputComboBox
     Friend WithEvents btnTransformation As Button

--- a/instat/dlgModelMultipleComparisons.vb
+++ b/instat/dlgModelMultipleComparisons.vb
@@ -54,7 +54,7 @@ Public Class dlgModelMultipleComparisons
             SetDefaults()
         End If
         SetRCodeForControls(bReset)
-        UpdateComparisonUI()
+        UpdateComparisonUI(bReset)
         AddComparisonParameters()
         bReset = False
         autoTranslate(Me)
@@ -259,7 +259,7 @@ Public Class dlgModelMultipleComparisons
 
     Private Sub ucrPnlComparisonType_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlComparisonType.ControlValueChanged
         If bFirstLoad Then Return
-        UpdateComparisonUI()
+        UpdateComparisonUI(True)
         AddComparisonParameters()
         UpdateReferenceLevels()
         UpdateClassifyAndByParameters()
@@ -270,30 +270,42 @@ Public Class dlgModelMultipleComparisons
 
     ' Updates control visibility and explicitly rebuilds the dropdown lists
     ' and default values from scratch to ensure the available UI options
-    ' strictly match the currently selected comparison mode.`
-
-    Private Sub UpdateComparisonUI()
+    ' strictly match the currently selected comparison mode.
+    Private Sub UpdateComparisonUI(bReset As Boolean)
 
         btnTransformation.Visible = rdoMultiple.Checked
         ucrInputGenerateMultipleComparisonGraphs.Visible = rdoMultiple.Checked AndAlso ucrChkGenerateMultipleComparisonPlot.Checked
 
+        Dim strCurrentAdjustment As String = ucrInputComboBoxAdjustment.GetText()
+        Dim strCurrentDescending As String = ucrInputComboBoxDescending.GetText()
+
         If rdoMultiple.Checked Then
             ucrInputComboBoxAdjustment.SetItems({strAdjustTukey, "bonferroni", strAdjustHolm, "hochberg", "hommel", "BH", "BY", "none"})
-            ucrInputComboBoxAdjustment.SetText(strAdjustTukey)
-
             ucrInputComboBoxDescending.SetItems({"TRUE", "FALSE"})
-            ucrInputComboBoxDescending.SetText("FALSE")
         Else
             ucrInputComboBoxDescending.SetItems({"NULL", "TRUE", "FALSE"})
-            ucrInputComboBoxDescending.SetText("NULL")
 
             If rdoPairwise.Checked Then
                 ucrInputComboBoxAdjustment.SetItems({strAdjustHolm, "bonferroni", "hochberg", "hommel", "BH", "BY", "none"})
-                ucrInputComboBoxAdjustment.SetText(strAdjustHolm)
             ElseIf rdoReference.Checked Then
                 ucrInputComboBoxAdjustment.SetItems({strAdjustDunnett, strAdjustHolm, "bonferroni", "hochberg", "hommel", "BH", "BY", "none"})
-                ucrInputComboBoxAdjustment.SetText(strAdjustDunnett)
             End If
+        End If
+
+        If bReset Then
+            If rdoMultiple.Checked Then
+                ucrInputComboBoxAdjustment.SetText(strAdjustTukey)
+                ucrInputComboBoxDescending.SetText("FALSE")
+            ElseIf rdoPairwise.Checked Then
+                ucrInputComboBoxAdjustment.SetText(strAdjustHolm)
+                ucrInputComboBoxDescending.SetText("NULL")
+            ElseIf rdoReference.Checked Then
+                ucrInputComboBoxAdjustment.SetText(strAdjustDunnett)
+                ucrInputComboBoxDescending.SetText("NULL")
+            End If
+        Else
+            ucrInputComboBoxAdjustment.SetText(strCurrentAdjustment)
+            ucrInputComboBoxDescending.SetText(strCurrentDescending)
         End If
     End Sub
 
@@ -525,7 +537,7 @@ Public Class dlgModelMultipleComparisons
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
         SetDefaults()
         SetRCodeForControls(True)
-        UpdateComparisonUI()
+        UpdateComparisonUI(True)
         AddComparisonParameters()
         TestOkEnabled()
     End Sub

--- a/instat/dlgModelMultipleComparisons.vb
+++ b/instat/dlgModelMultipleComparisons.vb
@@ -27,7 +27,14 @@ Public Class dlgModelMultipleComparisons
     Private ReadOnly strLastGraphName As String = "last_graph"
     Private ReadOnly strDefaultGraphType As String = "Point"
 
+    Private ReadOnly strAdjustTukey As String = "tukey"
+    Private ReadOnly strAdjustHolm As String = "holm"
+    Private ReadOnly strAdjustDunnett As String = "dunnett"
+
     Private clsMultipleComparisonsFunction As New RFunction
+    Private clsPairwiseComparisonFunction As New RFunction
+    Private clsReferenceComparisonFunction As New RFunction
+
     Private clsGetModelFunction As New RFunction
     Private clsAssignModelOperator As New ROperator
     Private clsRmFunction As New RFunction
@@ -36,6 +43,8 @@ Public Class dlgModelMultipleComparisons
     Private clsCheckGraphFunction As New RFunction
     Private clsAddPlotObjectFunction As New RFunction
     Private clsGetPlotObjectDataFunction As New RFunction
+    Private clsDummyMultipleComparisonFunction As New RFunction
+
     Private Sub dlgModelMultipleComparisons_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
             InitialiseDialog()
@@ -45,6 +54,8 @@ Public Class dlgModelMultipleComparisons
             SetDefaults()
         End If
         SetRCodeForControls(bReset)
+        UpdateComparisonUI()
+        AddComparisonParameters()
         bReset = False
         autoTranslate(Me)
         TestOkEnabled()
@@ -55,6 +66,14 @@ Public Class dlgModelMultipleComparisons
         ucrBase.iHelpTopicID = 0
         ucrBase.clsRsyntax.bExcludeAssignedFunctionOutput = False
         ucrBase.clsRsyntax.iCallType = 3
+
+        ucrPnlComparisonType.AddRadioButton(rdoMultiple)
+        ucrPnlComparisonType.AddRadioButton(rdoPairwise)
+        ucrPnlComparisonType.AddRadioButton(rdoReference)
+
+        ucrPnlComparisonType.AddParameterValuesCondition(rdoMultiple, "check", "multiple")
+        ucrPnlComparisonType.AddParameterValuesCondition(rdoPairwise, "check", "pairwise")
+        ucrPnlComparisonType.AddParameterValuesCondition(rdoReference, "check", "reference")
 
         ucrReceiverMultipleMeanComparisonUseModel.SetItemType(RObjectTypeLabel.Model)
         ucrReceiverMultipleMeanComparisonUseModel.Selector = ucrSelectorModelMultipleComparisons
@@ -70,6 +89,11 @@ Public Class dlgModelMultipleComparisons
         ucrReceiverBy.SetParameter(New RParameter("by", 2))
         ucrReceiverBy.SetParameterIsString()
         ucrReceiverBy.SetIncludedDataTypes({"factor"})
+
+        ucrReceiverReference.SetParameter(New RParameter("reference", 8))
+        ucrReceiverReference.AddQuotesIfUnrecognised = True
+        ucrReceiverReference.bAllowNonConditionValues = True
+        ucrReceiverReference.SetLinkedDisplayControl(lblReference)
 
         ucrChkByOptional.SetText("By (Optional):")
         ucrChkByOptional.AddToLinkedControls({ucrReceiverBy}, {True}, bNewLinkedHideIfParameterMissing:=True)
@@ -89,11 +113,11 @@ Public Class dlgModelMultipleComparisons
         ucrChkDescending.AddToLinkedControls(ucrInputComboBoxDescending, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="TRUE")
 
         ucrChkAdjustment.SetText("Adjustment")
-        ucrInputComboBoxAdjustment.SetItems({"tukey", "bonferroni", "holm", "hochberg", "hommel", "BH", "BY", "none"})
+        ucrInputComboBoxAdjustment.SetItems({strAdjustTukey, "bonferroni", strAdjustHolm, "hochberg", "hommel", "BH", "BY", "none"})
         ucrInputComboBoxAdjustment.SetDropDownStyleAsNonEditable()
         ucrInputComboBoxAdjustment.AddQuotesIfUnrecognised = True
         ucrInputComboBoxAdjustment.SetParameter(New RParameter("adjust", 6))
-        ucrChkAdjustment.AddToLinkedControls(ucrInputComboBoxAdjustment, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="tukey")
+        ucrChkAdjustment.AddToLinkedControls(ucrInputComboBoxAdjustment, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:=strAdjustTukey)
 
         ucrChkConfidenceInterval.SetText("Confidence Interval")
         ucrInputComboBoxConfidenceInterval.SetItems({"ci", "tukey", "1se", "2se", "none"})
@@ -110,7 +134,7 @@ Public Class dlgModelMultipleComparisons
         ucrChkDisplayLetters.AddToLinkedControls(ucrInputComboBoxDisplayLetters, {True}, bNewLinkedAddRemoveParameter:=True, bNewLinkedHideIfParameterMissing:=True, bNewLinkedChangeToDefaultState:=True, objNewDefaultState:="TRUE")
 
         ucrSaveModelMultipleComparisons.SetPrefix("mct")
-        ucrSaveModelMultipleComparisons.SetCheckBoxText("Store mct:")
+        ucrSaveModelMultipleComparisons.SetCheckBoxText("Store Output:")
         ucrSaveModelMultipleComparisons.SetIsComboBox()
         ucrSaveModelMultipleComparisons.SetSaveType(strRObjectType:=RObjectTypeLabel.Summary, strRObjectFormat:=RObjectFormat.Text)
 
@@ -130,6 +154,10 @@ Public Class dlgModelMultipleComparisons
         ucrSaveGraph.SetPrefix("mct_plot")
         ucrSaveGraph.SetAssignToIfUncheckedValue(strLastGraphName)
         ucrSaveGraph.Enabled = False
+
+        ucrPnlComparisonType.AddToLinkedControls({ucrChkDisplayLetters, ucrChkConfidenceInterval}, {rdoMultiple}, bNewLinkedHideIfParameterMissing:=True)
+        ucrPnlComparisonType.AddToLinkedControls({ucrReceiverReference}, {rdoReference}, bNewLinkedHideIfParameterMissing:=True)
+
     End Sub
 
     Private Sub SetDefaults()
@@ -137,11 +165,14 @@ Public Class dlgModelMultipleComparisons
         clsGetModelFunction = New RFunction
         clsAssignModelOperator = New ROperator
         clsMultipleComparisonsFunction = New RFunction
+        clsPairwiseComparisonFunction = New RFunction
+        clsReferenceComparisonFunction = New RFunction
         clsRmFunction = New RFunction
         clsAutoplotFunction = New RFunction
         clsCheckGraphFunction = New RFunction
         clsAddPlotObjectFunction = New RFunction
         clsGetPlotObjectDataFunction = New RFunction
+        clsDummyMultipleComparisonFunction = New RFunction
 
         ucrSelectorModelMultipleComparisons.Reset()
         ucrSaveModelMultipleComparisons.Reset()
@@ -156,6 +187,8 @@ Public Class dlgModelMultipleComparisons
 
         lstModelFactorNames = New List(Of String)
 
+        clsDummyMultipleComparisonFunction.AddParameter("check", "multiple", iPosition:=0)
+
         clsGetModelFunction.SetRCommand(frmMain.clsRLink.strInstatDataObject & "$get_object_data")
 
         clsAssignModelOperator.SetOperation("<-")
@@ -166,6 +199,14 @@ Public Class dlgModelMultipleComparisons
         clsMultipleComparisonsFunction.SetPackageName("biometryassist")
         clsMultipleComparisonsFunction.SetRCommand("multiple_comparisons")
         clsMultipleComparisonsFunction.AddParameter("model.obj", strModelTmpName, iPosition:=0)
+
+        clsPairwiseComparisonFunction.SetPackageName("biometryassist")
+        clsPairwiseComparisonFunction.SetRCommand("pairwise_comparisons")
+        clsPairwiseComparisonFunction.AddParameter("model.obj", strModelTmpName, iPosition:=0)
+
+        clsReferenceComparisonFunction.SetPackageName("biometryassist")
+        clsReferenceComparisonFunction.SetRCommand("reference_comparisons")
+        clsReferenceComparisonFunction.AddParameter("model.obj", strModelTmpName, iPosition:=0)
 
         clsRmFunction.SetRCommand("rm")
         clsRmFunction.bToScriptAsRString = False
@@ -182,12 +223,25 @@ Public Class dlgModelMultipleComparisons
     End Sub
 
     Private Sub SetRCodeForControls(bReset As Boolean)
+        ucrPnlComparisonType.SetRCode(clsDummyMultipleComparisonFunction, bReset)
+        ucrInputComboBoxDisplayLetters.AddAdditionalCodeParameterPair(clsPairwiseComparisonFunction, ucrInputComboBoxDisplayLetters.GetParameter(), iAdditionalPairNo:=1)
+        ucrInputComboBoxDisplayLetters.AddAdditionalCodeParameterPair(clsReferenceComparisonFunction, ucrInputComboBoxDisplayLetters.GetParameter(), iAdditionalPairNo:=2)
+        ucrInputComboBoxConfidenceInterval.AddAdditionalCodeParameterPair(clsPairwiseComparisonFunction, ucrInputComboBoxConfidenceInterval.GetParameter(), iAdditionalPairNo:=1)
+        ucrInputComboBoxConfidenceInterval.AddAdditionalCodeParameterPair(clsReferenceComparisonFunction, ucrInputComboBoxConfidenceInterval.GetParameter(), iAdditionalPairNo:=2)
+        ucrInputComboBoxAlpha.AddAdditionalCodeParameterPair(clsPairwiseComparisonFunction, ucrInputComboBoxAlpha.GetParameter(), iAdditionalPairNo:=1)
+        ucrInputComboBoxAlpha.AddAdditionalCodeParameterPair(clsReferenceComparisonFunction, ucrInputComboBoxAlpha.GetParameter(), iAdditionalPairNo:=2)
+        ucrInputComboBoxDescending.AddAdditionalCodeParameterPair(clsPairwiseComparisonFunction, ucrInputComboBoxDescending.GetParameter(), iAdditionalPairNo:=1)
+        ucrInputComboBoxDescending.AddAdditionalCodeParameterPair(clsReferenceComparisonFunction, ucrInputComboBoxDescending.GetParameter(), iAdditionalPairNo:=2)
+        ucrInputComboBoxAdjustment.AddAdditionalCodeParameterPair(clsPairwiseComparisonFunction, ucrInputComboBoxAdjustment.GetParameter(), iAdditionalPairNo:=1)
+        ucrInputComboBoxAdjustment.AddAdditionalCodeParameterPair(clsReferenceComparisonFunction, ucrInputComboBoxAdjustment.GetParameter(), iAdditionalPairNo:=2)
 
         ucrInputComboBoxDisplayLetters.SetRCode(clsMultipleComparisonsFunction, bReset)
         ucrInputComboBoxConfidenceInterval.SetRCode(clsMultipleComparisonsFunction, bReset)
         ucrInputComboBoxAlpha.SetRCode(clsMultipleComparisonsFunction, bReset)
         ucrInputComboBoxDescending.SetRCode(clsMultipleComparisonsFunction, bReset)
         ucrInputComboBoxAdjustment.SetRCode(clsMultipleComparisonsFunction, bReset)
+        ucrReceiverReference.SetRCode(clsMultipleComparisonsFunction, bReset)
+        ucrReceiverReference.SetRCode(clsReferenceComparisonFunction, bReset)
 
         If bReset Then
             ucrChkAlpha.SetRCode(clsMultipleComparisonsFunction, bReset)
@@ -203,45 +257,155 @@ Public Class dlgModelMultipleComparisons
         UpdateGraphCode()
     End Sub
 
+    Private Sub ucrPnlComparisonType_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrPnlComparisonType.ControlValueChanged
+        If bFirstLoad Then Return
+        UpdateComparisonUI()
+        AddComparisonParameters()
+        UpdateReferenceLevels()
+        UpdateClassifyAndByParameters()
+        UpdateAssignTo()
+        UpdateGraphCode()
+        TestOkEnabled()
+    End Sub
+
+    ' Updates control visibility and explicitly rebuilds the dropdown lists
+    ' and default values from scratch to ensure the available UI options
+    ' strictly match the currently selected comparison mode.`
+
+    Private Sub UpdateComparisonUI()
+
+        btnTransformation.Visible = rdoMultiple.Checked
+        ucrInputGenerateMultipleComparisonGraphs.Visible = rdoMultiple.Checked AndAlso ucrChkGenerateMultipleComparisonPlot.Checked
+
+        If rdoMultiple.Checked Then
+            ucrInputComboBoxAdjustment.SetItems({strAdjustTukey, "bonferroni", strAdjustHolm, "hochberg", "hommel", "BH", "BY", "none"})
+            ucrInputComboBoxAdjustment.SetText(strAdjustTukey)
+
+            ucrInputComboBoxDescending.SetItems({"TRUE", "FALSE"})
+            ucrInputComboBoxDescending.SetText("FALSE")
+        Else
+            ucrInputComboBoxDescending.SetItems({"NULL", "TRUE", "FALSE"})
+            ucrInputComboBoxDescending.SetText("NULL")
+
+            If rdoPairwise.Checked Then
+                ucrInputComboBoxAdjustment.SetItems({strAdjustHolm, "bonferroni", "hochberg", "hommel", "BH", "BY", "none"})
+                ucrInputComboBoxAdjustment.SetText(strAdjustHolm)
+            ElseIf rdoReference.Checked Then
+                ucrInputComboBoxAdjustment.SetItems({strAdjustDunnett, strAdjustHolm, "bonferroni", "hochberg", "hommel", "BH", "BY", "none"})
+                ucrInputComboBoxAdjustment.SetText(strAdjustDunnett)
+            End If
+        End If
+    End Sub
+
+    Private Sub AddComparisonParameters()
+        clsMultipleComparisonsFunction.RemoveParameterByName("groups")
+        clsMultipleComparisonsFunction.RemoveParameterByName("int.type")
+        clsPairwiseComparisonFunction.RemoveParameterByName("pairs")
+        clsPairwiseComparisonFunction.RemoveParameterByName("contrasts")
+        clsPairwiseComparisonFunction.RemoveParameterByName("groups")
+        clsPairwiseComparisonFunction.RemoveParameterByName("int.type")
+        clsReferenceComparisonFunction.RemoveParameterByName("groups")
+        clsReferenceComparisonFunction.RemoveParameterByName("int.type")
+
+        If rdoMultiple.Checked Then
+            clsDummyMultipleComparisonFunction.AddParameter("check", "multiple", iPosition:=0)
+        ElseIf rdoPairwise.Checked Then
+            clsDummyMultipleComparisonFunction.AddParameter("check", "pairwise", iPosition:=0)
+            clsPairwiseComparisonFunction.AddParameter("pairs", "NULL", bIncludeArgumentName:=True)
+            clsPairwiseComparisonFunction.AddParameter("contrasts", "NULL", bIncludeArgumentName:=True)
+        ElseIf rdoReference.Checked Then
+            clsDummyMultipleComparisonFunction.AddParameter("check", "reference", iPosition:=0)
+        End If
+    End Sub
 
     ' Builds the classify (and, when By is in use, the by:classify interaction)
-    ' and by arguments on clsMultipleComparisonsFunction from the current receiver selections.`
+    ' and by arguments on the functions from the current receiver selections.`
     Private Sub UpdateClassifyAndByParameters()
         Dim bByInUse As Boolean = ucrChkByOptional.Checked AndAlso Not ucrReceiverBy.IsEmpty()
+        Dim strClassifyValue As String = ""
 
         If Not ucrReceiverLabelVariable.IsEmpty() Then
             Dim strClassify As String = ucrReceiverLabelVariable.GetVariableNames(bWithQuotes:=False)
             If bByInUse Then
                 Dim strBy As String = ucrReceiverBy.GetVariableNames(bWithQuotes:=False)
-                clsMultipleComparisonsFunction.AddParameter("classify", Chr(34) & strBy & ":" & strClassify & Chr(34), iPosition:=1)
+                strClassifyValue = Chr(34) & strBy & ":" & strClassify & Chr(34)
             Else
-                clsMultipleComparisonsFunction.AddParameter("classify", Chr(34) & strClassify & Chr(34), iPosition:=1)
+                strClassifyValue = Chr(34) & strClassify & Chr(34)
             End If
+
+            clsMultipleComparisonsFunction.AddParameter("classify", strClassifyValue, iPosition:=1)
+            clsPairwiseComparisonFunction.AddParameter("classify", strClassifyValue, iPosition:=1)
+            clsReferenceComparisonFunction.AddParameter("classify", strClassifyValue, iPosition:=1)
         Else
             clsMultipleComparisonsFunction.RemoveParameterByName("classify")
+            clsPairwiseComparisonFunction.RemoveParameterByName("classify")
+            clsReferenceComparisonFunction.RemoveParameterByName("classify")
         End If
 
         If bByInUse Then
-            clsMultipleComparisonsFunction.AddParameter("by", Chr(34) & ucrReceiverBy.GetVariableNames(bWithQuotes:=False) & Chr(34), iPosition:=2)
+            Dim strByValue As String = Chr(34) & ucrReceiverBy.GetVariableNames(bWithQuotes:=False) & Chr(34)
+            clsMultipleComparisonsFunction.AddParameter("by", strByValue, iPosition:=2)
+            clsPairwiseComparisonFunction.AddParameter("by", strByValue, iPosition:=2)
+            clsReferenceComparisonFunction.AddParameter("by", strByValue, iPosition:=2)
         Else
-            clsMultipleComparisonsFunction.AddParameter("by", "NULL", iPosition:=2, bIncludeArgumentName:=True)
+            clsMultipleComparisonsFunction.RemoveParameterByName("by")
+            clsPairwiseComparisonFunction.RemoveParameterByName("by")
+            clsReferenceComparisonFunction.RemoveParameterByName("by")
+        End If
+    End Sub
+
+    Private Sub UpdateReferenceLevels()
+        If Not rdoReference.Checked Then Return
+
+        If ucrReceiverLabelVariable.IsEmpty() OrElse String.IsNullOrEmpty(ucrSelectorModelMultipleComparisons.strCurrentDataFrame) Then
+            ucrReceiverReference.SetItems(New String() {})
+
+            Return
+        End If
+
+        Dim strVariables As String = ucrReceiverLabelVariable.GetVariableNames(bWithQuotes:=True)
+        If ucrChkByOptional.Checked AndAlso Not ucrReceiverBy.IsEmpty() Then
+            strVariables = ucrReceiverBy.GetVariableNames(bWithQuotes:=True) & ", " & strVariables
+        End If
+
+        Dim strDfCall As String = frmMain.clsRLink.strInstatDataObject & "$get_data_frame(data_name = " & Chr(34) & ucrSelectorModelMultipleComparisons.strCurrentDataFrame & Chr(34) & ")"
+        Dim strScript As String = "as.character(na.omit(unique(interaction(" & strDfCall & "[, c(" & strVariables & "), drop=FALSE], sep=':'))))"
+
+        Dim expLevels As SymbolicExpression = frmMain.clsRLink.RunInternalScriptGetValue(strScript, bSilent:=True)
+
+        If expLevels IsNot Nothing AndAlso Not expLevels.Type = RDotNet.Internals.SymbolicExpressionType.Null Then
+            Dim lstLevels As List(Of String) = expLevels.AsCharacter().ToList()
+            lstLevels.Sort()
+            ucrReceiverReference.SetItems(lstLevels.ToArray())
+
+            If lstLevels.Contains(ucrReceiverReference.GetText()) Then
+                ucrReceiverReference.SetText(ucrReceiverReference.GetText())
+            Else
+                ucrReceiverReference.SetText("")
+            End If
+        Else
+            ucrReceiverReference.SetItems(New String() {})
         End If
     End Sub
 
     Private Sub UpdateAssignTo()
         If ucrSaveModelMultipleComparisons.ucrChkSave.Checked AndAlso ucrSaveModelMultipleComparisons.GetText() <> "" AndAlso ucrSaveModelMultipleComparisons.IsComplete() Then
-            clsMultipleComparisonsFunction.SetAssignToOutputObject(
-                strRObjectToAssignTo:=ucrSaveModelMultipleComparisons.GetText(),
-                strRObjectTypeLabelToAssignTo:=RObjectTypeLabel.Summary,
-                strRObjectFormatToAssignTo:=RObjectFormat.Text,
-                strRDataFrameNameToAddObjectTo:=ucrSelectorModelMultipleComparisons.strCurrentDataFrame,
-                strObjectName:=ucrSaveModelMultipleComparisons.GetText())
+            Dim strSaveName As String = ucrSaveModelMultipleComparisons.GetText()
+            Dim strDfName As String = ucrSelectorModelMultipleComparisons.strCurrentDataFrame
+
+            clsMultipleComparisonsFunction.SetAssignToOutputObject(strSaveName, RObjectTypeLabel.Summary, RObjectFormat.Text, strDfName, strSaveName)
+            clsPairwiseComparisonFunction.SetAssignToOutputObject(strSaveName, RObjectTypeLabel.Summary, RObjectFormat.Text, strDfName, strSaveName)
+            clsReferenceComparisonFunction.SetAssignToOutputObject(strSaveName, RObjectTypeLabel.Summary, RObjectFormat.Text, strDfName, strSaveName)
         Else
             clsMultipleComparisonsFunction.RemoveAssignTo()
+            clsPairwiseComparisonFunction.RemoveAssignTo()
+            clsReferenceComparisonFunction.RemoveAssignTo()
+
             clsMultipleComparisonsFunction.SetAssignTo(strLastMctName)
+            clsPairwiseComparisonFunction.SetAssignTo(strLastMctName)
+            clsReferenceComparisonFunction.SetAssignTo(strLastMctName)
         End If
     End Sub
-
 
     ' Rebuilds the graph pipeline: produce the plot, validate it, register it in the object store,
     ' then pull it back out for display. Uses ClearCodes() and rebuilds everything from scratch
@@ -249,7 +413,12 @@ Public Class dlgModelMultipleComparisons
     Private Sub UpdateGraphCode()
         ucrBase.clsRsyntax.ClearCodes()
         ucrBase.clsRsyntax.AddToBeforeCodes(clsAssignModelOperator)
-        ucrBase.clsRsyntax.SetBaseRFunction(clsMultipleComparisonsFunction)
+
+        Dim activeComparisonFunction As RFunction = clsMultipleComparisonsFunction
+        If rdoPairwise.Checked Then activeComparisonFunction = clsPairwiseComparisonFunction
+        If rdoReference.Checked Then activeComparisonFunction = clsReferenceComparisonFunction
+
+        ucrBase.clsRsyntax.SetBaseRFunction(activeComparisonFunction)
 
         Dim strMctName As String = GetMctName()
         Dim strRmList As String = BuildRemovalList(strMctName)
@@ -266,20 +435,17 @@ Public Class dlgModelMultipleComparisons
         AddCleanupCode(strRmList)
     End Sub
 
-
     ' Name the current mct object will be assigned to (or the transient default if not saved).
     Private Function GetMctName() As String
         Return If(ucrSaveModelMultipleComparisons.ucrChkSave.Checked AndAlso ucrSaveModelMultipleComparisons.GetText() <> "",
                    ucrSaveModelMultipleComparisons.GetText(), strLastMctName)
     End Function
 
-
     ' Name the current graph object will be assigned to (or the transient default if not saved).
     Private Function GetGraphName() As String
         Return If(ucrSaveGraph.ucrChkSave.Checked AndAlso ucrSaveGraph.GetText() <> "",
                   ucrSaveGraph.GetText(), strLastGraphName)
     End Function
-
 
     ' Starts the rm list with the temporary model object, adding the mct object too if it wasn't saved.
     Private Function BuildRemovalList(strMctName As String) As String
@@ -290,7 +456,6 @@ Public Class dlgModelMultipleComparisons
         Return strRmList
     End Function
 
-
     ' Wires up autoplot() -> check_graph() -> add_object() -> get_object_data() and appends them
     ' to the after-codes so the graph is built, validated, stored, and pulled back out for display.
     Private Sub BuildGraphPipeline(strMctName As String, strGraphName As String)
@@ -299,10 +464,14 @@ Public Class dlgModelMultipleComparisons
         ' autoplot
         clsAutoplotFunction.ClearParameters()
         clsAutoplotFunction.AddParameter("object", strMctName, iPosition:=0, bIncludeArgumentName:=False)
-        Dim strType As String = ucrInputGenerateMultipleComparisonGraphs.GetText()
-        If strType = "" Then strType = strDefaultGraphType
-        clsAutoplotFunction.AddParameter("type", Chr(34) & strType.ToLower() & Chr(34), iPosition:=1)
-        clsAutoplotFunction.AddParameter("label_height", "0.1", iPosition:=2) ' fraction of plot height reserved for group letters
+
+        If rdoMultiple.Checked Then
+            Dim strType As String = ucrInputGenerateMultipleComparisonGraphs.GetText()
+            If strType = "" Then strType = strDefaultGraphType
+            clsAutoplotFunction.AddParameter("type", Chr(34) & strType.ToLower() & Chr(34), iPosition:=1)
+            clsAutoplotFunction.AddParameter("label_height", "0.1", iPosition:=2) ' fraction of plot height reserved for group letters
+        End If
+
         clsAutoplotFunction.SetAssignTo(strGraphName)
 
         ' check_graph
@@ -332,7 +501,6 @@ Public Class dlgModelMultipleComparisons
         ucrBase.clsRsyntax.AddToAfterCodes(clsGetPlotObjectDataFunction)
     End Sub
 
-
     ' rm call that clears out unsaved objects at the end of the script.
     Private Sub AddCleanupCode(strRmList As String)
         clsRmFunction.ClearParameters()
@@ -347,6 +515,7 @@ Public Class dlgModelMultipleComparisons
         Dim bOKEnabled As Boolean = Not ucrReceiverMultipleMeanComparisonUseModel.IsEmpty() AndAlso
                                     Not ucrReceiverLabelVariable.IsEmpty() AndAlso
                                     Not bByDuplicatesLabel AndAlso
+                                    (Not rdoReference.Checked OrElse Not String.IsNullOrEmpty(ucrReceiverReference.GetText())) AndAlso
                                     ucrSaveModelMultipleComparisons.IsComplete() AndAlso
                                     (Not ucrChkGenerateMultipleComparisonPlot.Checked OrElse ucrSaveGraph.IsComplete())
 
@@ -356,6 +525,8 @@ Public Class dlgModelMultipleComparisons
     Private Sub ucrBase_ClickReset(sender As Object, e As EventArgs) Handles ucrBase.ClickReset
         SetDefaults()
         SetRCodeForControls(True)
+        UpdateComparisonUI()
+        AddComparisonParameters()
         TestOkEnabled()
     End Sub
 
@@ -374,6 +545,7 @@ Public Class dlgModelMultipleComparisons
         If Not String.IsNullOrEmpty(ucrSelectorModelMultipleComparisons.strCurrentDataFrame) Then
             clsGetModelFunction.AddParameter("data_name", Chr(34) & ucrSelectorModelMultipleComparisons.strCurrentDataFrame & Chr(34))
         End If
+        UpdateReferenceLevels()
         UpdateAssignTo()
         UpdateGraphCode()
         UpdateModelFactorNames()
@@ -387,12 +559,17 @@ Public Class dlgModelMultipleComparisons
     End Sub
 
     Private Sub ucrReceiverLabelVariable_SelectionChanged(sender As Object, e As EventArgs) Handles ucrReceiverLabelVariable.SelectionChanged
+        UpdateReferenceLevels()
         UpdateClassifyAndByParameters()
         TestOkEnabled()
     End Sub
 
     Private Sub ucrReceiverBy_SelectionChanged(sender As Object, e As EventArgs) Handles ucrReceiverBy.SelectionChanged
         UpdateClassifyAndByParameters()
+        TestOkEnabled()
+    End Sub
+
+    Private Sub ucrReceiverReference_ControlValueChanged(ucrChangedControl As ucrCore) Handles ucrReceiverReference.ControlValueChanged
         TestOkEnabled()
     End Sub
 
@@ -413,7 +590,10 @@ Public Class dlgModelMultipleComparisons
             ucrSaveGraph.ucrChkSave.Checked = False
         End If
         ucrSaveGraph.Enabled = ucrChkGenerateMultipleComparisonPlot.Checked
-        ucrInputGenerateMultipleComparisonGraphs.Visible = ucrChkGenerateMultipleComparisonPlot.Checked
+
+        ' Ensure pulldown only shows for Multiple Comparisons
+        ucrInputGenerateMultipleComparisonGraphs.Visible = ucrChkGenerateMultipleComparisonPlot.Checked AndAlso rdoMultiple.Checked
+
         UpdateAssignTo()
         UpdateGraphCode()
         TestOkEnabled()
@@ -430,8 +610,10 @@ Public Class dlgModelMultipleComparisons
     End Sub
 
     Private Sub Controls_ControlContentsChanged(ucrChangedControl As ucrCore) Handles _
+        ucrPnlComparisonType.ControlContentsChanged,
         ucrReceiverLabelVariable.ControlContentsChanged,
         ucrReceiverBy.ControlContentsChanged,
+        ucrReceiverReference.ControlContentsChanged,
         ucrSaveModelMultipleComparisons.ControlContentsChanged,
         ucrChkAlpha.ControlContentsChanged,
         ucrInputComboBoxAlpha.ControlContentsChanged,

--- a/instat/translations/en/r_instat_not_menus.json
+++ b/instat/translations/en/r_instat_not_menus.json
@@ -6966,5 +6966,9 @@
   "By (Optional):": "By (Optional):",
   "Adjustment": "Adjustment",
   "Store mct:": "Store mct:",
-  "Display Letters": "Display Letters"
+  "Display Letters": "Display Letters",
+  "Reference": "Reference",
+  "Reference Level:": "Reference Level:",
+  "Comparisons": "Comparisons",
+  "Store Output:": "Store Output:"
 }


### PR DESCRIPTION
Partly solve #10433 @rdstern Kindly Review
Taking from last conversation this was what was wanted and what I have been working on

> a) Can there now be 3 radio buttons at the top, namely Multiple, Pairwise, Reference. The default - is the current dialog, which is Multiple. (Note I describe Pairwise before Reference, but the changes are almost the same for both.)
> b) If Pairwise, then swap multiple in biometryassist::multiple_comparisons( function for pairwise, i.e. biometryassist::pairwise_comparisons( described on page 8 of the manual.
> c) For pairwise the selector, and controls on the top right are the same as for Multiple. The Transform is deleted.
> d) On the left is the new top 3 checkboxes, namely Alpha, Descending and Adjustment. The next 2 (Display Letter and Confidence Intervals are omitted.
> e) Descending now has a third option, namely NULL and that is the default.
> f) descend has a different default, namely holm and tukey is omitted.
> g) The Plot checkbox is included, but the additional pull down (with point, line, bar) is not.
> h) The remaining store, etc are as for multiple.
> i) In the command please also include pairs = NULL, contrasts = NULL. (I need longer to think how they could be added to the dialog. It works ok with the default and the user could tweak them to change.
> 
> Now for Reference:
> 
> Ref_a) As Pairwise but running biometryassist::reference_comparisons( instead, see page 13.
> Ref_b) Selector and controls on right as for others, with no Transform. But new control, below By, added to choose a Reference level from the Label Variable factor. (We have this control in the Climatic > Examine/Edit Data > Daily Data Editing - Select Station control.)
> Ref_c) Same checkboxes on the left as for pairwise. Descding and Plot are exactly the same. The Adjustment now has Dunnet as the default and (like Pairwise) no Tukey.

------------------

<img width="520" height="715" alt="image" src="https://github.com/user-attachments/assets/a3159bc9-faf9-4a8a-bb47-685ceb59c4cc" />
-----
<img width="520" height="715" alt="image" src="https://github.com/user-attachments/assets/5ce6342d-22d6-4747-b228-fc7e5530de37" />

------

<img width="520" height="715" alt="image" src="https://github.com/user-attachments/assets/3abbda2d-ea55-4bb4-aeb4-aa2192abcb33" />


------
For Pairwise 

<img width="867" height="492" alt="image" src="https://github.com/user-attachments/assets/5a48dad8-7894-46ab-a43f-f2a3d2347a52" />

-----
For Reference

<img width="886" height="387" alt="image" src="https://github.com/user-attachments/assets/f32325bd-bcc1-43fe-8d59-ee8dce46ad21" />






