### PR TITLE
Fix column overwriting bug in transform dialog

### DIFF
--- a/instat/dlgTransform.vb
+++ b/instat/dlgTransform.vb
@@ -761,7 +761,6 @@ Public Class dlgTransform
         ucrNudLagPosition.AddAdditionalCodeParameterPair(clsLagColsFunction, New RParameter("lag", 1), iAdditionalPairNo:=1)
         ucrNudSignifDigits.AddAdditionalCodeParameterPair(clsSignifColsFunction, New RParameter("digits", 1), iAdditionalPairNo:=1)
         ucrInputPower.AddAdditionalCodeParameterPair(clsPowerColsOperator, New RParameter("y", 1), iAdditionalPairNo:=1)
-        ucrSaveNew.AddAdditionalRCode(clsDescToolsFormatFunction, iAdditionalPairNo:=0)
 
         ucrReceiverRank.AddAdditionalCodeParameterPair(clsAddConstantOperator, ucrReceiverRank.GetParameter(), iAdditionalPairNo:=10)
         ucrReceiverRank.AddAdditionalCodeParameterPair(clsScaleSubtractOperator, New RParameter("x", 0), iAdditionalPairNo:=11)
@@ -803,6 +802,7 @@ Public Class dlgTransform
         ucrInputSubtract.AddAdditionalCodeParameterPair(clsScaleSubtractColsOperator, New RParameter("u", 1), iAdditionalPairNo:=1)
         ucrInputConstant.AddAdditionalCodeParameterPair(clsAddConstantColsOperator, New RParameter("c", 1), iAdditionalPairNo:=1)
 
+        ucrSaveNew.AddAdditionalRCode(clsDescToolsFormatFunction, iAdditionalPairNo:=0)
         ucrSaveNew.AddAdditionalRCode(clsLeadFunction, iAdditionalPairNo:=1)
         ucrSaveNew.AddAdditionalRCode(clsLagFunction, iAdditionalPairNo:=2)
         ucrSaveNew.AddAdditionalRCode(clsSignifFunction, iAdditionalPairNo:=3)
@@ -818,7 +818,7 @@ Public Class dlgTransform
         ucrSaveNew.AddAdditionalRCode(clsPreviewOperator, iAdditionalPairNo:=13)
         ucrSaveNew.AddAdditionalRCode(clsBooleanOperator, iAdditionalPairNo:=14)
         ucrSaveNew.AddAdditionalRCode(clsIsNAFunction, iAdditionalPairNo:=15)
-        ucrSaveNew.AddAdditionalRCode(clsDescToolsFormatFunction, iAdditionalPairNo:=16)
+        ucrSaveNew.AddAdditionalRCode(clsRoundFunction, iAdditionalPairNo:=16)
 
         ucrPnlTransformOptions.SetRCode(clsDummyTransformFunction, bReset)
         ucrPnlColumnSelectOptions.SetRCode(clsDummyTransformFunction, bReset)
@@ -924,7 +924,7 @@ Public Class dlgTransform
         If rdoSingle.Checked Then
             ucrSaveNew.SetLabelText("New Column Name:")
             ' Only set prefix if the control is empty or hasn't been user-modified
-            If Not ucrSaveNew.bUserTyped AndAlso Not ucrReceiverRank.IsEmpty AndAlso String.IsNullOrEmpty(ucrSaveNew.GetText()) Then
+            If Not ucrSaveNew.bUserTyped AndAlso Not ucrReceiverRank.IsEmpty Then
                 ucrSaveNew.SetPrefix(ucrReceiverRank.GetVariableNames(bWithQuotes:=False))
             End If
         ElseIf rdoMultiple.Checked Then


### PR DESCRIPTION
Fixes #10499
@rdstern Kindly Check Now

I've tracked down and resolved the overwriting issue. The bug was caused by two interacting factors

The UI wasn't tracking column changes because **NewDefaultName was blocked** from updating the save control once an initial value was populated.

The save control (**ucrSaveNew) wasn't internally linked to clsRoundFunction, so the generated script kept using the old assignment variable even if the UI text updated correctly.**


I did convert to Numeric first then started with longitude the latitude
-------------
For Longitude

<img width="692" height="601" alt="image" src="https://github.com/user-attachments/assets/dcee06c4-eb6b-49f3-b86c-9e7c50cef8d8" />

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/daed2df8-1753-40c8-a7c0-67128446167e" />

---------------------------

For Latitude

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/d3fd6cf0-3f8a-4264-a63a-a84126ab38a5" />

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/ca3ee3fd-3f53-4da9-b944-cb4c6d817b6c" />
------------

Here are the scripts now 

```
# Dialog: Transform

longitude <- data_book$get_columns_from_data(data_name="cassava32", col_names="longitude", use_current_filter=FALSE)
longitude <- round(longitude, digits=2)
data_book$add_columns_to_data(data_name="cassava32", col_name="longitude", col_data=longitude, before=FALSE, adjacent_column="longitude")

data_book$append_to_variables_metadata(data_name="cassava32", col_names="longitude", property="labels", new_val="")
rm(longitude)
```

```
# Dialog: Transform

latitude <- data_book$get_columns_from_data(data_name="cassava32", col_names="latitude", use_current_filter=FALSE)
latitude <- round(latitude, digits=2)
data_book$add_columns_to_data(data_name="cassava32", col_name="latitude", col_data=latitude, before=FALSE, adjacent_column="latitude")

data_book$append_to_variables_metadata(data_name="cassava32", col_names="latitude", property="labels", new_val="")
rm(latitude)
```









